### PR TITLE
Allocate config args from new rather than malloc

### DIFF
--- a/plugin/src/Config.cc
+++ b/plugin/src/Config.cc
@@ -626,8 +626,7 @@ Errata Config::load_file_glob(TextView pattern, swoc::TextView cfg_key, YamlCach
 /* ------------------------------------------------------------------------------------ */
 Errata Config::load_args(const std::vector<std::string> &args, int arg_offset, YamlCache * cache) {
   using argv_type = char const *; // Overall clearer in context of pointers to pointers.
-  size_t buff_size = args.size() * sizeof(argv_type);
-  std::unique_ptr<argv_type> buff { static_cast<argv_type*>(malloc(buff_size)) };
+  std::unique_ptr<argv_type[]> buff { new argv_type[args.size()] };
   swoc::MemSpan<argv_type> argv{ buff.get(), args.size() };
   int idx = 0;
   for ( auto const& arg : args ) {


### PR DESCRIPTION
ASan reported a alloc-dealloc-mismatch in Config::load_args because
memory was allocated with malloc and stored in unique_ptr which later
freed it with delete. new should be paired with delete and malloc should
be paired with free. This addresses this by allocating the arg buffer
with new rather than malloc.