### PR TITLE
Add extractor for server session count. "server-ssn-txn-count"

### DIFF
--- a/doc/misc.en.rst
+++ b/doc/misc.en.rst
@@ -63,7 +63,7 @@ in which case the field value is really a list. On the other hand, there are exc
 as well, most notably `Set-Cookie <https://tools.ietf.org/html/rfc6265#section-4.1>`__ which,
 while multi-valued, does not follow the standard mechanism.
 
-To handle all of these cases, the extendsion field of the field extractors can be used to force
+To handle all of these cases, the extension field of the field extractors can be used to force
 the field to be handled either by value or by field. In both cases the result is a tuple to which
 the standard :txb:drtv:`with` tuple handling can be used.
 

--- a/doc/user/ExtractorReference.en.rst
+++ b/doc/user/ExtractorReference.en.rst
@@ -105,6 +105,19 @@ because both ATS and the upstream will treat them indentically. Note this applie
 separating the "authority" / "location" from the path. The path for the URLs
 "http://delain.nl/pix/charlotte" and "http://delain.nl/pix/charlotte/" are distinguishable.
 
+* :ref:`ex-user-agent`
+* :ref:`ex-pre-remap`
+* :ref:`ex-rewrite-rule-urls`
+* :ref:`ex-proxy-request`
+* :ref:`ex-upstream-response`
+* :ref:`ex-proxy-response`
+* :ref:`ex-transaction`
+* :ref:`ex-session`
+* :ref:`ex-duration`
+* :ref:`ex-utility`
+
+.. _ex-user-agent:
+
 User Agent Request
 ------------------
 
@@ -222,6 +235,8 @@ Pre-Remap
 
       The query string for the pre-remap user agent request URL.
 
+.. _ex-rewrite-rule-urls:
+
 Rewrite Rule URLs
 -----------------
 
@@ -292,6 +307,8 @@ Rewrite Rule URLs
    :result: string
 
    The path in the replacement URL.
+
+.. _ex-proxy-request:
 
 Proxy Request
 -------------
@@ -365,6 +382,8 @@ Proxy Request
    empty string which is returned if the field is present but has no value. If there are duplicate
    fields then a string list is returned, each element of which corresponds to a field.
 
+.. _ex-upstream-response:
+
 Upstream Response
 -----------------
 
@@ -388,6 +407,8 @@ Upstream Response
    If the field is not present, the ``NULL`` value is returned. Note this is distinct from the
    empty string which is returned if the field is present but has no value. If there are duplicate
    fields then a string list is returned, each element of which corresponds to a field.
+
+.. _ex-proxy-response:
 
 Proxy Response
 --------------
@@ -413,6 +434,8 @@ Proxy Response
    empty string which is returned if the field is present but has no value. If there are duplicate
    fields then a string list is returned, each element of which corresponds to a field.
 
+.. _ex-transaction:
+
 Transaction
 ===========
 
@@ -421,10 +444,12 @@ Transaction
 
    This returns a boolean value, ``true`` if the request is an internal request, and ``false`` if not.
 
+.. _ex-session:
+
 Session
 =======
 
-.. extractor::  inbound-txn-coujnt
+.. extractor::  inbound-txn-count
    :result: integer
 
    The number of transactions, including the current on, that have occurred on the inbound
@@ -504,6 +529,27 @@ Session
    In general, though, :ex:`has-inbound-protocol-prefix` is usually a better choice for doing such
    checking unless the full stack or a full tag is needed.
 
+
+.. extractor::  server-ssn-txn-count
+   :result: integer
+
+   The number of transactions between the Traffic Server proxy and the origin server from a single session.
+   Any value greater than zero indicates connection reuse.
+
+   .. code-block:: yaml
+
+      with: server-ssn-txn-count
+      select:
+      - gt: 10
+        do:
+         - proxy-rsp-field<Connection>: "close"
+
+.. warning::
+   For ATS version different to 10, this will return `0` and the value should not be taken
+   into consideration to determine connection reuse.
+
+.. _ex-duration:
+
 Duration
 ========
 
@@ -532,6 +578,8 @@ A "duration" is a span of time. This is specified by one of a set of extractors.
    :result: duration
 
    A duration of :arg:`count` hours.
+
+.. _ex-utility:
 
 Utility
 =======

--- a/plugin/include/txn_box/ts_util.h
+++ b/plugin/include/txn_box/ts_util.h
@@ -586,6 +586,12 @@ public:
    */
   static swoc::Errata & init(swoc::Errata & errata);
 
+  /** Gets the number of transactions between the Traffic Server proxy and the
+   *  origin server from a single session. Any value greater than zero indicates connection reuse.
+   *
+   * @return int The number of transaction
+   */
+  int server_ssn_txn_count() const;
 protected:
   using TxnConfigVarTable = std::unordered_map<swoc::TextView, std::unique_ptr<TxnConfigVar>, std::hash<std::string_view>>;
 
@@ -705,6 +711,7 @@ inline HttpTxn::operator TSHttpTxn() const { return _txn; }
 inline HttpSsn HttpTxn::ssn() const { return _txn ? TSHttpTxnSsnGet(_txn) : nullptr; }
 
 inline unsigned HttpSsn::txn_count() const { return TSHttpSsnTransactionCount(_ssn); };
+
 
 const swoc::TextView HTTP_FIELD_HOST { TS_MIME_FIELD_HOST, static_cast<size_t>(TS_MIME_LEN_HOST) };
 const swoc::TextView HTTP_FIELD_LOCATION { TS_MIME_FIELD_LOCATION, static_cast<size_t>(TS_MIME_LEN_LOCATION) };

--- a/plugin/src/Ex_HTTP.cc
+++ b/plugin/src/Ex_HTTP.cc
@@ -1158,6 +1158,24 @@ BufferWriter& Ex_proxy_rsp_status_reason::format(BufferWriter &w, Spec const &sp
   return bwformat(w, spec, ctx._txn.prsp_hdr().reason());
 }
 /* ------------------------------------------------------------------------------------ */
+class Ex_server_ssn_txn_count : public Extractor {
+public:
+  static constexpr TextView NAME { "server-ssn-txn-count" };
+
+  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+
+  /// Extract the feature from the @a ctx.
+  Feature extract(Context& ctx, Extractor::Spec const&) override;
+};
+
+Rv<ActiveType> Ex_server_ssn_txn_count::validate(Config &, Spec &, TextView const&) {
+  return { INTEGER };
+}
+
+Feature Ex_server_ssn_txn_count::extract(Context &ctx, Extractor::Spec const&) {
+  return static_cast<feature_type_for<INTEGER>>(ctx._txn.server_ssn_txn_count());
+}
+/* ------------------------------------------------------------------------------------ */
 namespace {
 // Extractors aren't constructed, they are always named references to singletons.
 // These are the singletons.
@@ -1223,6 +1241,7 @@ Ex_proxy_rsp_status proxy_rsp_status;
 Ex_upstream_rsp_status upstream_rsp_status;
 Ex_proxy_rsp_status_reason proxy_rsp_status_reason;
 Ex_upstream_rsp_status_reason upstream_rsp_status_reason;
+Ex_server_ssn_txn_count server_ssn_txn_count;
 
 [[maybe_unused]] bool INITIALIZED = [] () -> bool {
   Extractor::define(Ex_ua_req_method::NAME, &ua_req_method);
@@ -1289,6 +1308,7 @@ Ex_upstream_rsp_status_reason upstream_rsp_status_reason;
   Extractor::define(Ex_upstream_rsp_status::NAME, &upstream_rsp_status);
   Extractor::define(Ex_proxy_rsp_status_reason::NAME, &proxy_rsp_status_reason);
   Extractor::define(Ex_upstream_rsp_status_reason::NAME, &upstream_rsp_status_reason);
+  Extractor::define(Ex_server_ssn_txn_count::NAME, &server_ssn_txn_count);
 
   Extractor::define(Ex_ua_req_field::NAME, &ua_req_field);
   Extractor::define(Ex_proxy_req_field::NAME, &proxy_req_field);


### PR DESCRIPTION
Adding extractor `server-ssn-txn-count` to retrieve the number of transactions between the Traffic Server proxy and the origin server from a single session. Any value greater than zero indicates connection reuse.