### PR TITLE
AuTest updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,5 @@ cd test/autest/
   --autest-site <path/to/trafficserver>/tests/gold_tests/autest-site \
   gold_tests/autest-site/ \
   --ats-bin <path/to/built/trafficserver/bin> \
-  --verifier-bin <path/to/built/proxy-verifier/bin>
-```
-
-After the first invocation of this, the pipenv shell is created. The tests can
-be re-run more quickly from within the shell like so:
-
-```
-# Still within test/autest/
-autest \
-  -D gold_tests/
-  --autest-site <path/to/trafficserver>/tests/gold_tests/autest-site \
-  gold_tests/autest-site/ \
-  --ats-bin <path/to/built/trafficserver>/bin \
-  --verifier-bin <path/to/built/proxy-verifier>/bin
+  --proxy-verifier-bin <path/to/built/proxy-verifier/bin>
 ```

--- a/test/autest/gold_tests/basic/basic.replay.yaml
+++ b/test/autest/gold_tests/basic/basic.replay.yaml
@@ -155,7 +155,6 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
@@ -182,13 +181,13 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ potzrebie, "true", equal ]
+        - [ potzrebie, { value: "true", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
       headers:
         fields:
-        - [ Best-Band, Delain, absent ]
+        - [ Best-Band, { as: absent } ]
 
   - all: { headers: { fields: [[ uuid, 2 ]]}}
     client-request:
@@ -200,7 +199,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ potzrebie, "true", equal ]
+        - [ potzrebie, { value: "true", as: equal } ]
     server-response:
       status: 200
       reason: OK
@@ -213,7 +212,7 @@ sessions:
     proxy-response:
       headers:
         fields:
-        - [ Best-Band, "Delain", equal ]
+        - [ Best-Band, { value: "Delain", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 3 ]]}}
     client-request:
@@ -225,7 +224,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Host-Check, "remapped.ex", "equal" ]
+        - [ Host-Check, { value: "remapped.ex", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -241,7 +240,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Delain, "four", equal ]
+        - [ Delain, { value: "four", as: equal } ]
     server-response:
       status: 200
       reason: OK
@@ -265,7 +264,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ rxp-tag, "", absent ]
+        - [ rxp-tag, { as: absent } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -282,7 +281,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ rxp-tag, "Tag is 'a' with trailer ''", equal]
+        - [ rxp-tag, { value: "Tag is 'a' with trailer ''", as: equal} ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -299,8 +298,8 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ upstream, "Max 500", equal]
-        - [ basic, "Fill 0.40", equal]
+        - [ upstream, { value: "Max 500", as: equal} ]
+        - [ basic, { value: "Fill 0.40", as: equal} ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -317,8 +316,8 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ upstream, "Max 400", equal]
-        - [ basic, "Fill 0.40", equal]
+        - [ upstream, { value: "Max 400", as: equal} ]
+        - [ basic, { value: "Fill 0.40", as: equal} ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -336,7 +335,7 @@ sessions:
       url: "/stuff?parmA=bob;parmB=dave"
       headers:
         fields:
-        - [ test-query, "query 'parmA=bob;parmB=dave'", equal]
+        - [ test-query, { value: "query 'parmA=bob;parmB=dave'", as: equal} ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -354,7 +353,7 @@ sessions:
       url: "/stuff?parmA=dave;parmB=bob"
       headers:
         fields:
-        - [ test-query, "query ''", equal]
+        - [ test-query, { value: "query ''", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -376,7 +375,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "pre-remap", "http://one.ex/path/more", "equal" ]
+        - [ "pre-remap", { value: "http://one.ex/path/more", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 12]]}}
     client-request:
@@ -394,8 +393,8 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "pre-remap", "http://one.ex/path/req", "equal" ]
-        - [ "pristine", "http://one.ex/path/req", "equal" ]
+        - [ "pre-remap", { value: "http://one.ex/path/req", as: equal } ]
+        - [ "pristine", { value: "http://one.ex/path/req", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 13]]}}
     client-request:
@@ -408,10 +407,10 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ Start-Anchored, "found", "equal" ]
-        - [ Un-Anchored, "found", "equal" ]
-        - [ End-Anchored, "found", "equal" ]
-        - [ Both-Anchored, "found", "equal" ]
+        - [ Start-Anchored, { value: "found", as: equal } ]
+        - [ Un-Anchored, { value: "found", as: equal } ]
+        - [ End-Anchored, { value: "found", as: equal } ]
+        - [ Both-Anchored, { value: "found", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -428,7 +427,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ "match", "Found 9560, 9560, 9560, 9560", "equal" ]
+        - [ "match", { value: "Found 9560, 9560, 9560, 9560", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -445,7 +444,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ "match", "Found 9560, 9560, 9560, 9560", "equal" ]
+        - [ "match", { value: "Found 9560, 9560, 9560, 9560", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -469,7 +468,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "very", "Stuff,Accept", equal ]
+        - [ "very", { value: "Stuff,Accept", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 17]]}}
     client-request:
@@ -486,7 +485,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "very", "Accept", equal ]
+        - [ "very", { value: "Accept", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 18]]}}
     client-request:
@@ -506,7 +505,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "very", "Accept", equal ]
+        - [ "very", { value: "Accept", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 19]]}}
     client-request:
@@ -523,7 +522,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "very", "accepT", equal ]
+        - [ "very", { value: "accepT", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 20]]}}
     client-request:
@@ -543,7 +542,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "very", "accepT", equal ]
+        - [ "very", { value: "accepT", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 21]]}}
     client-request:
@@ -556,8 +555,8 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ "z-from", "From: 'http://remap.ex/'", equal ]
-        - [ "z-pristine", "Pre: 'http://remap.ex/21'", equal ]
+        - [ "z-from", { value: "From: 'http://remap.ex/'", as: equal } ]
+        - [ "z-pristine", { value: "Pre: 'http://remap.ex/21'", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/cmp.replay.yaml
+++ b/test/autest/gold_tests/basic/cmp.replay.yaml
@@ -75,7 +75,6 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
@@ -103,13 +102,13 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ cmp-path, "true", equal ]
-        - [ "match-path", "true", equal ]
-        - [ "rxp-sub", "v1/video/channels/delain/subchannel/streaming", equal]
-        - [ "rxp-0", "v1/video/channels/delain/subchannel/streaming", equal]
-        - [ "cmp-any", "true", equal ]
-        - [ "cmp-mix", "true", equal ]
-        - [ "cmp-split", "true", equal]
+        - [ cmp-path, { value: "true", as: equal } ]
+        - [ "match-path", { value: "true", as: equal } ]
+        - [ "rxp-sub", { value: "v1/video/channels/delain/subchannel/streaming", as: equal } ]
+        - [ "rxp-0", { value: "v1/video/channels/delain/subchannel/streaming", as: equal } ]
+        - [ "cmp-any", { value: "true", as: equal } ]
+        - [ "cmp-mix", { value: "true", as: equal } ]
+        - [ "cmp-split", { value: "true", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -126,13 +125,13 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ cmp-path, "true", equal ]
-        - [ "match-path", "true", equal ]
-        - [ "cmp-any", "true", equal ]
-        - [ "cmp-mix", "true", equal ]
-        - [ "cmp-split", "true", equal]
-        - [ "rxp-sub", "", absent ]
-        - [ "rxp-0", "", absent ]
+        - [ cmp-path, { value: "true", as: equal } ]
+        - [ "match-path", { value: "true", as: equal } ]
+        - [ "cmp-any", { value: "true", as: equal } ]
+        - [ "cmp-mix", { value: "true", as: equal } ]
+        - [ "cmp-split", { value: "true", as: equal} ]
+        - [ "rxp-sub", { as: absent } ]
+        - [ "rxp-0", { as: absent } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -149,11 +148,11 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ cmp-path, "", absent ]
-        - [ "match-path", "", absent ]
-        - [ "cmp-any", "true", equal ]
-        - [ "cmp-mix", "true", equal ]
-        - [ "cmp-split", "true", equal]
+        - [ cmp-path, { as: absent } ]
+        - [ "match-path", { as: absent } ]
+        - [ "cmp-any", { value: "true", as: equal } ]
+        - [ "cmp-mix", { value: "true", as: equal } ]
+        - [ "cmp-split", { value: "true", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -170,13 +169,13 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "cmp-path", "true", equal ]
-        - [ "match-path", "true", equal ]
-        - [ "cmp-any", "", absent ]
-        - [ "cmp-mix", "", absent ]
-        - [ "cmp-split", "", absent ]
-        - [ "rxp-sub", "", absent ]
-        - [ "rxp-0", "", absent ]
+        - [ "cmp-path", { value: "true", as: equal } ]
+        - [ "match-path", { value: "true", as: equal } ]
+        - [ "cmp-any", { as: absent } ]
+        - [ "cmp-mix", { as: absent } ]
+        - [ "cmp-split", { as: absent } ]
+        - [ "rxp-sub", { as: absent } ]
+        - [ "rxp-0", { as: absent } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/ip-addr.replay.yaml
+++ b/test/autest/gold_tests/basic/ip-addr.replay.yaml
@@ -16,14 +16,11 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
       status: 200
       reason: "OK"
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -43,7 +40,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "via", "traffic_server", contains]
+        - [ "via", { value: "traffic_server", as: contains } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/multi-cfg.replay.yaml
+++ b/test/autest/gold_tests/basic/multi-cfg.replay.yaml
@@ -4,7 +4,6 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
@@ -31,8 +30,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "", absent ]
-        - [ "Ship-Name", "Frank Exchange of Views", equal]
+        - [ "Best-Band", { as: absent } ]
+        - [ "Ship-Name", { value: "Frank Exchange of Views", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -48,8 +47,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "NightWish", equal ]
-        - [ "Ship-Name", "Frank Exchange of Views", equal]
+        - [ "Best-Band", { value: "NightWish", as: equal } ]
+        - [ "Ship-Name", { value: "Frank Exchange of Views", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -64,8 +63,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "", absent ]
-        - [ "Ship-Name", "Frank Exchange of Views", absent ]
+        - [ "Best-Band", { as: absent } ]
+        - [ "Ship-Name", { as: absent } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -81,8 +80,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "Delain", equal ]
-        - [ "Ship-Name", "Frank Exchange of Views", absent ]
+        - [ "Best-Band", { value: "Delain", as: equal } ]
+        - [ "Ship-Name", { as: absent } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -97,8 +96,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "Delain", absent ]
-        - [ "Ship-Name", "Frank Exchange of Views", equal ]
+        - [ "Best-Band", { as: absent } ]
+        - [ "Ship-Name", { value: "Frank Exchange of Views", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -114,8 +113,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "Delain", equal ]
-        - [ "Ship-Name", "Frank Exchange of Views", equal ]
+        - [ "Best-Band", { value: "Delain", as: equal } ]
+        - [ "Ship-Name", { value: "Frank Exchange of Views", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/redirect.replay.yaml
+++ b/test/autest/gold_tests/basic/redirect.replay.yaml
@@ -31,13 +31,10 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
   - base-rsp: &base-rsp
       status: 200
       reason: OK
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -61,7 +58,7 @@ sessions:
       status: 301
       headers:
         fields:
-        - [ "Location", "http://bravo.ex/", equal]
+        - [ "Location", { value: "http://bravo.ex/", as: equal } ]
 
   - all: { headers: { fields: [ [ uuid, 102 ] ] } }
     client-request:
@@ -78,7 +75,7 @@ sessions:
       status: 301
       headers:
         fields:
-        - [ "Location", "http://bravo.ex/", equal]
+        - [ "Location", { value: "http://bravo.ex/", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 103 ]] }}
     client-request:
@@ -95,7 +92,7 @@ sessions:
       status: 301
       headers:
         fields:
-        - [ "Location", "http://bravo.ex/lucidity.html", equal]
+        - [ "Location", { value: "http://bravo.ex/lucidity.html", as: equal } ]
 
   - all: { headers: { fields: [ [ uuid, 104 ] ] } }
     client-request:
@@ -112,7 +109,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://charlie.ex/nightwish", equal]
+        - [ "Location", { value: "http://charlie.ex/nightwish", as: equal } ]
 
   - all: { headers: { fields: [ [ uuid, 105 ] ] } }
     client-request:
@@ -129,7 +126,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://charlie.ex/nightwish/once.html", equal]
+        - [ "Location", { value: "http://charlie.ex/nightwish/once.html", as: equal } ]
 
   # Check for no clipping if the key path element isn't first.
   - all: { headers: { fields: [ [ uuid, 106 ] ] } }
@@ -147,7 +144,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://charlie.ex/album/delain/moon-bathers.html", equal]
+        - [ "Location", { value: "http://charlie.ex/album/delain/moon-bathers.html", as: equal } ]
 
   # This should match a remap rule without TxnBox therefore shouldn't be redirected.
   - all: { headers: { fields: [ [ uuid, 107 ] ] } }
@@ -165,7 +162,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "Location", "", absent]
+        - [ "Location", { as: absent } ]
 
   # test tuple value support.
   - all: { headers: { fields: [ [ uuid, 108 ] ] } }
@@ -183,7 +180,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://delta.ex/spot.html", equal]
+        - [ "Location", { value: "http://delta.ex/spot.html", as: equal } ]
 
   - all: { headers: { fields: [ [ uuid, reply ] ] } }
     client-request:
@@ -200,5 +197,4 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://reply.ex/reply/doc.html", equal]
-
+        - [ "Location", { value: "http://reply.ex/reply/doc.html", as: equal } ]

--- a/test/autest/gold_tests/basic/reply.replay.yaml
+++ b/test/autest/gold_tests/basic/reply.replay.yaml
@@ -31,13 +31,10 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
   - base-rsp: &base-rsp
       status: 200
       reason: OK
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]

--- a/test/autest/gold_tests/basic/rxp.replay.yaml
+++ b/test/autest/gold_tests/basic/rxp.replay.yaml
@@ -24,14 +24,11 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
       status: 200
       reason: "OK"
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -50,10 +47,10 @@ sessions:
         - [ Host, app.ex ]
     proxy-request:
       url:
-      - [ path, "/method", equal ]
+      - [ path, { value: "/method", as: equal } ]
       headers:
         field:
-        - [ host, "v1.app.ex", prefix ]
+        - [ host, { value: "v1.app.ex", as: prefix } ]
       <<: *base-req
     server-response:
       <<: *base-rsp
@@ -69,10 +66,10 @@ sessions:
         - [ Host, app.ex ]
     proxy-request:
       url:
-      - [ path, "/method/arg1/arg2", equal ]
+      - [ path, { value: "/method/arg1/arg2", as: equal } ]
       headers:
         field:
-        - [ host, "v2.app.ex", prefix ]
+        - [ host, { value: "v2.app.ex", as: prefix } ]
       <<: *base-req
     server-response:
       <<: *base-rsp
@@ -88,11 +85,11 @@ sessions:
         - [ Host, app.ex ]
     proxy-request:
       url:
-      - [ path, "/method", equal ]
-      - [ query, "parm1=arg1;parm2=arg2", equal ]
+      - [ path, { value: "/method", as: equal } ]
+      - [ query, { value: "parm1=arg1;parm2=arg2", as: equal } ]
       headers:
         field:
-        - [ host, "v2.app.ex", prefix ]
+        - [ host, { value: "v2.app.ex", as: prefix } ]
       <<: *base-req
     server-response:
       <<: *base-rsp

--- a/test/autest/gold_tests/basic/stat.replay.yaml
+++ b/test/autest/gold_tests/basic/stat.replay.yaml
@@ -35,7 +35,6 @@ meta:
 
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
       headers:
         fields:

--- a/test/autest/gold_tests/basic/tls.replay.yaml
+++ b/test/autest/gold_tests/basic/tls.replay.yaml
@@ -17,7 +17,6 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
   - base-rsp: &base-rsp
       status: 200
@@ -43,7 +42,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ "Host", "stage.video.ex", prefix ]
+        - [ "Host", { value: "stage.video.ex", as: prefix } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -60,7 +59,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ "Host", "stage.video.ex", prefix ]
+        - [ "Host", { value: "stage.video.ex", as: prefix } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -79,7 +78,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ "Host", "stage.video.ex", prefix ]
+        - [ "Host", { value: "stage.video.ex", as: prefix } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -96,7 +95,7 @@ sessions:
       <<: *base-req
       headers:
         fields:
-        - [ "Host", "stage.video.ex", prefix ]
+        - [ "Host", { value: "stage.video.ex", as: prefix } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/tuple.replay.yaml
+++ b/test/autest/gold_tests/basic/tuple.replay.yaml
@@ -26,14 +26,11 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
       status: 200
       reason: "OK"
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -53,9 +50,9 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ alpha, "smoke", equal ]
-        - [ bravo, "path/stuff", equal ]
-        - [ charlie, "path/stuff", equal ]
+        - [ alpha, { value: "smoke", as: equal } ]
+        - [ bravo, { value: "path/stuff", as: equal } ]
+        - [ charlie, { value: "path/stuff", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -71,11 +68,11 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ alpha, "1 h", equal ]
-        - [ bravo, [ "1 h", "30 m" ], equal ]
-        - [ charlie, "1 h 30 m", equal ]
-        - [ delta, "1 h 45 m", equal ]
-        - [ echo, "1 h 30 m", equal ]
+        - [ alpha, { value: "1 h", as: equal } ]
+        - [ bravo, { value: [ "1 h", "30 m" ], as: equal } ]
+        - [ charlie, { value: "1 h 30 m", as: equal } ]
+        - [ delta, { value: "1 h 45 m", as: equal } ]
+        - [ echo, { value: "1 h 30 m", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/txn_open_1.replay.yaml
+++ b/test/autest/gold_tests/basic/txn_open_1.replay.yaml
@@ -11,7 +11,6 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
@@ -38,7 +37,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Test, "NATO = 120", equal ]
+        - [ Test, { value: "NATO = 120", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/txn_open_2.replay.yaml
+++ b/test/autest/gold_tests/basic/txn_open_2.replay.yaml
@@ -22,14 +22,11 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
       status: 200
       reason: "OK"
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -49,7 +46,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Test, "NATO = 937", equal ]
+        - [ Test, { value: "NATO = 937", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/txn_open_3.replay.yaml
+++ b/test/autest/gold_tests/basic/txn_open_3.replay.yaml
@@ -19,14 +19,11 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
       status: 200
       reason: "OK"
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -46,7 +43,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Test, "NATO = 120", equal ]
+        - [ Test, { value: "NATO = 120", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/basic/with.replay.yaml
+++ b/test/autest/gold_tests/basic/with.replay.yaml
@@ -50,14 +50,11 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
       status: 200
       reason: "OK"
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -79,8 +76,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "", absent ]
-        - [ "with", "passed", equal ] # Didn't update Best-Band, fall through.
+        - [ "Best-Band", { as: absent } ]
+        - [ "with", { value: "passed", as: equal } ] # Didn't update Best-Band, fall as: through} .
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -96,8 +93,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "Delain", equal ]
-        - [ "with", "", absent ] # updated Best-Band, shouldn't do this.
+        - [ "Best-Band", { value: "Delain", as: equal } ]
+        - [ "with", { as: absent } ] # updated Best-Band, shouldn't do as: this} .
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -114,8 +111,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "", absent ]
-        - [ "with", "", absent ]
+        - [ "Best-Band", { as: absent } ]
+        - [ "with", { as: absent } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -131,8 +128,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "Delain", equal ]
-        - [ "with", "", absent ]
+        - [ "Best-Band", { value: "Delain", as: equal } ]
+        - [ "with", { as: absent } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -148,8 +145,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "", absent ]
-        - [ "with", "passed", equal ]
+        - [ "Best-Band", { as: absent } ]
+        - [ "with", { value: "passed", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -165,8 +162,8 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ "Best-Band", "Delain", equal ]
-        - [ "with", "passed", equal ]
+        - [ "Best-Band", { value: "Delain", as: equal } ]
+        - [ "with", { value: "passed", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/ct_header/ct_header.replay.yaml
+++ b/test/autest/gold_tests/ct_header/ct_header.replay.yaml
@@ -64,7 +64,6 @@ sessions:
 
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/config/settings.yaml"
       headers: { fields: [[ Host, base.ex]]}
@@ -74,7 +73,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 72 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -84,9 +82,9 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ expect-ct, "", absent]
-        - [ x-xss-protection, "", absent]
-        - [ x-content-type-options, "", absent]
+        - [ expect-ct, { as: absent } ]
+        - [ x-xss-protection, { as: absent } ]
+        - [ x-content-type-options, { as: absent } ]
 
 
   #
@@ -99,7 +97,6 @@ sessions:
 
     client-request:
       version: "1.1"
-      scheme: "https"
       method: "GET"
       url: "/config/settings.yaml"
       headers: { fields: [[ Host, base.ex ]]}
@@ -109,7 +106,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 72 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -119,9 +115,9 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ expect-ct, "max-age=31536000, report-uri=\"http://cane.example.com/path/cane?src=examplecom-expect-ct-report-only\"", equal]
-        - [ x-xss-protection, "1; mode=block", equal ]
-        - [ x-content-type-options, "nosniff", equal ]
+        - [ expect-ct, { value: "max-age=31536000, report-uri=\"http://cane.example.com/path/cane?src=examplecom-expect-ct-report-only\"", as: equal } ]
+        - [ x-xss-protection, { value: "1; mode=block", as: equal } ]
+        - [ x-content-type-options, { value: "nosniff", as: equal } ]
 
   #
   # Test 3: For u.protected.ex, expect the 'enforce' ct-policy.
@@ -130,7 +126,6 @@ sessions:
 
     client-request:
       version: "1.1"
-      scheme: "https"
       method: "GET"
       url: /config/settings.yaml
       headers: { fields: [[ Host, u.protected.ex ]]}
@@ -140,7 +135,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 72 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -150,9 +144,9 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ expect-ct, "max-age=31536000, enforce", equal]
-        - [ x-xss-protection, "1; mode=block", equal ]
-        - [ x-content-type-options, "nosniff", equal ]
+        - [ expect-ct, { value: "max-age=31536000, enforce", as: equal } ]
+        - [ x-xss-protection, { value: "1; mode=block", as: equal } ]
+        - [ x-content-type-options, { value: "nosniff", as: equal } ]
 
   #
   # Test 4: Not u.protected.ex, so expect the default ct-policy.
@@ -161,7 +155,6 @@ sessions:
 
     client-request:
       version: "1.1"
-      scheme: "https"
       method: "GET"
       url: "/config/settings.yaml"
       headers: { fields: [[ Host, protected.ex ]]}
@@ -171,7 +164,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 72 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -181,7 +173,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ expect-ct, "max-age=31536000, report-uri=\"http://cane.example.com/path/cane?src=examplecom-expect-ct-report-only\"", equal]
+        - [ expect-ct, { value: "max-age=31536000, report-uri=\"http://cane.example.com/path/cane?src=examplecom-expect-ct-report-only\"", as: equal} ]
 
 - protocol: [ { name: ip, version : 4} ]
   transactions:
@@ -192,7 +184,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 5 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/config/settings.yaml"
       headers:
@@ -204,12 +195,11 @@ sessions:
       method: "GET"
       headers:
         fields:
-        - [ Cookie, "w=some; delicious=cookie", equal ]
+        - [ Cookie, { value: "w=some; delicious=cookie", as: equal } ]
 
     server-response:
       status: 200
       reason: OK
-      content: { size: 84 }
       headers:
         fields: &srv-response-fields
         - [ Content-Type, text/html ]
@@ -224,7 +214,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 6 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/fancy-picture.jpg"
       headers:
@@ -235,12 +224,11 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Cookie, "", absent ]
+        - [ Cookie, { as: absent } ]
 
     server-response:
       status: 200
       reason: OK
-      content: { size: 84 }
       headers:
         fields: *srv-response-fields
 
@@ -253,7 +241,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 7 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/fancy-picture.jpg"
       headers:
@@ -265,7 +252,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 84 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -276,7 +262,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ set-cookie, "A1=d=AQABBO; Max-Age=31557600; Domain=.example.com; Path=/; SameSite=Lax; Secure; HttpOnly", equal ]
+        - [ set-cookie, { value: "A1=d=AQABBO; Max-Age=31557600; Domain=.example.com; Path=/; SameSite=Lax; Secure; HttpOnly", as: equal } ]
 
   #
   # Test 8: Set-Cookie fields with protected.com content should be removed.
@@ -284,7 +270,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 8 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "http://s.protected.ex/fancy-picture.jpg"
       headers:
@@ -296,7 +281,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 84 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -307,7 +291,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ set-cookie, "", absent ]
+        - [ set-cookie, { as: absent } ]
 
 #
 # Test 9: Filter out Set-Cookie fields with protected.com content when with another.
@@ -315,7 +299,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 9 ]]}}
     client-request:
       version: "1.1"
-      scheme: "https"
       method: "GET"
       url: "http://s.protected.ex/fancy-picture.jpg"
       headers:
@@ -327,7 +310,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 84 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -339,7 +321,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ set-cookie, "A2=d=AQABBO; Max-Age=31557600; Domain=.example.com; Path=/; SameSite=Lax; Secure; HttpOnly", equal ]
+        - [ set-cookie, { value: "A2=d=AQABBO; Max-Age=31557600; Domain=.example.com; Path=/; SameSite=Lax; Secure; HttpOnly", as: equal } ]
 
   #
   # Test 10: Filter out Set-Cookie fields with protected.com content when with two others.
@@ -347,7 +329,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 10 ]]}}
     client-request:
       version: "1.1"
-      scheme: "https"
       method: "GET"
       url: "http://s.protected.ex/fancy-picture.jpg"
       headers:
@@ -359,7 +340,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 84 }
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -372,7 +352,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ set-cookie, [ "A2=d=AQABBO; Max-Age=31557600; Domain=.example.com; Path=/; SameSite=Lax; Secure; HttpOnly" ], equal ]
+        - [ set-cookie, { value: [ "A2=d=AQABBO; Max-Age=31557600; Domain=.example.com; Path=/; SameSite=Lax; Secure; HttpOnly" ], as: equal } ]
 
   #
   # Test 10: Filter out Set-Cookie fields with protected.com content when in between two others.
@@ -380,7 +360,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 11 ]]}}
     client-request:
       version: "1.1"
-      scheme: "https"
       method: "GET"
       url: "http://s.protected.ex/fancy-picture.jpg"
       headers:
@@ -395,7 +374,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content: { size: 84 }
       headers:
         fields:
         - [ Content-Type, text/html ]

--- a/test/autest/gold_tests/example/accept-encoding.replay.yaml
+++ b/test/autest/gold_tests/example/accept-encoding.replay.yaml
@@ -12,7 +12,6 @@ meta:
 
   - base_request: &base_request
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - rsp: &rsp
@@ -38,7 +37,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Accept-Encoding, "identity", equal ]
+        - [ Accept-Encoding, { value: "identity", as: equal } ]
     server-response:
       <<: *rsp
     proxy-response:
@@ -55,7 +54,7 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Accept-Encoding, "gzip", equal ]
+        - [ Accept-Encoding, { value: "gzip", as: equal } ]
     server-response:
       <<: *rsp
     proxy-response:

--- a/test/autest/gold_tests/prod/ip-acl.replay.yaml
+++ b/test/autest/gold_tests/prod/ip-acl.replay.yaml
@@ -26,13 +26,10 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
   - base-rsp: &base-rsp
       status: 200
       reason: OK
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]

--- a/test/autest/gold_tests/prod/vznith-1.replay.yaml
+++ b/test/autest/gold_tests/prod/vznith-1.replay.yaml
@@ -25,13 +25,10 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
   - base-rsp: &base-rsp
       status: 200
       reason: OK
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -52,7 +49,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -69,7 +66,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_noma.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_noma.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -86,7 +83,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -103,7 +100,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -120,7 +117,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_mac.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_mac.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -137,7 +134,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_noma_mac.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_noma_mac.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -154,7 +151,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_noma_mac.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_noma_mac.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -171,7 +168,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_noma_mac.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_noma_mac.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -188,7 +185,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_noma_mac.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_noma_mac.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -205,7 +202,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_noma.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_noma.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:
@@ -222,7 +219,7 @@ sessions:
     proxy-request:
       <<: *base-req
       url:
-      - [ path, "/edge/file/boot_noma.ipxe.img", equal ]
+      - [ path, { value: "/edge/file/boot_noma.ipxe.img", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:

--- a/test/autest/gold_tests/prod/yts-3489.replay.yaml
+++ b/test/autest/gold_tests/prod/yts-3489.replay.yaml
@@ -61,13 +61,10 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
   - base-rsp: &base-rsp
       status: 200
       reason: OK
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -91,7 +88,7 @@ sessions:
       status: 301
       headers:
         fields:
-        - [ "Location", "http://bravo.ex/", equal]
+        - [ "Location", { value: "http://bravo.ex/", as: equal } ]
 
   - all: { headers: { fields: [ [ uuid, 102 ] ] } }
     client-request:
@@ -108,7 +105,7 @@ sessions:
       status: 301
       headers:
         fields:
-        - [ "Location", "http://bravo.ex/", equal]
+        - [ "Location", { value: "http://bravo.ex/", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 103 ]] }}
     client-request:
@@ -125,7 +122,7 @@ sessions:
       status: 301
       headers:
         fields:
-        - [ "Location", "http://bravo.ex/lucidity.html", equal]
+        - [ "Location", { value: "http://bravo.ex/lucidity.html", as: equal } ]
 
   - all: { headers: { fields: [ [ uuid, 104 ] ] } }
     client-request:
@@ -142,7 +139,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://charlie.ex/nightwish", equal]
+        - [ "Location", { value: "http://charlie.ex/nightwish", as: equal } ]
 
   - all: { headers: { fields: [ [ uuid, 105 ] ] } }
     client-request:
@@ -159,7 +156,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://charlie.ex/nightwish/once.html", equal]
+        - [ "Location", { value: "http://charlie.ex/nightwish/once.html", as: equal } ]
 
   # Verify no clipping if target path element isn't first.
   - all: { headers: { fields: [ [ uuid, 106 ] ] } }
@@ -177,7 +174,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://charlie.ex/album/delain/moon-bathers.html", equal]
+        - [ "Location", { value: "http://charlie.ex/album/delain/moon-bathers.html", as: equal } ]
 
   # This shouldn't match the remap rule and therefore shouldn't be redirected.
   - all: { headers: { fields: [ [ uuid, 107 ] ] } }
@@ -195,7 +192,7 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ "Location", "", absent]
+        - [ "Location", { as: absent } ]
 
   # Is the query string preserved?
   - all: { headers: { fields: [ [ uuid, 108 ] ] } }
@@ -213,7 +210,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://charlie.ex/nightwish/ocean-born.html?track=3", equal]
+        - [ "Location", { value: "http://charlie.ex/nightwish/ocean-born.html?track=3", as: equal } ]
 
   # Does the alternate style work without a query string?
   - all: { headers: { fields: [ [ uuid, 109 ] ] } }
@@ -231,7 +228,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://delta.ex/nightwish/ocean-born.html", equal]
+        - [ "Location", { value: "http://delta.ex/nightwish/ocean-born.html", as: equal } ]
 
   # Is the query string preserved in the alternate style?
   - all: { headers: { fields: [ [ uuid, 110 ] ] } }
@@ -249,7 +246,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://delta.ex/nightwish/ocean-born.html?track=3", equal]
+        - [ "Location", { value: "http://delta.ex/nightwish/ocean-born.html?track=3", as: equal } ]
 
   # Does the alternate style work without a query string?
   - all: { headers: { fields: [ [ uuid, 111 ] ] } }
@@ -267,7 +264,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://echo.ex/nightwish/ocean-born.html", equal]
+        - [ "Location", { value: "http://echo.ex/nightwish/ocean-born.html", as: equal } ]
 
   # Is the query string preserved in the alternate style?
   - all: { headers: { fields: [ [ uuid, 112 ] ] } }
@@ -285,7 +282,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://echo.ex/nightwish/ocean-born.html?track=3", equal]
+        - [ "Location", { value: "http://echo.ex/nightwish/ocean-born.html?track=3", as: equal } ]
 
   # Does the alternate style work without a query string?
   - all: { headers: { fields: [ [ uuid, 113 ] ] } }
@@ -303,7 +300,7 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://foxtrot.ex/nightwish/ocean-born.html", equal]
+        - [ "Location", { value: "http://foxtrot.ex/nightwish/ocean-born.html", as: equal } ]
 
   # Is the query string preserved in the alternate style?
   - all: { headers: { fields: [ [ uuid, 114 ] ] } }
@@ -321,4 +318,4 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", "http://foxtrot.ex/nightwish/ocean-born.html?track=3", equal]
+        - [ "Location", { value: "http://foxtrot.ex/nightwish/ocean-born.html?track=3", as: equal } ]

--- a/test/autest/gold_tests/ramp/multi-ramp.replay.yaml
+++ b/test/autest/gold_tests/ramp/multi-ramp.replay.yaml
@@ -9,15 +9,12 @@ meta:
 
   - base_request: &base_request
       version: "1.1"
-      scheme: "http"
       method: "GET"
       <<: *ua-req-hdr
 
   - upstream-rsp: &upstream-rsp
       status: 200
       reason: OK
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]

--- a/test/autest/gold_tests/ramp/ramp.replay.yaml
+++ b/test/autest/gold_tests/ramp/ramp.replay.yaml
@@ -12,7 +12,6 @@ meta:
   blocks:
   - base_request: &base_request
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/1"
 
@@ -30,8 +29,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content:
-        size: 96
       headers:
         fields:
         - [ Content-Type, html/plaintext ]

--- a/test/autest/gold_tests/smoke/smoke.replay.yaml
+++ b/test/autest/gold_tests/smoke/smoke.replay.yaml
@@ -28,7 +28,6 @@ meta:
   blocks:
   - base_request: &base_request
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
 sessions:
@@ -48,8 +47,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content:
-        size: 234
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -57,7 +54,7 @@ sessions:
     proxy-response:
       headers:
         fields:
-        - [ Best-Band, Delain, absent ]
+        - [ Best-Band, { as: absent } ]
 
   - all: { headers: { fields: [[ uuid, 2 ]]}}
     client-request:
@@ -73,8 +70,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content:
-        size: 234
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -82,7 +77,7 @@ sessions:
     proxy-response:
       headers:
         fields:
-        - [ Best-Band, "Delain", equal ]
+        - [ Best-Band, { value: "Delain", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 3 ]]}}
     client-request:
@@ -94,12 +89,10 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Host-Check, "ex.three", "equal" ]
+        - [ Host-Check, { value: "ex.three", as: equal } ]
     server-response:
       status: 200
       reason: OK
-      content:
-        size: 130
       headers:
         fields:
         - [ Content-Type, html/plaintext ]

--- a/test/autest/gold_tests/static_file/static_file.replay.yaml
+++ b/test/autest/gold_tests/static_file/static_file.replay.yaml
@@ -106,14 +106,11 @@ meta:
   blocks:
   - base-req: &base-req
       version: "1.1"
-      scheme: "http"
       method: "GET"
 
   - base-rsp: &base-rsp
       status: 200
       reason: "OK"
-      content:
-        size: 56
       headers:
         fields:
         - [ Content-Type, html/plaintext ]
@@ -136,8 +133,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content:
-        size: 110
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -147,12 +142,11 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ SWOC, "upstream", equal ]
+        - [ SWOC, { value: "upstream", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 2 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/2"
       headers:
@@ -160,7 +154,6 @@ sessions:
         - [ Host, base.ex ]
     proxy-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/2"
       headers:
@@ -169,8 +162,6 @@ sessions:
     server-response:
       status: 200
       reason: OK
-      content:
-        size: 120
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -179,12 +170,11 @@ sessions:
       status: 200
       headers:
         fields:
-        - [ SWOC, "Delain Concert.", equal ]
+        - [ SWOC, { value: "Delain Concert.", as: equal } ]
 
   - all: { headers: { fields: [[ uuid, 3 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/security.txt"
       headers:
@@ -192,7 +182,6 @@ sessions:
         - [ Host, base.ex ]
     proxy-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/security.txt"
       headers:
@@ -201,8 +190,6 @@ sessions:
     server-response:
       status: 404
       reason: Not Found
-      content:
-        size: 130
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -215,7 +202,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 4 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/concert.txt"
       headers:
@@ -223,16 +209,13 @@ sessions:
         - [ Host, base.ex ]
     proxy-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/concert.txt"
       headers:
         fields:
-        - [ Author-i-tay, "Delain Concert.", equal ]
+        - [ Author-i-tay, { value: "Delain Concert.", as: equal } ]
     server-response:
       status: 200
-      content:
-        size: 140
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -243,7 +226,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 5 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/concert.txt"
       headers:
@@ -253,11 +235,9 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Author-i-tay, "Nightwish Concert.", equal ]
+        - [ Author-i-tay, { value: "Nightwish Concert.", as: equal } ]
     server-response:
       status: 200
-      content:
-        size: 50
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -268,7 +248,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 6 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/alternate.txt"
       headers:
@@ -278,11 +257,9 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Author-i-tay, "Delain Concert.", equal ]
+        - [ Author-i-tay, { value: "Delain Concert.", as: equal } ]
     server-response:
       status: 200
-      content:
-        size: 50
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -293,7 +270,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 7 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/alternate.txt"
       headers:
@@ -302,11 +278,9 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Author-i-tay, "Delain Concert.", equal ]
+        - [ Author-i-tay, { value: "Delain Concert.", as: equal } ]
     server-response:
       status: 200
-      content:
-        size: 50
       headers:
         fields:
         - [ Content-Type, text/html ]
@@ -317,7 +291,6 @@ sessions:
   - all: { headers: { fields: [[ uuid, 8 ]]}}
     client-request:
       version: "1.1"
-      scheme: "http"
       method: "GET"
       url: "/missing.txt"
       headers:
@@ -326,11 +299,9 @@ sessions:
     proxy-request:
       headers:
         fields:
-        - [ Author-i-tay, "Concert missing.", equal ]
+        - [ Author-i-tay, { value: "Concert missing.", as: equal } ]
     server-response:
       status: 200
-      content:
-        size: 50
       headers:
         fields:
         - [ Content-Type, text/html ]

--- a/test/autest/test-env-check.sh
+++ b/test/autest/test-env-check.sh
@@ -27,7 +27,7 @@ _END_
 if [ $? = 1 ]
 then
     echo "Python 3.5 or newer is not installed/enabled."
-    return
+    exit 1
 else
     echo "Python 3.5 or newer detected!"
 fi
@@ -39,16 +39,22 @@ then
     echo "python3-dev/devel detected!"
 else
     echo "python3-dev/devel is not installed. "
-    return
+    exit 1
 fi
 
 # check for pipenv
 pipenv --version &> /dev/null
-if [ $? = 0 ]
+if [ $? -eq 0 ]
 then
     echo "pipenv detected!"
+    pipenv --venv &> /dev/null
+    if [ $? -ne 0 ]
+    then
+        echo "Installing a new virtual environment via pipenv"
     pipenv install
-    # pipenv shell
+    else
+        echo "Using the pre-existing virtual environment."
+    fi
 else
     echo "pipenv is not installed/enabled. "
 fi


### PR DESCRIPTION
* Update the test-env-check.sh to check for an existing pipenv and use
  that if it is there.
* Update the README to no longer mention the now-unneeded autest within
  pipenv shell. The smarter test-env-check.sh obsoletes this.
* Update the README to reference the correct --proxy-verifier-switch
* Update the replay files:
  * Use the new map verification syntax.
  * Remove references to scheme. scheme makes sense for traffic dump to
    emit for recording purposes, but is dead weight in end to end test
    YAML files.
  * Remove content node when Content-Length header exists.