### PR TITLE
List support

### DIFF
--- a/doc/building.en.rst
+++ b/doc/building.en.rst
@@ -13,6 +13,16 @@ Buiding
 <https://pypi.org/project/scons-parts/>`__. As a plugin, |TxB| also requires an instance of `Traffic
 Server <https://trafficserver.apache.org>`__, or at least the plugin API header files.
 
+Other dependencies
+
+*  `pcre2 <https://www.pcre.org>`__
+
+*  Scons/Parts::
+
+      python3 -m pip install scons-parts
+
+   It is important to use `Python 3 <https://www.python.org/download/releases/3.0/>`__ - no attempt has been made for Python 2 compabitility.
+
 To build the plugin, first build or install Traffic Server. Then use the command ::
 
    scons txn_box --with-trafficserver=<ts_path>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -52,6 +52,7 @@ extensions = [ 'sphinx.ext.graphviz'
              , 'sphinx.ext.githubpages'
              , 'sphinxcontrib.plantuml'
 	     , 'sphinxcontrib.doxylink'
+             , 'txnbox'
              , 'local-config'
              ]
 

--- a/doc/ext/txnbox.py
+++ b/doc/ext/txnbox.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019, Oath Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+    Transaction Box Sphinx Directives
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Sphinx Docs directives for Transaction Box plugin.
+
+    :copyright: Copyright 2019, Oath inc.
+    :license: Apache-2.0
+"""
+
+from docutils import nodes
+from docutils.parsers import rst
+from docutils.parsers.rst import directives
+from sphinx.domains import Domain, ObjType, std
+from sphinx.roles import XRefRole
+from sphinx.locale import l_, _
+import sphinx
+
+import re
+
+
+class TxbDirective(std.Target):
+    """
+    Directive description.
+
+    Descriptive text should follow, indented.
+
+    Then the bulk description (if any) undented. This should be considered equivalent to the Doxygen
+    short and long description.
+    """
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    has_content = True
+
+    # External entry point
+    def run(self):
+        env = self.state.document.settings.env
+        txb_name = self.arguments[0];
+        txb_id = nodes.make_id(txb_name);
+
+        # First, make a generic desc() node to be the parent.
+        node = sphinx.addnodes.desc()
+        node.document = self.state.document
+        node['objtype'] = 'directive'
+
+        # Next, make a signature node. This creates a permalink and a highlighted background when the link is selected.
+        title = sphinx.addnodes.desc_signature(txb_name, '')
+        title['ids'].append(txb_id)
+        title['names'].append(txb_name)
+        title['first'] = False
+        title['objtype'] = 'directive'
+        self.add_name(title)
+        title.set_class('directive-title')
+
+        # Finally, add a desc_name() node to display the name of the
+        # configuration variable.
+        title += sphinx.addnodes.desc_name(txb_name, txb_name)
+
+        node.append(title)
+
+        if ('class' in self.options):
+            title.set_class(self.options.get('class'))
+
+        # This has to be a distinct node before the title. if nested then the browser will scroll forward to just past the title.
+        anchor = nodes.target('', '', names=[txb_name])
+        # Second (optional) arg is 'msgNode' - no idea what I should pass for that
+        # or if it even matters, although I now think it should not be used.
+        self.state.document.note_explicit_target(title)
+        env.domaindata['txb']['directive'][txb_name] = env.docname
+
+        # Get any contained content
+        nn = nodes.compound()
+        self.state.nested_parse(self.content, self.content_offset, nn)
+
+        # Create an index node so that Sphinx adds this directive to the index.
+        indexnode = sphinx.addnodes.index(entries=[])
+        if sphinx.version_info >= (1, 4):
+            indexnode['entries'].append(
+                ('single', _('%s') % txb_name, txb_id, '', '')
+            )
+        else:
+            indexnode['entries'].append(
+                ('single', _('%s') % txb_name, txb_id, '')
+            )
+
+        return [indexnode, node, nodes.field_list(), nn]
+
+
+class TxbExtractor(std.Target):
+    """
+    Directive description.
+
+    Descriptive text should follow, indented.
+
+    Then the bulk description (if any) undented. This should be considered equivalent to the Doxygen
+    short and long description.
+    """
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    has_content = True
+
+    # External entry point
+    def run(self):
+        env = self.state.document.settings.env
+        txb_name = self.arguments[0];
+        txb_id = nodes.make_id(txb_name);
+
+        # First, make a generic desc() node to be the parent.
+        node = sphinx.addnodes.desc()
+        node.document = self.state.document
+        node['objtype'] = 'extractor'
+
+        # Next, make a signature node. This creates a permalink and a highlighted background when the link is selected.
+        title = sphinx.addnodes.desc_signature(txb_name, '')
+        title['ids'].append(txb_id)
+        title['names'].append(txb_name)
+        title['first'] = False
+        title['objtype'] = 'extractor'
+        self.add_name(title)
+        title.set_class('directive-title')
+
+        # Finally, add a desc_name() node to display the name of the
+        # configuration variable.
+        title += sphinx.addnodes.desc_name(txb_name, txb_name)
+
+        node.append(title)
+
+        if ('class' in self.options):
+            title.set_class(self.options.get('class'))
+
+        # This has to be a distinct node before the title. if nested then the browser will scroll forward to just past the title.
+        anchor = nodes.target('', '', names=[txb_name])
+        # Second (optional) arg is 'msgNode' - no idea what I should pass for that
+        # or if it even matters, although I now think it should not be used.
+        self.state.document.note_explicit_target(title)
+        env.domaindata['txb']['extractor'][txb_name] = env.docname
+
+        # Get any contained content
+        nn = nodes.compound()
+        self.state.nested_parse(self.content, self.content_offset, nn)
+
+        # Create an index node so that Sphinx adds this directive to the index.
+        indexnode = sphinx.addnodes.index(entries=[])
+        indexnode['entries'].append(('single', _('%s') % txb_name, txb_id, '', ''))
+
+        return [indexnode, node, nodes.field_list(), nn]
+
+class TxbDirectiveRef(XRefRole):
+    def process_link(self, env, ref_node, explicit_title_p, title, target):
+        return title, target
+
+class TxbExtractorRef(XRefRole):
+    def process_link(self, env, ref_node, explicit_title_p, title, target):
+        return title, target
+
+class TxnBoxDomain(Domain):
+    """
+    Transaction Box Documentation.
+    """
+
+    name = 'txb'
+    label = 'Transaction Box'
+    data_version = 2
+
+    object_types = {
+        'directive': ObjType(_('Directive'), 'directive'),
+        'extractor': ObjType(_('Extractor'), 'extractor')
+    }
+
+    directives = {
+        'directive': TxbDirective,
+        'extractor': TxbExtractor
+    }
+
+
+    roles = {
+        'directive': TxbDirectiveRef(),
+        'extractor': TxbExtractorRef()
+    }
+
+    initial_data = {
+        'directive': {},  # full name -> docname
+        'extractor': {}
+    }
+
+    dangling_warnings = {
+        'directive': "No definition found for directive '%(target)s'",
+        'extractor': "No definition found for extractor '%(target)s'"
+    }
+
+    def clear_doc(self, docname):
+        tmp_list = self.data['directive'];
+        for var, doc in list(tmp_list.items()):
+            if doc == docname:
+                del tmp_list[var]
+        tmp_list = self.data['extractor'];
+        for var, doc in list(tmp_list.items()):
+            if doc == docname:
+                del tmp_list[var]
+
+    def find_doc(self, key, obj_type):
+        zret = None
+
+        if obj_type == 'directive':
+            obj_list = self.data['directive']
+        elif obj_type == 'extractor':
+            obj_list = self.data['extractor']
+        else:
+            obj_list = None
+
+        if obj_list and key in obj_list:
+            zret = obj_list[key]
+
+        return zret
+
+    def resolve_xref(self, env, src_doc, builder, obj_type, target, node, cont_node):
+        dst_doc = self.find_doc(target, obj_type)
+        if (dst_doc):
+            return sphinx.util.nodes.make_refnode(builder, src_doc, dst_doc, nodes.make_id(target), cont_node, target)
+
+    def get_objects(self):
+        for var, doc in self.data['directive'].items():
+            yield var, var, 'directive', doc, var, 1
+        for var, doc in self.data['extractor'].items():
+            yield var, var, 'extractor', doc, var, 1
+
+
+def setup(app):
+    rst.roles.register_generic_role('arg', nodes.emphasis)
+    rst.roles.register_generic_role('const', nodes.literal)
+
+    app.add_domain(TxnBoxDomain)

--- a/doc/future.en.rst
+++ b/doc/future.en.rst
@@ -35,19 +35,6 @@ rand
 Features
 ********
 
-Feature Types
-=============
-
-For better performance feature extraction which consists of only a single extractor is handled as a
-special case. In particular the feature can have a non-string type in this case. Two such types are
-currently supported.
-
-Integer
-   A integer value.
-
-IP Addressß
-   An IP address.
-
 Feature Modifiers
 =================
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,8 @@ Transaction Box
    building.en
    arch.en
    directive.en
+   user/ExtractorReference.en
+   user/DirectiveReference.en
    design.en
    future.en
 

--- a/doc/reference.en.rst
+++ b/doc/reference.en.rst
@@ -33,6 +33,9 @@ Glossary
    extractor
       A mechanism which can performat :term:`extraction`.
 
+   feature string
+      A string that is used to extract a feature.
+
    directive
       An action to perform.
 

--- a/doc/user/DirectiveReference.en.rst
+++ b/doc/user/DirectiveReference.en.rst
@@ -1,0 +1,23 @@
+.. include:: /common.defs
+
+.. highlight:: yaml
+.. default-domain:: cpp
+
+.. _directive_reference:
+
+*******************
+Directive Reference
+*******************
+
+Directives
+**********
+
+.. txb:directive:: set-creq-query
+
+   Sets the query field for the client request.
+
+   Setting this to an empty string will remove the query entirely.
+
+   If the argument is set this affects only query parameters with that :arg:`name`. In that case the
+   value can be a list, in which case a query parameter for :arg:`name` is created for each element
+   of the list, with the query paramter value set to the corresponding list element.

--- a/doc/user/ExtractorReference.en.rst
+++ b/doc/user/ExtractorReference.en.rst
@@ -1,0 +1,71 @@
+.. include:: /common.defs
+
+.. highlight:: yaml
+.. default-domain:: cpp
+
+.. _extractor_reference:
+
+*******************
+Extractor Reference
+*******************
+
+:term:`Extractor`\s are the data access mechanism for |TxB|. They are used to compose :term:`feature
+string`\s. Such a string describes how a :term:`feature` is extracted. The general form is a double
+quoted string containing a mix of literal text and extractors. Extractors are marked by being
+enclosed in braces, in a manner heavily based on `Python string formating
+<https://docs.python.org/3.7/library/string.html#format-string-syntax>`__.
+
+For convenience, because a single extractor is by far the most common case, unquoted strings
+are treated as a single extractor. Consider the extractor :txb:extractor:`creq-host`. This can be
+used in the following feature strings, presuming the host is "example.one".
+
+============================= ==================================
+Feature String                Extracted Feature
+============================= ==================================
+``"Host = {creq-host}"``      ``Host = example.one``
+``"Host = {creq-host:*<15}"`` ``Host = example.one***``
+``creq-host``                 ``example.one``
+``"creq-host"``               ``creq-host``
+``"{creq-host}"``             ``example.one``
+``!literal "{creq-host}"``    ``{creq-host}``
+============================= ==================================
+
+Every feature can be expressed as a string, but can also be extracted as a different type. The
+currently supported types are
+
+``STRING``
+   A string, the default type.
+
+``INTEGER``
+   An integral value.
+
+``BOOLEAN``
+   A value that is either :code:`true` or :code:`false`.
+
+``IP_ADDRESS``
+   An IP address.
+
+``LIST``
+   A list of strings.
+
+``TUPLE``
+  A tuple of features, each of which can be a distinct type.
+
+All quoted feature strings yield a ``STRING`` when extracted. Only unquoted singleton feature strings
+can have a different type, which is determined by the extractor.
+
+Extractors
+*************
+
+.. txb:extractor:: creq-host
+
+   Host for the request. This is retrieved from the URL if present, otherwise from the ``Host``
+   field.
+
+.. txb:extractor:: creq-query
+
+   The query string from the client request.
+
+.. txb:extractor:: creq-url
+
+   The client request URL.

--- a/lib/pkgconfig/libswoc++.pc
+++ b/lib/pkgconfig/libswoc++.pc
@@ -1,0 +1,11 @@
+prefix=/home/amc/git/txn_box/
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: LibSWOC++
+Description: A collection of solid C++ utilities and classes.
+Version: 1.0.8
+Requires:
+Libs: -L${libdir} -lswoc++
+Cflags: -I${includedir}

--- a/plugin/include/txn_box/Comparison.h
+++ b/plugin/include/txn_box/Comparison.h
@@ -14,8 +14,8 @@
 #include <swoc/TextView.h>
 #include <swoc/Errata.h>
 
-#include "txn_box/yaml_util.h"
 #include "txn_box/common.h"
+#include "txn_box/yaml_util.h"
 
 /** Base class for comparisons.
  *
@@ -42,13 +42,8 @@ public:
    */
   virtual unsigned rxp_group_count() const;
 
-  bool operator()(Context& ctx, FeatureData & data) {
-    auto visitor = [&](auto && arg) { return (*this)(ctx, arg); };
-    return std::visit(visitor, data);
-  }
-
   /// @defgroup Comparison overloads.
-  /// These must match the set of types in @c FeatureData.
+  /// These must match the set of types in @c FeatureTypes.
   /// Subclasses (specific comparisons) should override these as appropriate for its supported types.
   /// The feature is passed by reference because comparisons are allowed to perform updates.
   /// @{
@@ -56,8 +51,17 @@ public:
   virtual bool operator()(Context&, FeatureView& view) const { return false; }
   virtual bool operator()(Context&, intmax_t& n) const { return false; }
   virtual bool operator()(Context&, bool& f) const { return false; }
-  virtual bool operator()(Context&, swoc::IPAddr & addr) const { return false; }
+  virtual bool operator()(Context&, swoc::IPAddr& addr) const { return false; }
+  virtual bool operator()(Context&, Cons* cons) const { return false; }
+  virtual bool operator()(Context&, FeatureTuple& tuple) const { return false; }
   /// @}
+
+  bool operator()(Context& ctx, Feature& data) const {
+    auto visitor = [&](auto && arg) { return (*this)(ctx, arg); };
+// This should work, but it doesn't. Need to find out why not.
+//    return std::visit(visitor, data);
+    return std::visit(visitor, static_cast<Feature::variant_type&>(data));
+  }
 
   /** Define a comparison.
    *

--- a/plugin/include/txn_box/Config.h
+++ b/plugin/include/txn_box/Config.h
@@ -29,7 +29,9 @@ class Config {
   using Errata = swoc::Errata;
 public:
 
+  /// Full name of the plugin.
   static constexpr swoc::TextView PLUGIN_NAME { "Transaction Tool Box" };
+  /// Tag name of the plugin.
   static constexpr swoc::TextView PLUGIN_TAG { "txn_box" };
 
   static const std::string ROOT_KEY; ///< Root key for plugin configuration.
@@ -50,6 +52,7 @@ public:
     int _rxp_line = -1; ///< Line of the active regular expression.
   };
 
+  /// Default constructor, makes an empty instance.
   Config();
 
   /** Parse YAML from @a node to initialize @a this configuration.
@@ -125,7 +128,8 @@ public:
    * Strings in the YAML configuration are transient. If the content needs to be available at
    * run time it must be first localized.
    */
-  swoc::TextView localize(swoc::TextView text);
+  std::string_view& localize(std::string_view & text);
+  swoc::TextView localize(std::string_view const& text) { swoc::TextView tv { text }; return this->localize(tv); }
 
   /** Localized a format.
    *
@@ -136,6 +140,10 @@ public:
    * it will be condensed in to a single item literal.
    */
   self_type & localize(Extractor::Format & fmt);
+
+  self_type& localize(Feature & feature);
+
+  template < typename T > auto localize(T & data) -> typename std::enable_if<swoc::meta::is_any_of<T, feature_type_for<NIL>, feature_type_for<INTEGER>, feature_type_for<BOOLEAN>, feature_type_for<IP_ADDR>, feature_type_for<CONS>, feature_type_for<TUPLE>>::value, self_type&>::type { return *this; }
 
   /** Allocate config space for an array of @a T.
    *
@@ -179,7 +187,7 @@ public:
   /** Define a directive.
    *
    */
-  static swoc::Errata define(swoc::TextView name, HookMask const& hooks, Directive::Worker const& worker, Directive::Options const& opts = Directive::Options{});
+  static swoc::Errata define(swoc::TextView name, HookMask const& hooks, Directive::Worker const& worker, Directive::Options const& opts = Directive::Options {});
 
 protected:
   friend class When;

--- a/plugin/include/txn_box/Context.h
+++ b/plugin/include/txn_box/Context.h
@@ -18,6 +18,7 @@
 #include "txn_box/Directive.h"
 #include "txn_box/Extractor.h"
 #include "txn_box/ts_util.h"
+#include <ts/remap.h>
 
 struct _tm_remap_request_info;
 using TSRemapRequestInfo = _tm_remap_request_info;
@@ -47,7 +48,7 @@ public:
   swoc::Errata on_hook_do(Hook hook, Directive *drtv);
 
   swoc::Errata invoke_for_hook(Hook hook);
-  swoc::Errata invoke_for_remap(Config & rule_cfg);
+  swoc::Errata invoke_for_remap(Config &rule_cfg, TSRemapRequestInfo *rri);
 
   /** Set up to handle the hooks in the @a txn.
    *
@@ -70,7 +71,7 @@ public:
    *
    * @see commit
    */
-  FeatureData extract(Extractor::Format const& fmt);
+  Feature extract(Extractor::Format const& fmt);
 
   /** Commit a feature.
    *
@@ -83,7 +84,7 @@ public:
    *
    * @see extract
    */
-  self_type& commit(FeatureData const& feature);
+  self_type& commit(Feature const& feature);
 
   swoc::MemSpan<void> storage_for(Directive* drtv);
 
@@ -91,7 +92,7 @@ public:
   TSCont _cont = nullptr;
   ts::HttpTxn _txn = nullptr;
   /// Current extracted feature data.
-  FeatureData _feature;
+  Feature _feature;
 
   void operator()(swoc::BufferWriter& w, Extractor::Spec const& spec);
 
@@ -172,6 +173,7 @@ public:
   }
 
   TSRemapRequestInfo* _remap_info = nullptr;
+  TSRemapStatus _remap_status = TSREMAP_NO_REMAP;
 
   /** Clear cached data.
    *

--- a/plugin/include/txn_box/FeatureMod.h
+++ b/plugin/include/txn_box/FeatureMod.h
@@ -43,7 +43,7 @@ public:
    *
    * The @a feature is modified in place.
    */
-  virtual swoc::Errata operator()(Context& ctx, FeatureData & feature) = 0;
+  virtual swoc::Errata operator()(Context& ctx, Feature & feature) = 0;
 
   /** Check if the comparison is valid for @a type.
    *

--- a/plugin/include/txn_box/ts_util.h
+++ b/plugin/include/txn_box/ts_util.h
@@ -109,6 +109,7 @@ public:
   swoc::TextView host() const; ///< View of the URL host.
   swoc::TextView scheme() const; ///< View of the URL scheme.
   swoc::TextView path() const; ///< View of the URL path.
+  swoc::TextView query() const; ///< View of the query.
 
   /** Set the host in the URL.
    *
@@ -294,6 +295,8 @@ inline URL::URL(TSMBuffer buff, TSMLoc loc) : super_type(buff, loc) {}
 inline swoc::TextView URL::scheme() const { int length; auto text = TSUrlSchemeGet(_buff, _loc, &length); return { text, static_cast<size_t>(length) }; }
 
 inline swoc::TextView URL::path() const { int length; auto text = TSUrlPathGet(_buff, _loc, &length); return { text, static_cast<size_t>(length) }; }
+
+inline swoc::TextView URL::query() const { int length; auto text = TSUrlHttpQueryGet(_buff, _loc, &length); return { text, static_cast<size_t>(length) }; }
 
 inline URL &URL::set_host(swoc::TextView host) {
   if (this->is_valid()) {

--- a/plugin/src/FeatureMod.cc
+++ b/plugin/src/FeatureMod.cc
@@ -52,7 +52,7 @@ class Mod_Hash : public FeatureMod {
 public:
   static const std::string KEY; ///< Identifier name.
 
-  Errata operator()(Context& ctx, FeatureData & feature) override;
+  Errata operator()(Context& ctx, Feature & feature) override;
 
   bool is_valid_for(FeatureType ftype) const override;
 
@@ -86,7 +86,7 @@ FeatureType Mod_Hash::output_type() const {
   return INTEGER;
 }
 
-Errata Mod_Hash::operator()(Context &ctx, FeatureData &feature) {
+Errata Mod_Hash::operator()(Context &ctx, Feature &feature) {
   return {};
 }
 

--- a/plugin/src/txn_box.cc
+++ b/plugin/src/txn_box.cc
@@ -32,6 +32,8 @@ namespace bwf = swoc::bwf;
 using namespace swoc::literals;
 /* ------------------------------------------------------------------------------------ */
 
+Global G;
+
 const std::string Config::ROOT_KEY { "txn_box" };
 
 Hook Convert_TS_Event_To_TxB_Hook(TSEvent ev) {


### PR DESCRIPTION
This is a major update that unfortunately breaks most of the existing functionality. However, it gets the infrastructure in place for list support which is required. The various elements will be repaired moving forward as production testing continues.

*  Added CONS, TUPLE as feature types to support lists.

*  Changed to use libswoc++ `type_list` support for defining the feature variant.

*  Restructured feature extraction to support lists.

*  Updated the package config support.

*  Started on better documention.