### PR TITLE
Bring in 0.4.0 version.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,139 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: All
+AlwaysBreakAfterReturnType: AllDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Linux
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     132
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - forv_Vec
+  - for_Vec
+  - forp_Vec
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 30000
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ include/swoc
 /var
 /_vcs
 /_sdk
+/_scm
 /_unit_tests
 /test/autest/_sandbox/
 /test/autest/Pipfile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,15 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 
 find_package(PkgConfig REQUIRED)
+
+# libSWOC
+#pkg_check_modules(swoc IMPORTED_TARGET libswoc.static)
+#if(NOT swoc_FOUND)
+#    message("Building libSWOC")
+#    execute_process(COMMAND git clone https://github.com/solidwallofcode/libswoc extern/libswoc)
+#    # cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib extern/libswoc
+#endif()
+
 pkg_check_modules(swoc REQUIRED IMPORTED_TARGET libswoc.static)
 pkg_check_modules(yaml-cpp REQUIRED IMPORTED_TARGET yaml-cpp)
 pkg_check_modules(trafficserver REQUIRED IMPORTED_TARGET trafficserver)

--- a/Sconstruct
+++ b/Sconstruct
@@ -29,7 +29,7 @@ AddOption("--with-ssl",
 
 # the depends
 Part("code/libswoc.part"
-     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="master")
+     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.2.23")
      )
 Part("#lib/libyaml-cpp.part", vcs_type=VcsGit(server="github.com", repository="jbeder/yaml-cpp.git", protocol="https", tag="yaml-cpp-0.6.3"))
 #Part("#lib/libyaml-cpp.part")

--- a/Sconstruct
+++ b/Sconstruct
@@ -29,8 +29,8 @@ AddOption("--with-ssl",
 
 # the depends
 Part("code/libswoc.part"
-        ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.2.20")
-        )
+     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.2.20")
+     )
 Part("#lib/libyaml-cpp.part", vcs_type=VcsGit(server="github.com", repository="jbeder/yaml-cpp.git", protocol="https", tag="yaml-cpp-0.6.3"))
 #Part("#lib/libyaml-cpp.part")
 

--- a/Sconstruct
+++ b/Sconstruct
@@ -3,7 +3,7 @@ from parts import *
 
 #enable smart linking
 SetOptionDefault("LINKFLAGS", ['-Wl,--copy-dt-needed-entries', '-Wl,--as-needed'])
-SetOptionDefault("CXXFLAGS", ['-std=c++17', '-fPIC', '-Wnon-virtual-dtor'])
+SetOptionDefault("CPPFLAGS", ['-std=c++17', '-Wnon-virtual-dtor'])
 SetOptionDefault("INSTALL_ROOT", "#")
 
 # control shim for trafficserver
@@ -29,7 +29,7 @@ AddOption("--with-ssl",
 
 # the depends
 Part("code/libswoc.part"
-     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.2.20")
+     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="master")
      )
 Part("#lib/libyaml-cpp.part", vcs_type=VcsGit(server="github.com", repository="jbeder/yaml-cpp.git", protocol="https", tag="yaml-cpp-0.6.3"))
 #Part("#lib/libyaml-cpp.part")

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "Transaction Box"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.3.20"
+PROJECT_NUMBER         = "0.4.0"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -78,9 +78,9 @@ copyright = u'2020, Verizon Media'
 # update a reasonable version number here.
 #
 # The short X.Y version.
-version = "0.3"
+version = "0.4"
 # The full version, including alpha/beta/rc tags.
-release = "0.3.20"
+release = "0.4.0"
 
 extlinks = { 'git': ( 'https://github.com/solidwallofcode/txn_box/tree/{}/%s'.format(release) , '') }
 

--- a/doc/txn_box.en.rst
+++ b/doc/txn_box.en.rst
@@ -15,20 +15,24 @@ Concepts
 consider some subset of the information in the transaction and, based on that, perform specific
 actions. There is a further presumption that the common use will be multiple comparisons against the
 same data, each comparison associated with different actions. This is a generalization of how URL
-rewriting happens currently in |TS| via "remap.config". The difference between this and |TS| is
+rewriting happens currently in |TS| via "remap.config". The difference between this and remapping is
 the latter considers only a fixed, very small subset of data in the transaction, the set of actions
 is limited, and there is only one decision point.
 
 To aid further explanation, some terms need to be defined.
 
-|TxB| has two phases of operation, :term:`load time` and :term:`run time`. Load time is the time
-during which the configuration is being loaded and run time is when processing transactions. A
-:term:`hook`\s is essentially the same as a hook in |TS|. In addition to the hooks in |TS|,
-|TxB| has additional hooks specific to |TxB|.
+Every action in |TxB| is associated with a specific :term:`hook`. A |TxB| hook is essentially the
+same as a hook in |TS|. In addition to the hooks in |TS|, |TxB| has additional hooks specific to
+|TxB|.
+
+|TxB| has two phases of operation, :term:`load time` and :term:`run time`. Load time is the
+time during which the configuration is being loaded and run time is when processing transactions.
+Operations during load time are done by associating the action with a hook that triggers during
+load time.
 
 A :term:`feature` is data of interest for a transaction. A feature is created by :term:`Extraction`
 which is specifed by a :term:`feature expression`, which is a series of literals and
-:term:`extractor`\s. Each extractor retrieves a specific datum and the combbination of those and
+:term:`extractor`\s. Each extractor retrieves a specific datum and the combination of those and
 (optional) literals defines the resulting feature. Features can be one of several types, the most
 common being a string.
 
@@ -53,7 +57,7 @@ file that is YAML.
 
 For a global configuration, the top level directives must all be :txb:drtv:`when` thereby
 associating every directive with a specific hook. For a remap configuration, all directives are
-grouped in an implied :code:`when: remap`and therefore no explicit :code:`when` is required.
+grouped in an implied :code:`when: remap` and therefore no explicit :code:`when` is required.
 
 Each directive and extractor has an associated set of hooks in which it is valid, therefore some
 will be available in a remap configuration and some will not. In particular there are several

--- a/doc/user/DirectiveReference.en.rst
+++ b/doc/user/DirectiveReference.en.rst
@@ -122,6 +122,15 @@ User Agent Request
 
    Sets the query string for the user agent request.
 
+.. directive:: ua-req-query-value
+   :arg: Query parameter key.
+   :value: string
+
+   Set the value for a specific query parameter, identified by key. This assumes the standard format
+   for a query string, key / value pairs (joined by '=') separated by '&' or ';'. The key comparison
+   is case insensitive. If the value is ``NULL`` the key and value are removed from the query string.
+   Otherwise, if the key is not present it is added, then the value updated.
+
 .. directive:: ua-req-fragment
    :value: string
 
@@ -188,6 +197,15 @@ Proxy Request
    :value: string
 
    Sets the query string for the proxy request.
+
+.. directive:: proxy-req-query-value
+   :arg: Query parameter key.
+   :value: string
+
+   Set the value for a specific query parameter, identified by key. This assumes the standard format
+   for a query string, key / value pairs (joined by '=') separated by '&' or ';'. The key comparison
+   is case insensitive. If the value is ``NULL`` the key and value are removed from the query string.
+   Otherwise, if the key is not present it is added, then the value updated.
 
 .. directive:: proxy-req-fragment
    :value: string

--- a/doc/user/ExtractorReference.en.rst
+++ b/doc/user/ExtractorReference.en.rst
@@ -164,6 +164,14 @@ User Agent Request
 
    The query string for the user agent request if present, an empty string if not.
 
+.. extractor:: ua-req-query-value
+   :result: string
+   :arg: Query parameter key.
+
+   The value for a specific query parameter, identified by key. This assumes the standard format for
+   a query string, key / value pairs (joined by '=') separated by '&' or ';'. The key comparison
+   is case insensitive. ``NIL`` is returned if the key is not found.
+
 .. extractor:: ua-req-fragment
    :result: string
 
@@ -239,6 +247,14 @@ Pre-Remap
    :result: string
 
       The query string for the pre-remap user agent request URL.
+
+.. extractor:: pre-remap-query-value
+   :result: string
+   :arg: Query parameter key.
+
+   The value for a specific query parameter, identified by key. This assumes the standard format for
+   a query string, key / value pairs (joined by '=') separated by '&' or ';'. The key comparison
+   is case insensitive. ``NIL`` is returned if the key is not found.
 
 .. extractor:: pre-remap-fragment
    :result: string
@@ -365,6 +381,14 @@ Proxy Request
    :result: string
 
    The query string in the proxy request.
+
+.. extractor:: proxy-req-query-value
+   :result: string
+   :arg: Query parameter key.
+
+   The value for a specific query parameter, identified by key. This assumes the standard format for
+   a query string, key / value pairs (joined by '=') separated by '&' or ';'. The key comparison
+   is case insensitive. ``NIL`` is returned if the key is not found.
 
 .. extractor:: proxy-req-fragment
    :result: string

--- a/plugin/include/txn_box/Accelerator.h
+++ b/plugin/include/txn_box/Accelerator.h
@@ -19,8 +19,10 @@
 class Comparison;
 
 /// Base class for Accelerator implementations.
-class Accelerator {
+class Accelerator
+{
   using self_type = Accelerator;
+
 public:
   /// Number of defined Accelerators.
   static constexpr size_t N_ACCELERATORS = 1;
@@ -35,30 +37,33 @@ public:
   using Handle = std::unique_ptr<Accelerator>;
 
   /// Construct a specific type of Accelerator.
-  using Builder = std::function<swoc::Rv<Handle> ()>;
+  using Builder = std::function<swoc::Rv<Handle>()>;
+
 protected:
   static std::array<Builder, N_ACCELERATORS> _factory;
 };
 
 // --- //
 
-class StringAccelerator : public Accelerator {
-  using self_type = StringAccelerator;
+class StringAccelerator : public Accelerator
+{
+  using self_type  = StringAccelerator;
   using super_type = Accelerator;
 
-  using Errata = swoc::Errata;
+  using Errata   = swoc::Errata;
   using TextView = swoc::TextView;
+
 public:
   StringAccelerator() = default;
 
-  void match_exact(TextView text, Comparison* cmp);
-  void match_prefix(TextView text, Comparison* cmp);
-  void match_suffix(TextView text, Comparison* cmp);
+  void match_exact(TextView text, Comparison *cmp);
+  void match_prefix(TextView text, Comparison *cmp);
+  void match_suffix(TextView text, Comparison *cmp);
 
   /** Find @a text in @a this.
    *
    * @param text Text to match.
    * @return The best match @c Comparison for @a text.
    */
-  Comparison* operator()(TextView text) const;
+  Comparison *operator()(TextView text) const;
 };

--- a/plugin/include/txn_box/Comparison.h
+++ b/plugin/include/txn_box/Comparison.h
@@ -21,8 +21,10 @@
 /** Base class for comparisons.
  *
  */
-class Comparison {
+class Comparison
+{
   using self_type = Comparison;
+
 public:
   /// Handle type for local instances.
   using Handle = std::unique_ptr<self_type>;
@@ -35,7 +37,8 @@ public:
    * @param arg Argument, if any.
    * @param value_node The value node for the @a key.
    */
-  using Loader = std::function<swoc::Rv<Handle> (Config& cfg, YAML::Node const& cmp_node, swoc::TextView const& key, swoc::TextView const& arg, YAML::Node const& value_node)>;
+  using Loader = std::function<swoc::Rv<Handle>(Config &cfg, YAML::Node const &cmp_node, swoc::TextView const &key,
+                                                swoc::TextView const &arg, YAML::Node const &value_node)>;
 
   // Factory that maps from names to assemblers.
   using Factory = std::unordered_map<swoc::TextView, std::tuple<Loader, ActiveType>, std::hash<std::string_view>>;
@@ -56,18 +59,62 @@ public:
   /// Subclasses (specific comparisons) should override these as appropriate for its supported types.
   /// Context state updates are done through the @c Context argument.
   /// @{
-  virtual bool operator()(Context&, std::monostate) const { return false; }
-  virtual bool operator()(Context&, nil_value) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<STRING> const&) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<INTEGER>) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<BOOLEAN>) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<FLOAT>) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<IP_ADDR> const&) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<DURATION>) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<TIMEPOINT>) const { return false; }
-  virtual bool operator()(Context&, Cons const*) const { return false; }
-  virtual bool operator()(Context&, feature_type_for<TUPLE> const&) const { return false; }
-  virtual bool operator()(Context&, Generic const*) const;
+  virtual bool
+  operator()(Context &, std::monostate) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, nil_value) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<STRING> const &) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<INTEGER>) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<BOOLEAN>) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<FLOAT>) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<IP_ADDR> const &) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<DURATION>) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<TIMEPOINT>) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, Cons const *) const
+  {
+    return false;
+  }
+  virtual bool
+  operator()(Context &, feature_type_for<TUPLE> const &) const
+  {
+    return false;
+  }
+  virtual bool operator()(Context &, Generic const *) const;
   /// @}
 
   /** External comparison entry.
@@ -80,8 +127,10 @@ public:
    * comparison is limited to a few or a single feature type, it is better to overload the
    * type specific comparisons.
    */
-  virtual bool operator()(Context& ctx, Feature const& feature) const {
-    auto visitor = [&](auto && value) { return (*this)(ctx, value); };
+  virtual bool
+  operator()(Context &ctx, Feature const &feature) const
+  {
+    auto visitor = [&](auto &&value) { return (*this)(ctx, value); };
     return std::visit(visitor, feature);
   }
 
@@ -100,7 +149,7 @@ public:
    *
    * @see accelerate
    */
-  virtual void can_accelerate(Accelerator::Counters& counters) const;
+  virtual void can_accelerate(Accelerator::Counters &counters) const;
 
   /** String acceleration.
    *
@@ -114,7 +163,7 @@ public:
    *
    * @see can_accelerate
    */
-  virtual void accelerate(StringAccelerator* str_accel) const;
+  virtual void accelerate(StringAccelerator *str_accel) const;
 
   /** Define a comparison.
    *
@@ -123,7 +172,7 @@ public:
    * @param worker Assembler to construct instance from configuration node.
    * @return A handle to a constructed instance on success, errors on failure.
    */
-  static swoc::Errata define(swoc::TextView name, ActiveType const& types, Loader && worker);
+  static swoc::Errata define(swoc::TextView name, ActiveType const &types, Loader &&worker);
 
   /** Load a comparison from a YAML @a node.
    *
@@ -131,22 +180,25 @@ public:
    * @param node Node with comparison config.
    * @return A constructed instance or errors on failure.
    */
-  static swoc::Rv<Handle> load(Config & cfg, YAML::Node node);
+  static swoc::Rv<Handle> load(Config &cfg, YAML::Node node);
 
 protected:
   /// The assemblers.
   static Factory _factory;
 };
 
-class ComparisonGroupBase {
+class ComparisonGroupBase
+{
   using self_type = ComparisonGroupBase;
-  using Errata = swoc::Errata;
+  using Errata    = swoc::Errata;
+
 public:
   virtual ~ComparisonGroupBase() = default;
-  virtual Errata load(Config& cfg, YAML::Node node);
+  virtual Errata load(Config &cfg, YAML::Node node);
+
 protected:
-  virtual Errata load_case(Config& cfg, YAML::Node node) = 0;
-  swoc::Rv<Comparison::Handle> load_cmp(Config& cfg, YAML::Node node);
+  virtual Errata load_case(Config &cfg, YAML::Node node) = 0;
+  swoc::Rv<Comparison::Handle> load_cmp(Config &cfg, YAML::Node node);
 };
 
 /** Container for an ordered list of Comparisons.
@@ -157,17 +209,19 @@ protected:
  * therefore each @c Comparison will be stored in a wrapper class @a W which holds the
  * ancillary data.
  */
-template < typename W > class ComparisonGroup : protected ComparisonGroupBase {
-  using self_type = ComparisonGroup;
+template <typename W> class ComparisonGroup : protected ComparisonGroupBase
+{
+  using self_type  = ComparisonGroup;
   using super_type = ComparisonGroupBase;
 
   using container = std::vector<W>;
 
   using Errata = swoc::Errata;
+
 public:
   using value_type = W; ///< Export template parameter.
 
-  using iterator = typename container::iterator;
+  using iterator       = typename container::iterator;
   using const_iterator = typename container::const_iterator;
 
   ComparisonGroup() = default;
@@ -181,7 +235,7 @@ public:
    * @a node can be an object, in which case it is treated as a list of length 1 containing that
    * object. Otherwise @a node must be a list of objects.
    */
-  Errata load(Config& cfg, YAML::Node node) override;
+  Errata load(Config &cfg, YAML::Node node) override;
 
   /** Invoke the comparisons.
    *
@@ -189,14 +243,30 @@ public:
    * @param feature Active feature to compare.
    * @return The iterator for the successful comparison, or the end iterator if none succeeded.
    */
-  iterator operator()(Context& ctx, Feature const& feature);
+  iterator operator()(Context &ctx, Feature const &feature);
 
   /// @return The location of the first comparison.
-  iterator begin() { return _cmps. begin(); }
+  iterator
+  begin()
+  {
+    return _cmps.begin();
+  }
   /// @return Location past the last comparison.
-  iterator end() { return _cmps.end(); }
-  const_iterator begin() const { return _cmps.begin(); }
-  const_iterator end() const { return _cmps.end(); }
+  iterator
+  end()
+  {
+    return _cmps.end();
+  }
+  const_iterator
+  begin() const
+  {
+    return _cmps.begin();
+  }
+  const_iterator
+  end() const
+  {
+    return _cmps.end();
+  }
 
 protected:
   /// The comparisons.
@@ -208,17 +278,23 @@ protected:
    * @param node Value node containing the case.
    * @return Errors, if any.
    */
-  Errata load_case(Config& cfg, YAML::Node node) override;
+  Errata load_case(Config &cfg, YAML::Node node) override;
 };
 
-template < typename W > auto ComparisonGroup<W>::load(Config &cfg, YAML::Node node) -> Errata {
+template <typename W>
+auto
+ComparisonGroup<W>::load(Config &cfg, YAML::Node node) -> Errata
+{
   if (node.IsSequence()) {
     _cmps.reserve(node.size());
   }
   return this->super_type::load(cfg, node);
 }
 
-template < typename W > auto ComparisonGroup<W>::load_case(Config &cfg, YAML::Node node) -> Errata {
+template <typename W>
+auto
+ComparisonGroup<W>::load_case(Config &cfg, YAML::Node node) -> Errata
+{
   W w;
   if (auto errata = w.pre_load(cfg, node); !errata.is_ok()) {
     return errata;
@@ -238,9 +314,11 @@ template < typename W > auto ComparisonGroup<W>::load_case(Config &cfg, YAML::No
   return {};
 }
 
-template<typename W>
-auto ComparisonGroup<W>::operator()(Context& ctx, Feature const& feature) -> iterator {
-  for ( auto spot = _cmps.begin() , limit = _cmps.end() ; spot != limit ; ++spot ) {
+template <typename W>
+auto
+ComparisonGroup<W>::operator()(Context &ctx, Feature const &feature) -> iterator
+{
+  for (auto spot = _cmps.begin(), limit = _cmps.end(); spot != limit; ++spot) {
     if ((*spot)(ctx, feature)) {
       return spot;
     }

--- a/plugin/include/txn_box/Comparison.h
+++ b/plugin/include/txn_box/Comparison.h
@@ -57,6 +57,7 @@ public:
   /// Context state updates are done through the @c Context argument.
   /// @{
   virtual bool operator()(Context&, std::monostate) const { return false; }
+  virtual bool operator()(Context&, nil_value) const { return false; }
   virtual bool operator()(Context&, feature_type_for<STRING> const&) const { return false; }
   virtual bool operator()(Context&, feature_type_for<INTEGER>) const { return false; }
   virtual bool operator()(Context&, feature_type_for<BOOLEAN>) const { return false; }

--- a/plugin/include/txn_box/Config.h
+++ b/plugin/include/txn_box/Config.h
@@ -3,14 +3,14 @@
  *
  * Copyright 2019, Oath Inc.
  * SPDX-License-Identifier: Apache-2.0
-*/
+ */
 
 #pragma once
 
 #include <array>
 #include <vector>
 #if __has_include(<memory_resource>)
-#  include <memory_resource>
+#include <memory_resource>
 #endif
 
 #include <swoc/TextView.h>
@@ -26,82 +26,86 @@
 
 /// Contains a configuration and configuration helper methods.
 /// This is also used to pass information between node parsing during configuration loading.
-class Config {
+class Config
+{
   using self_type = Config; ///< Self reference type.
-  using Errata = swoc::Errata;
-public:
+  using Errata    = swoc::Errata;
 
+public:
   /// Full name of the plugin.
-  static constexpr swoc::TextView PLUGIN_NAME { "Transaction Tool Box" };
+  static constexpr swoc::TextView PLUGIN_NAME{"Transaction Tool Box"};
   /// Tag name of the plugin.
-  static constexpr swoc::TextView PLUGIN_TAG { "txn_box" };
+  static constexpr swoc::TextView PLUGIN_TAG{"txn_box"};
 
   static const std::string GLOBAL_ROOT_KEY; ///< Root key for global configuration.
-  static const std::string REMAP_ROOT_KEY; ///< Root key for remap configuration.
+  static const std::string REMAP_ROOT_KEY;  ///< Root key for remap configuration.
 
   /// Track the state of provided features.
   struct ActiveFeatureState {
-    ActiveType _type; ///< Type of active feature.
+    ActiveType _type;    ///< Type of active feature.
     bool _ref_p = false; ///< Feature has been referenced / used.
   };
 
-  class ActiveFeatureScope {
+  class ActiveFeatureScope
+  {
     using self_type = ActiveFeatureScope;
     friend class Config;
 
-    Config * _cfg = nullptr;
+    Config *_cfg = nullptr;
     ActiveFeatureState _state;
 
   public:
-    ActiveFeatureScope(Config& cfg) : _cfg(&cfg), _state(cfg._active_feature) {}
+    ActiveFeatureScope(Config &cfg) : _cfg(&cfg), _state(cfg._active_feature) {}
 
-    ActiveFeatureScope(self_type && that) : _cfg(that._cfg), _state(that._state) {
-      that._cfg = nullptr;
-    }
+    ActiveFeatureScope(self_type &&that) : _cfg(that._cfg), _state(that._state) { that._cfg = nullptr; }
 
     // No copying.
-    ActiveFeatureScope(self_type const& that) = delete;
-    self_type & operator = (self_type const& that) = delete;
+    ActiveFeatureScope(self_type const &that) = delete;
+    self_type &operator=(self_type const &that) = delete;
 
     ~ActiveFeatureScope();
   };
   friend ActiveFeatureScope;
-  ActiveFeatureScope feature_scope(ActiveType const& ex_type);
+  ActiveFeatureScope feature_scope(ActiveType const &ex_type);
 
   /// Track the state of the active capture groups.
   struct ActiveCaptureState {
-    unsigned _count = 0; ///< Number of active capture groups - 0 => not active.
-    int _line = -1; ///< Line of the active regular expression.
-    bool _ref_p = false; ///< Regular expression capture groups referenced / used.
+    unsigned _count = 0;     ///< Number of active capture groups - 0 => not active.
+    int _line       = -1;    ///< Line of the active regular expression.
+    bool _ref_p     = false; ///< Regular expression capture groups referenced / used.
   };
 
-  class ActiveCaptureScope {
+  class ActiveCaptureScope
+  {
     using self_type = ActiveCaptureScope;
     friend class Config;
 
-    Config * _cfg = nullptr;
+    Config *_cfg = nullptr;
     ActiveCaptureState _state;
 
   public:
-    ActiveCaptureScope(Config& cfg) : _cfg(&cfg), _state(cfg._active_capture) {}
+    ActiveCaptureScope(Config &cfg) : _cfg(&cfg), _state(cfg._active_capture) {}
 
-    ActiveCaptureScope(self_type && that);
+    ActiveCaptureScope(self_type &&that);
 
     // No copying.
-    ActiveCaptureScope(self_type const& that) = delete;
-    self_type & operator = (self_type const& that) = delete;
+    ActiveCaptureScope(self_type const &that) = delete;
+    self_type &operator=(self_type const &that) = delete;
 
-    ~ActiveCaptureScope() {
+    ~ActiveCaptureScope()
+    {
       if (_cfg) {
         _cfg->_active_capture = _state;
       }
     }
   };
   friend ActiveCaptureScope;
-  ActiveCaptureScope capture_scope(unsigned count, unsigned line_no) {
+  ActiveCaptureScope
+  capture_scope(unsigned count, unsigned line_no)
+  {
     ActiveCaptureScope scope(*this);
     _active_capture._count = count;
-    _active_capture._line = line_no;
+    _active_capture._line  = line_no;
     _active_capture._ref_p = false;
     return scope;
   }
@@ -129,8 +133,7 @@ public:
    * @param cache Cache of the results of YAML parsing the files.
    * @return Errors, if any.
    */
-  Errata load_cli_args(Handle handle, std::vector<std::string> const& args, int arg_idx = 0
-                       , YamlCache * cache = nullptr);
+  Errata load_cli_args(Handle handle, std::vector<std::string> const &args, int arg_idx = 0, YamlCache *cache = nullptr);
 
   /** Load the configuration from CLI arguments.
    *
@@ -140,8 +143,7 @@ public:
    * @param cache Cache of the results of YAML parsing the files.
    * @return Errors, if any.
    */
-  Errata load_cli_args(Handle handle, swoc::MemSpan<char const*> argv, int arg_idx = 0
-                       , YamlCache * cache = nullptr);
+  Errata load_cli_args(Handle handle, swoc::MemSpan<char const *> argv, int arg_idx = 0, YamlCache *cache = nullptr);
 
   /** Load file(s) in to @a this configuation.
    *
@@ -152,7 +154,7 @@ public:
    * All files matching the @a pattern are loaded in to this configuration, using @a CfgKey as
    * the root key.
    */
-  swoc::Errata load_file_glob(swoc::TextView pattern, swoc::TextView cfg_key, YamlCache* cache = nullptr);
+  swoc::Errata load_file_glob(swoc::TextView pattern, swoc::TextView cfg_key, YamlCache *cache = nullptr);
 
   /** Load a file into @a this.
    *
@@ -162,7 +164,7 @@ public:
    *
    * The content of @a cfg_path is loaded in to @a this configuration instance.
    */
-  swoc::Errata load_file(swoc::file::path const& cfg_path, swoc::TextView cfg_key, YamlCache * cache = nullptr);
+  swoc::Errata load_file(swoc::file::path const &cfg_path, swoc::TextView cfg_key, YamlCache *cache = nullptr);
 
   /** Parse YAML from @a node to initialize @a this configuration.
    *
@@ -179,7 +181,11 @@ public:
    */
   Errata parse_yaml(YAML::Node root, swoc::TextView path);
 
-  void mark_as_remap() { _hook = Hook::REMAP; }
+  void
+  mark_as_remap()
+  {
+    _hook = Hook::REMAP;
+  }
 
   /** Load directives at the top level.
    *
@@ -198,7 +204,7 @@ public:
    * @param drtv_node Directive node.
    * @return A new directive instance, or errors if loading failed.
    */
-  swoc::Rv<Directive::Handle> parse_directive(YAML::Node const& drtv_node);
+  swoc::Rv<Directive::Handle> parse_directive(YAML::Node const &drtv_node);
 
   /** Parse a feature expression.
    *
@@ -215,12 +221,16 @@ public:
 
 #if __has_include(<memory_resource>) && _GLIBCXX_USE_CXX11_ABI
   /// Access the internal memory arena as a memory resource.
-  std::pmr::memory_resource * pmr() { return &_arena; }
+  std::pmr::memory_resource *
+  pmr()
+  {
+    return &_arena;
+  }
 #endif
 
   enum LocalOpt {
     LOCAL_VIEW, ///< Localize as view.
-    LOCAL_CSTR ///< Localize as C string.
+    LOCAL_CSTR  ///< Localize as C string.
   };
 
   /** Copy @a text to local storage in this instance.
@@ -231,12 +241,22 @@ public:
    * Strings in the YAML configuration are transient. If the content needs to be available at
    * run time it must be first localized.
    */
-  std::string_view& localize(std::string_view & text, LocalOpt opt = LOCAL_VIEW);
-  swoc::TextView localize(std::string_view const& text, LocalOpt opt = LOCAL_VIEW) { swoc::TextView tv { text }; return this->localize(tv, opt); }
+  std::string_view &localize(std::string_view &text, LocalOpt opt = LOCAL_VIEW);
+  swoc::TextView
+  localize(std::string_view const &text, LocalOpt opt = LOCAL_VIEW)
+  {
+    swoc::TextView tv{text};
+    return this->localize(tv, opt);
+  }
 
-  self_type& localize(Feature & feature);
+  self_type &localize(Feature &feature);
 
-  template < typename T > auto localize(T &) -> EnableForFeatureTypes<T, self_type&> { return *this; }
+  template <typename T>
+  auto
+  localize(T &) -> EnableForFeatureTypes<T, self_type &>
+  {
+    return *this;
+  }
 
   /** Allocate config space for an array of @a T.
    *
@@ -249,7 +269,10 @@ public:
    *
    * @see mark_for_cleanup
    */
-  template < typename T > swoc::MemSpan<T> alloc_span(unsigned count) {
+  template <typename T>
+  swoc::MemSpan<T>
+  alloc_span(unsigned count)
+  {
     return _arena.alloc(sizeof(T) * count).rebind<T>();
   }
 
@@ -260,7 +283,11 @@ public:
   Hook current_hook() const;
 
   /// @return The type of the active feature.
-  ActiveType active_type() const { return _active_feature._type; }
+  ActiveType
+  active_type() const
+  {
+    return _active_feature._type;
+  }
 
   /** Require regular expression capture vectors to support at least @a n groups.
    *
@@ -274,7 +301,12 @@ public:
    * @param hook Runtime dispatch hook.
    * @return @a this
    */
-  self_type &reserve_slot(Hook hook) { ++_directive_count[IndexFor(hook)]; return *this; }
+  self_type &
+  reserve_slot(Hook hook)
+  {
+    ++_directive_count[IndexFor(hook)];
+    return *this;
+  }
 
   /// Check for top level directives.
   /// @return @a true if there are any top level directives, @c false if not.
@@ -285,7 +317,7 @@ public:
    * @param hook The hook identifier.
    * @return A reference to the vector of top level directives for @a hook.
    */
-  std::vector<Directive::Handle> const& hook_directives(Hook hook) const;
+  std::vector<Directive::Handle> const &hook_directives(Hook hook) const;
 
   /** Mark @a ptr for cleanup when @a this is destroyed.
    *
@@ -295,7 +327,7 @@ public:
    *
    * @a ptr is cleaned up by calling @c std::destroy_at.
    */
-  template <typename T> self_type & mark_for_cleanup(T* ptr);
+  template <typename T> self_type &mark_for_cleanup(T *ptr);
 
   /** Define a directive.
    *
@@ -306,11 +338,9 @@ public:
    * @param cfg_init_cb Config time initialization if needed.
    * @return Errors, if any.
    */
-  static swoc::Errata define(swoc::TextView name
-                             , HookMask const& hooks
-                             , Directive::Options const& options
-                             , Directive::InstanceLoader && worker
-                             , Directive::CfgInitializer && cfg_init_cb = [](Config&, Directive::CfgStaticData const*) -> swoc::Errata { return {}; });
+  static swoc::Errata define(
+    swoc::TextView name, HookMask const &hooks, Directive::Options const &options, Directive::InstanceLoader &&worker,
+    Directive::CfgInitializer &&cfg_init_cb = [](Config &, Directive::CfgStaticData const *) -> swoc::Errata { return {}; });
 
   /** Define a directive.
    *
@@ -320,7 +350,10 @@ public:
    * This is used when the directive class layout is completely standard. The template picks out those
    * pieces and passes them to the argument based @c define.
    */
-  template < typename D > static swoc::Errata define() {
+  template <typename D>
+  static swoc::Errata
+  define()
+  {
     return self_type::define(D::KEY, D::HOOKS, D::OPTIONS, &D::load, &D::cfg_init);
   }
 
@@ -333,7 +366,10 @@ public:
    * This is used when a directive needs to be available under an alternative name. All of the arguments
    * are pulled from standard class members except the key (directive name).
    */
-  template < typename D > static swoc::Errata define(swoc::TextView name) {
+  template <typename D>
+  static swoc::Errata
+  define(swoc::TextView name)
+  {
     return self_type::define(name, D::HOOKS, D::OPTIONS, &D::load, &D::cfg_init);
   }
 
@@ -370,33 +406,43 @@ public:
    * @note The directive itself should use its embedded pointer. This is required by other elements
    * that need access to shared configuration state for the directive.
    */
-  Directive::CfgStaticData const * drtv_info(swoc::TextView const& name) const;
+  Directive::CfgStaticData const *drtv_info(swoc::TextView const &name) const;
 
   /// @return Number of files loaded for this configuration.
-  size_t file_count() const { return _cfg_file_count; }
+  size_t
+  file_count() const
+  {
+    return _cfg_file_count;
+  }
 
   /// @return The total amount of context storage reserved.
-  size_t reserved_ctx_storage_size() const { return _ctx_storage_required; }
+  size_t
+  reserved_ctx_storage_size() const
+  {
+    return _ctx_storage_required;
+  }
 
-  template < typename T > T* active_value(swoc::TextView const & name) {
-    return static_cast<T*>(_active_values[name]);
+  template <typename T>
+  T *
+  active_value(swoc::TextView const &name)
+  {
+    return static_cast<T *>(_active_values[name]);
   }
 
   struct active_value_save {
-    void *& _value;
-    void * _saved;
+    void *&_value;
+    void *_saved;
 
-    active_value_save(void*& var, void* value) : _value(var), _saved(_value) {
-      _value = value;
-    }
-    ~active_value_save() {
-      _value = _saved;
-    }
+    active_value_save(void *&var, void *value) : _value(var), _saved(_value) { _value = value; }
+    ~active_value_save() { _value = _saved; }
   };
 
-  active_value_save active_value_let(swoc::TextView const & name, void * value) {
+  active_value_save
+  active_value_let(swoc::TextView const &name, void *value)
+  {
     return active_value_save(_active_values[name], value);
   }
+
 protected:
   /// As the top level directive, this needs special access.
   friend class When;
@@ -407,7 +453,7 @@ protected:
   Hook _hook = Hook::INVALID;
 
   /// Mark whether there are any top level directives.
-  bool _has_top_level_directive_p { false };
+  bool _has_top_level_directive_p{false};
 
   /// Maximum number of capture groups for regular expression matching.
   /// Always at least one because literal matches use that.
@@ -456,7 +502,7 @@ protected:
 
   /// Largest number of directives across the hooks. These are updated during
   /// directive load, if needed. This includes the top level directives.
-  std::array<size_t, std::tuple_size<Hook>::value> _directive_count { 0 };
+  std::array<size_t, std::tuple_size<Hook>::value> _directive_count{0};
 
   /// For localizing data at a configuration level, primarily strings.
   swoc::MemArena _arena;
@@ -464,7 +510,7 @@ protected:
   /// Additional clean up to perform when @a this is destroyed.
   swoc::IntrusiveDList<Finalizer::Linkage> _finalizers;
 
-  swoc::Rv<Directive::Handle> load_directive(YAML::Node const& drtv_node);
+  swoc::Rv<Directive::Handle> load_directive(YAML::Node const &drtv_node);
 
   /** Parse a scalar feature expression.
    *
@@ -476,7 +522,7 @@ protected:
    */
   swoc::Rv<Expr> parse_scalar_expr(YAML::Node node);
 
-  swoc::Rv<Expr> parse_composite_expr(swoc::TextView const& text);
+  swoc::Rv<Expr> parse_composite_expr(swoc::TextView const &text);
 
   /** Parse an unquoted feature expression.
    *
@@ -484,7 +530,7 @@ protected:
    * @return The expression, or errors on failure.
    *
    */
-  swoc::Rv<Expr> parse_unquoted_expr(swoc::TextView const& text);
+  swoc::Rv<Expr> parse_unquoted_expr(swoc::TextView const &text);
 
   swoc::Rv<Expr> parse_expr_with_mods(YAML::Node node);
 
@@ -502,7 +548,8 @@ protected:
   swoc::Rv<ActiveType> validate(Extractor::Spec &spec);
 
   /// Tracking for configuration files loaded in to @a this.
-  class FileInfo {
+  class FileInfo
+  {
     using self_type = FileInfo; ///< Self reference type.
   public:
     /** Check if a specific @a key has be used as a root for this file.
@@ -531,32 +578,53 @@ protected:
   size_t _cfg_file_count = 0;
 };
 
-inline bool Config::FileInfo::has_cfg_key(swoc::TextView key) const {
-  return _keys.end() != std::find_if(_keys.begin(), _keys.end(), [=] (std::string const& k) { return 0 == strcasecmp(k, key);});
+inline bool
+Config::FileInfo::has_cfg_key(swoc::TextView key) const
+{
+  return _keys.end() != std::find_if(_keys.begin(), _keys.end(), [=](std::string const &k) { return 0 == strcasecmp(k, key); });
 }
 
-inline void Config::FileInfo::add_cfg_key(swoc::TextView key) {
+inline void
+Config::FileInfo::add_cfg_key(swoc::TextView key)
+{
   _keys.emplace_back(key);
 }
 
-inline Config::ActiveCaptureScope::ActiveCaptureScope(Config::ActiveCaptureScope::self_type&& that) : _cfg(that._cfg), _state(that._state) {
+inline Config::ActiveCaptureScope::ActiveCaptureScope(Config::ActiveCaptureScope::self_type &&that)
+  : _cfg(that._cfg), _state(that._state)
+{
   that._cfg = nullptr;
 }
 
-inline Hook Config::current_hook() const { return _hook; }
-inline bool Config::has_top_level_directive() const { return _has_top_level_directive_p; }
+inline Hook
+Config::current_hook() const
+{
+  return _hook;
+}
+inline bool
+Config::has_top_level_directive() const
+{
+  return _has_top_level_directive_p;
+}
 
-inline std::vector<Directive::Handle> const &Config::hook_directives(Hook hook) const {
+inline std::vector<Directive::Handle> const &
+Config::hook_directives(Hook hook) const
+{
   return _roots[static_cast<unsigned>(hook)];
 }
 
-inline Config& Config::require_rxp_group_count(unsigned n) {
+inline Config &
+Config::require_rxp_group_count(unsigned n)
+{
   _capture_groups = std::max(_capture_groups, n);
   return *this;
 }
 
-template < typename T > auto Config::mark_for_cleanup(T *ptr) -> self_type & {
-  auto f = _arena.make<Finalizer>(ptr, [](void* ptr) { std::destroy_at(static_cast<T*>(ptr)); });
+template <typename T>
+auto
+Config::mark_for_cleanup(T *ptr) -> self_type &
+{
+  auto f = _arena.make<Finalizer>(ptr, [](void *ptr) { std::destroy_at(static_cast<T *>(ptr)); });
   _finalizers.append(f);
   return *this;
 }

--- a/plugin/include/txn_box/Directive.h
+++ b/plugin/include/txn_box/Directive.h
@@ -23,7 +23,8 @@
 class Context;
 
 /// Base class for directives.
-class Directive {
+class Directive
+{
   using self_type = Directive; ///< Self reference type.
   friend Config;
   friend Context;
@@ -44,7 +45,9 @@ public:
    * @param key_node Child of @a drtv_node that contains the key used to match the functor.
    * @return A new instance of the appropriate directive, or errors on failure.
    */
-  using InstanceLoader = std::function<swoc::Rv<Directive::Handle> (Config& cfg, CfgStaticData const * rtti, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value)>;
+  using InstanceLoader =
+    std::function<swoc::Rv<Directive::Handle>(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node,
+                                              swoc::TextView const &name, swoc::TextView const &arg, YAML::Node key_value)>;
 
   /** Functor to do config level initialization.
    *
@@ -56,16 +59,16 @@ public:
    * in the configuration. The most common use is if the directive needs space in a @c Context -
    * that space must be reserved during the invocation of this functor.
    */
-  using CfgInitializer = std::function<swoc::Errata (Config& cfg, CfgStaticData const* rtti)>;
+  using CfgInitializer = std::function<swoc::Errata(Config &cfg, CfgStaticData const *rtti)>;
 
   /** Information about a directive type.
    * This is stored in the directive factory.
    */
   struct FactoryInfo {
-    unsigned _idx; ///< Index for doing config time type info lookup.
-    HookMask _hook_mask; ///< Valid hooks for this directive.
-    size_t _cfg_reserve; ///< Reserved storage in configuration.
-    Directive::InstanceLoader _load_cb; ///< Functor to load the directive from YAML data.
+    unsigned _idx;                          ///< Index for doing config time type info lookup.
+    HookMask _hook_mask;                    ///< Valid hooks for this directive.
+    size_t _cfg_reserve;                    ///< Reserved storage in configuration.
+    Directive::InstanceLoader _load_cb;     ///< Functor to load the directive from YAML data.
     Directive::CfgInitializer _cfg_init_cb; ///< Configuration init callback.
   };
 
@@ -74,8 +77,8 @@ public:
    * provide the equivalent of run time type information. Instances are stored in the @c Config.
    */
   struct CfgStaticData {
-    FactoryInfo const * _static; ///< Related static information.
-    unsigned _count = 0; ///< Number of instances.
+    FactoryInfo const *_static;     ///< Related static information.
+    unsigned _count = 0;            ///< Number of instances.
     swoc::MemSpan<void> _cfg_store; ///< Shared config storage.
   };
 
@@ -85,7 +88,7 @@ public:
     // In turn, that means a default constructor which disables aggregate construction. Sigh.
     constexpr Options() : _cfg_store_required(0) {}
     constexpr Options(size_t storage) : _cfg_store_required(storage) {}
-    size_t _cfg_store_required ; ///< Reserved per configuration storage.
+    size_t _cfg_store_required; ///< Reserved per configuration storage.
   };
 
   /// Provide a default so the templated method works as expected.
@@ -109,22 +112,27 @@ public:
    *
    * This exists so the templated @c Config::define works as expected, and does nothing.
    */
-  static swoc::Errata cfg_init(Config&, CfgStaticData const*) { return {}; }
+  static swoc::Errata
+  cfg_init(Config &, CfgStaticData const *)
+  {
+    return {};
+  }
 
 protected:
-  CfgStaticData const* _rtti = nullptr; ///< Run time (per Config) information.
+  CfgStaticData const *_rtti = nullptr; ///< Run time (per Config) information.
 };
 
 /** An ordered list of directives.
  *
  * This has no action of its own, it contains a list of other directives which are performed.
  */
-class DirectiveList : public Directive {
-  using self_type = DirectiveList; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class DirectiveList : public Directive
+{
+  using self_type  = DirectiveList; ///< Self reference type.
+  using super_type = Directive;     ///< Parent type.
 
 public:
-  self_type & push_back(Handle && d);
+  self_type &push_back(Handle &&d);
 
   /** Invoke the directive.
    *
@@ -141,9 +149,11 @@ protected:
 
 /// @c when directive - control which hook on which the configuration is handled.
 // @c when is special and needs to be globally visible.
-class When : public Directive {
+class When : public Directive
+{
   using super_type = Directive;
-  using self_type = When;
+  using self_type  = When;
+
 public:
   static const std::string KEY;
   static const HookMask HOOKS; ///< Valid hooks for directive.
@@ -162,11 +172,11 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static swoc::Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static swoc::Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                               swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
-  Hook _hook { Hook::INVALID };
+  Hook _hook{Hook::INVALID};
   Handle _directive; /// Directive to invoke in the specified hook.
 
   /** Construct from hook and a directive.
@@ -174,7 +184,7 @@ protected:
    * @param hook_idx The hook on which @a directive is invoked.
    * @param directive Directive to invoke.
    */
-  When(Hook hook_idx, Directive::Handle && directive);
+  When(Hook hook_idx, Directive::Handle &&directive);
 
   // Because @c When is handle in a special manner for configurations, it must be able to reach in.
   friend Config;
@@ -186,9 +196,10 @@ protected:
  * it is used when the directive is omitted (e.g. an empty @c do key).
  */
 
-class NilDirective : public Directive {
-  using self_type = NilDirective; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class NilDirective : public Directive
+{
+  using self_type  = NilDirective; ///< Self reference type.
+  using super_type = Directive;    ///< Parent type.
 
 public:
   /** Invoke the directive.
@@ -198,19 +209,22 @@ public:
    *
    * All information needed for the invocation of the directive is accessible from the @a ctx.
    */
-  swoc::Errata invoke(Context &ctx) override;;
+  swoc::Errata invoke(Context &ctx) override;
+  ;
+
 protected:
 };
 
-class LambdaDirective : public Directive {
-  using self_type = LambdaDirective; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class LambdaDirective : public Directive
+{
+  using self_type  = LambdaDirective; ///< Self reference type.
+  using super_type = Directive;       ///< Parent type.
 
 public:
-  using Lambda = std::function<swoc::Errata (Context&)>;
+  using Lambda = std::function<swoc::Errata(Context &)>;
   /// Construct with function @a f.
   /// When the directive is invoked, it in turn invokes @a f.
-  LambdaDirective(Lambda && f);
+  LambdaDirective(Lambda &&f);
 
   /** Invoke the directive.
    *
@@ -220,14 +234,22 @@ public:
    * All information needed for the invocation of the directive is accessible from the @a ctx.
    */
   swoc::Errata invoke(Context &ctx) override;
+
 protected:
   /// Function to invoke.
   Lambda _f;
 };
 
-inline Hook When::get_hook() const { return _hook; }
+inline Hook
+When::get_hook() const
+{
+  return _hook;
+}
 
-inline swoc::Errata LambdaDirective::invoke(Context &ctx) { return _f(ctx); }
+inline swoc::Errata
+LambdaDirective::invoke(Context &ctx)
+{
+  return _f(ctx);
+}
 
 inline LambdaDirective::LambdaDirective(std::function<swoc::Errata(Context &)> &&f) : _f(std::move(f)) {}
-

--- a/plugin/include/txn_box/Extractor.h
+++ b/plugin/include/txn_box/Extractor.h
@@ -43,7 +43,17 @@ public:
     /// Extractor used in the spec, if any.
     Extractor * _exf = nullptr;
     /// Config storage for extractor, if needed.
-    swoc::MemSpan<void> _data;
+    /// No member should be larger than a string view or span nor have any state.
+    /// Extractors are required to know what type was stored and retrieve it without addtional
+    /// type information.
+    union union_type {
+      uintmax_t u;
+      swoc::MemSpan<void> span;
+      swoc::TextView text;
+
+      union_type() { span = decltype(span){}; } // provide copy constructor for Spec constructors.
+      union_type(union_type const& that) { span = that.span; } // provide copy constructor for Spec constructors.
+    } _data;
   };
 
   virtual ~Extractor() = default;

--- a/plugin/include/txn_box/Extractor.h
+++ b/plugin/include/txn_box/Extractor.h
@@ -29,7 +29,8 @@ class FeatureGroup;
  * which maps from names to instances of subclasses. In use, the extractor will be passed a
  * run time context which is expected to suffice to extract the appropriate information.
  */
-class Extractor {
+class Extractor
+{
   using self_type = Extractor; ///< Self reference type.
 public:
   /// Container for extractor factory.
@@ -41,7 +42,7 @@ public:
    */
   struct Spec : public swoc::bwf::Spec {
     /// Extractor used in the spec, if any.
-    Extractor * _exf = nullptr;
+    Extractor *_exf = nullptr;
     /// Config storage for extractor, if needed.
     /// No member should be larger than a string view or span nor have any state.
     /// Extractors are required to know what type was stored and retrieve it without addtional
@@ -51,8 +52,8 @@ public:
       swoc::MemSpan<void> span;
       swoc::TextView text;
 
-      union_type() { span = decltype(span){}; } // provide copy constructor for Spec constructors.
-      union_type(union_type const& that) { span = that.span; } // provide copy constructor for Spec constructors.
+      union_type() { span = decltype(span){}; }                // provide copy constructor for Spec constructors.
+      union_type(union_type const &that) { span = that.span; } // provide copy constructor for Spec constructors.
     } _data;
   };
 
@@ -68,7 +69,7 @@ public:
    * The base implementation returns successfully as a @c STRING or @c NULL. If the extractor
    * returns some other type or needs to actually validate @a spec, it must override this method.
    */
-  virtual swoc::Rv<ActiveType> validate(Config & cfg, Spec & spec, swoc::TextView const& arg);
+  virtual swoc::Rv<ActiveType> validate(Config &cfg, Spec &spec, swoc::TextView const &arg);
 
   /** Whether the extractor uses data from the context.
    *
@@ -88,7 +89,7 @@ public:
    * @param spec Specifier for the extractor.
    * @return The extracted feature.
    */
-  virtual Feature extract(Context & ctx, Spec const& spec) = 0;
+  virtual Feature extract(Context &ctx, Spec const &spec) = 0;
 
   /** Extract from the configuration.
    *
@@ -103,7 +104,7 @@ public:
    * @see validate
    * @see extract(Context & ctx, Spec const& spec)
    */
-  virtual Feature extract(Config & cfg, Spec const& spec);
+  virtual Feature extract(Config &cfg, Spec const &spec);
 
   /** Generate string output for the feature.
    *
@@ -115,7 +116,7 @@ public:
    * This is the generic entry point for generating string output for a feature, which is required
    * for all extractors. The base implementation calls @c extract and pass that to @c bwformat.
    */
-  virtual swoc::BufferWriter & format(swoc::BufferWriter& w, Spec const& spec, Context & ctx);
+  virtual swoc::BufferWriter &format(swoc::BufferWriter &w, Spec const &spec, Context &ctx);
 
   /** Define @a name as the extractor @a ex.
    *
@@ -125,39 +126,41 @@ public:
    *
    * This populates the set of names used in the configuration file to specify extractors.
    */
-  static swoc::Errata define(swoc::TextView name, self_type * ex);
+  static swoc::Errata define(swoc::TextView name, self_type *ex);
 
   /** Find the extractor for @a name.
    *
    * @param name Extractor name.
    * @return A pointer to the extractor, @c nullptr if not found.
    */
-  static self_type* find(swoc::TextView const& name);
+  static self_type *find(swoc::TextView const &name);
 
 protected:
   /** Defined extractors.
    */
-  static Table _ex_table;  /// Obtain the named extractor table.
+  static Table _ex_table; /// Obtain the named extractor table.
 };
 
 /** Cross reference extractor.
  * This requires special handling and therefore needs to be externally visible.
  */
-class Ex_this : public Extractor {
+class Ex_this : public Extractor
+{
 public:
-  static constexpr swoc::TextView NAME { "this" }; ///< Extractor name.
+  static constexpr swoc::TextView NAME{"this"}; ///< Extractor name.
 
   Ex_this() = default;
-  explicit Ex_this(FeatureGroup& fg) : _fg(&fg) {}
+  explicit Ex_this(FeatureGroup &fg) : _fg(&fg) {}
 
-  swoc::Rv<ActiveType> validate(Config & cfg, Spec & spec, swoc::TextView const& arg) override;
+  swoc::Rv<ActiveType> validate(Config &cfg, Spec &spec, swoc::TextView const &arg) override;
 
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 
   /// Required text formatting access.
-  swoc::BufferWriter& format(swoc::BufferWriter& w, Spec const& spec, Context & ctx) override;
+  swoc::BufferWriter &format(swoc::BufferWriter &w, Spec const &spec, Context &ctx) override;
+
 protected:
-  FeatureGroup* _fg = nullptr; ///< FeatureGroup for name lookup.
+  FeatureGroup *_fg = nullptr; ///< FeatureGroup for name lookup.
 };
 
 extern Ex_this ex_this;
@@ -166,8 +169,8 @@ extern Ex_this ex_this;
  * The feature is extracted to transient memory. The subclass needs to provide only the @c format
  * method, this @c extract will use that to return a string.
  */
-class StringExtractor : public Extractor {
+class StringExtractor : public Extractor
+{
 public:
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
-

--- a/plugin/include/txn_box/FeatureGroup.h
+++ b/plugin/include/txn_box/FeatureGroup.h
@@ -14,7 +14,8 @@
 /** Handle a group of features that can cross reference.
  * Support a map or list of features as a group.
  */
-class FeatureGroup {
+class FeatureGroup
+{
   using self_type = FeatureGroup; ///< Self reference type.
 public:
   /// Index type for the various indices.
@@ -24,35 +25,36 @@ public:
 
   /// Initialization flags.
   enum Flag : int8_t {
-    NONE = -1, ///< No flags
-    REQUIRED = 0, ///< Key must exist and have a valid expression.
+    NONE     = -1, ///< No flags
+    REQUIRED = 0,  ///< Key must exist and have a valid expression.
   };
 
   /// Description of a key with a feature to extract.
   struct Descriptor {
     using self_type = Descriptor; ///< Self reference type.
-    swoc::TextView _name; ///< Key name
-    std::bitset<2> _flags; ///< Flags.
+    swoc::TextView _name;         ///< Key name
+    std::bitset<2> _flags;        ///< Flags.
 
     // Convenience constructors.
     /// Construct with only a name, no flags.
-    Descriptor(swoc::TextView const& name);
+    Descriptor(swoc::TextView const &name);
     /// Construct with a name and a single flag.
-    Descriptor(swoc::TextView const& name, Flag flag);;
+    Descriptor(swoc::TextView const &name, Flag flag);
+    ;
     /// Construct with a name and a list of flags.
-    Descriptor(swoc::TextView const& name, std::initializer_list<Flag> const& flags);
+    Descriptor(swoc::TextView const &name, std::initializer_list<Flag> const &flags);
   };
 
   /// Information about an expression.
   /// This is per configuration data.
   struct ExprInfo {
-    Expr _expr; ///< The feature expression.
+    Expr _expr;           ///< The feature expression.
     swoc::TextView _name; ///< Key name.
     /// Extracted feature index. For each referenced key, a slot is allocated for caching the
     /// extracted feature. @c INVALID_IDX indicates the feature isn't a dependency target
     /// and is therefore not cached.
     index_type _exf_idx = INVALID_IDX;
-    bool _dependent_p = false; ///< Is expression dependent on another key in the group?
+    bool _dependent_p   = false; ///< Is expression dependent on another key in the group?
   };
 
   /** Store invocation state for extracting features.
@@ -85,7 +87,7 @@ public:
    * not even clear what that would mean in practice - is the entire multi-value extracted? Obscure
    * enough I'll leave that for when a use case becomes known.
    */
-  swoc::Errata load(Config& cfg, YAML::Node const& node, std::initializer_list<Descriptor> const& ex_keys);
+  swoc::Errata load(Config &cfg, YAML::Node const &node, std::initializer_list<Descriptor> const &ex_keys);
 
   /** Load the expressions from @a node
    *
@@ -98,7 +100,7 @@ public:
    * The formats are extracted in order. If any format is @c REQUIRED then all preceding ones are
    * also required, even if not marked as such.
    */
-  swoc::Errata load_as_tuple(Config& cfg, YAML::Node const& node, std::initializer_list<Descriptor> const& ex_keys);
+  swoc::Errata load_as_tuple(Config &cfg, YAML::Node const &node, std::initializer_list<Descriptor> const &ex_keys);
 
   /** Load the expression from a scalar @a value.
    *
@@ -107,21 +109,21 @@ public:
    * @param name Name of the key to load.
    * @return Errors, if any.
    */
-  swoc::Errata load_as_scalar(Config& cfg, YAML::Node const& value, swoc::TextView const& name);
+  swoc::Errata load_as_scalar(Config &cfg, YAML::Node const &value, swoc::TextView const &name);
 
   /** Get the index of extraction information for @a name.
    *
    * @param name Name of the key.
    * @return The index for the extraction info for @a name or @c INVALID_IDX if not found.
    */
-  index_type index_of(swoc::TextView const& name);
+  index_type index_of(swoc::TextView const &name);
 
   /** Get the extraction information for @a idx.
    *
    * @param idx Key index.
    * @return The extraction information.
    */
-  ExprInfo & operator [] (index_type idx);
+  ExprInfo &operator[](index_type idx);
 
   /** Extract the feature.
    *
@@ -130,7 +132,7 @@ public:
    * @param name Name of the feature key.
    * @return The extracted data.
    */
-  Feature extract(Context& ctx, swoc::TextView const& name);
+  Feature extract(Context &ctx, swoc::TextView const &name);
 
   /** Extract the feature.
    *
@@ -139,10 +141,10 @@ public:
    * @param idx Index of the feature key.
    * @return The extracted data.
    */
-  Feature extract(Context& ctx, index_type idx);
+  Feature extract(Context &ctx, index_type idx);
 
 protected:
-  static constexpr uint8_t DONE = 1; ///< All dependencies computed.
+  static constexpr uint8_t DONE    = 1; ///< All dependencies computed.
   static constexpr uint8_t IN_PLAY = 2; ///< Dependencies currently being computed.
 
   /** Wrapper for tracking array.
@@ -164,7 +166,6 @@ protected:
    * @internal Move @c Config in here as well?
    */
   struct Tracking {
-
     /// Per tracked item information.
     struct Info : public ExprInfo {
       int8_t _mark = NONE; ///< Ordering search march.
@@ -183,7 +184,7 @@ protected:
     /// The number of valid elements in the @a _info array.
     index_type _count = 0;
 
-    YAML::Node const& _node; ///< Node containing the keys.
+    YAML::Node const &_node; ///< Node containing the keys.
 
     /** Construct a wrapper on a tracking array.
      *
@@ -191,24 +192,28 @@ protected:
      * @param info Array.
      * @param n # of elements in @a info.
      */
-    Tracking(YAML::Node const& node, Info * info, unsigned n) : _info(info, n), _node(node)  {}
+    Tracking(YAML::Node const &node, Info *info, unsigned n) : _info(info, n), _node(node) {}
 
     /// Allocate an entry and return a pointer to it.
-    Info * alloc() { return &_info[_count++]; }
+    Info *
+    alloc()
+    {
+      return &_info[_count++];
+    }
 
     /// Find the array element with @a name.
     /// @return A pointer to the element, or @c nullptr if not found.
-    Info * find(swoc::TextView const& name) const;
+    Info *find(swoc::TextView const &name) const;
 
     /// Obtain an array element for @a name.
     /// @return A pointer to the element.
     /// If @a name is not in the array, an element is allocated and set to @a name.
-    Info * obtain(swoc::TextView const& name);
+    Info *obtain(swoc::TextView const &name);
   };
 
   index_type _ref_count = 0; ///< Number of edge targets.
 
-  swoc::MemSpan<ExprInfo> _expr_info; ///< Info for the key expression by key.
+  swoc::MemSpan<ExprInfo> _expr_info;  ///< Info for the key expression by key.
   swoc::MemSpan<index_type> _ordering; ///< Extraction ordering for dependency targets.
 
   /// Context storage to store a @c State instance across feature extraction.
@@ -225,7 +230,7 @@ protected:
    * @param node Node that has the expression as a value.
    * @return Errors, if any.
    */
-  swoc::Errata load_expr(Config & cfg, Tracking & tracking, Tracking::Info * info, YAML::Node const& node);
+  swoc::Errata load_expr(Config &cfg, Tracking &tracking, Tracking::Info *info, YAML::Node const &node);
 
   /** Load the format at key @a name from the tracking node.
    *
@@ -237,20 +242,31 @@ protected:
    * The base node is contained in @a tracking. The key for @a name is selected and the
    * format there loaded.
    */
-  swoc::Rv<Tracking::Info*> load_key(Config & cfg, Tracking& tracking, swoc::TextView name);
-
+  swoc::Rv<Tracking::Info *> load_key(Config &cfg, Tracking &tracking, swoc::TextView name);
 };
 
 inline FeatureGroup::Descriptor::Descriptor(swoc::TextView const &name) : _name(name) {}
 
-inline FeatureGroup::Descriptor::Descriptor(swoc::TextView const &name, FeatureGroup::Flag flag) : _name(name) { if (flag != NONE) { _flags[flag] = true ; } }
-
-inline FeatureGroup::Descriptor::Descriptor(swoc::TextView const &name
-                                     , std::initializer_list<FeatureGroup::Flag> const &flags) : _name(name) {
-  for ( auto f : flags ) {
-    if (f != NONE) { _flags[f] = true; }
+inline FeatureGroup::Descriptor::Descriptor(swoc::TextView const &name, FeatureGroup::Flag flag) : _name(name)
+{
+  if (flag != NONE) {
+    _flags[flag] = true;
   }
 }
 
-inline FeatureGroup::ExprInfo &FeatureGroup::operator[](FeatureGroup::index_type idx) { return _expr_info[idx]; }
+inline FeatureGroup::Descriptor::Descriptor(swoc::TextView const &name, std::initializer_list<FeatureGroup::Flag> const &flags)
+  : _name(name)
+{
+  for (auto f : flags) {
+    if (f != NONE) {
+      _flags[f] = true;
+    }
+  }
+}
+
+inline FeatureGroup::ExprInfo &
+FeatureGroup::operator[](FeatureGroup::index_type idx)
+{
+  return _expr_info[idx];
+}
 /* ---------------------------------------------------------------------------------------------- */

--- a/plugin/include/txn_box/Modifier.h
+++ b/plugin/include/txn_box/Modifier.h
@@ -19,7 +19,8 @@
 /** Feature modification / transformation.
  *
  */
-class Modifier {
+class Modifier
+{
   using self_type = Modifier; ///< Self reference type.
 
 public:
@@ -34,7 +35,8 @@ public:
    * @param key_value The YAML node in @a mod_node that identified the modifier.
    * @return A handle for the new instance, or errors if any.
    */
-  using Worker = std::function<swoc::Rv<Handle> (Config& cfg, YAML::Node mod_node, swoc::TextView key, swoc::TextView arg, YAML::Node key_value)>;
+  using Worker =
+    std::function<swoc::Rv<Handle>(Config &cfg, YAML::Node mod_node, swoc::TextView key, swoc::TextView arg, YAML::Node key_value)>;
 
   virtual ~Modifier() = default;
 
@@ -44,8 +46,10 @@ public:
    * @param feature Feature to modify.
    * @return Modified feature, or errors.
    */
-  virtual swoc::Rv<Feature> operator()(Context& ctx, Feature & feature) {
-    auto visitor = [&](auto && value) { return (*this)(ctx, value); };
+  virtual swoc::Rv<Feature>
+  operator()(Context &ctx, Feature &feature)
+  {
+    auto visitor = [&](auto &&value) { return (*this)(ctx, value); };
     return std::visit(visitor, feature);
   }
 
@@ -55,28 +59,33 @@ public:
    * @param feature The feature to modify.
    * @return The modified feature.
    */
-  virtual swoc::Rv<Feature> operator()(Context& ctx, std::monostate);
+  virtual swoc::Rv<Feature> operator()(Context &ctx, std::monostate);
 
   // Do-nothing base implementations - subclasses should override methods for supported types.
-  virtual swoc::Rv<Feature> operator()(Context& ctx, feature_type_for<STRING> feature);
-  virtual swoc::Rv<Feature> operator()(Context& ctx, feature_type_for<IP_ADDR> feature);
+  virtual swoc::Rv<Feature> operator()(Context &ctx, feature_type_for<STRING> feature);
+  virtual swoc::Rv<Feature> operator()(Context &ctx, feature_type_for<IP_ADDR> feature);
 
   // Temporary until actually used.
-  template < typename T > auto operator()(Context&, T const&) -> EnableForFeatureTypes<T, swoc::Rv<Feature>> { return {}; }
+  template <typename T>
+  auto
+  operator()(Context &, T const &) -> EnableForFeatureTypes<T, swoc::Rv<Feature>>
+  {
+    return {};
+  }
 
   /** Check if the comparison is valid for @a type.
    *
    * @param type Type of feature to compare.
    * @return @c true if this comparison can compare to that feature type, @c false otherwise.
    */
-  virtual bool is_valid_for(ActiveType const& type) const = 0;
+  virtual bool is_valid_for(ActiveType const &type) const = 0;
 
   /** Output type of the modifier.
    *
    * @param in The input type for the modifier.
    * @return The type of the modified feature.
    */
-  virtual ActiveType result_type(ActiveType  const& ex_type) const = 0;
+  virtual ActiveType result_type(ActiveType const &ex_type) const = 0;
 
   /** Define a mod for @a name.
    *
@@ -85,7 +94,7 @@ public:
    * @return Errors, if any.
    *
    */
-  static swoc::Errata define(swoc::TextView name, Worker const& f);
+  static swoc::Errata define(swoc::TextView name, Worker const &f);
 
   /** Load an instance from YAML.
    *
@@ -94,7 +103,7 @@ public:
    * @param ex_type Feature type to modify.
    * @return
    */
-  static swoc::Rv<Handle> load(Config& cfg, YAML::Node const& node, ActiveType ex_type);
+  static swoc::Rv<Handle> load(Config &cfg, YAML::Node const &node, ActiveType ex_type);
 
 protected:
   /// Set of defined modifiers.

--- a/plugin/include/txn_box/Rxp.h
+++ b/plugin/include/txn_box/Rxp.h
@@ -23,20 +23,25 @@
  * block and it seems silly to have a handle to what is effectively a handle. Aggregrating classes
  * can deal with it the same way as a @c std::unique_ptr.
  */
-class Rxp {
+class Rxp
+{
   using self_type = Rxp; ///< Self reference type.
   /// Cleanup for compiled regular expressions.
   struct PCRE_Deleter {
-    void operator()(pcre2_code* ptr) { pcre2_code_free(ptr); }
+    void
+    operator()(pcre2_code *ptr)
+    {
+      pcre2_code_free(ptr);
+    }
   };
   /// Handle for compiled regular expression.
   using RxpHandle = std::unique_ptr<pcre2_code, PCRE_Deleter>;
 
 public:
-  Rxp() = default;
-  Rxp(self_type const&) = delete;
-  Rxp(self_type && that) : _rxp(std::move(that._rxp)) {}
-  self_type & operator = (self_type const&) = delete;
+  Rxp()                  = default;
+  Rxp(self_type const &) = delete;
+  Rxp(self_type &&that) : _rxp(std::move(that._rxp)) {}
+  self_type &operator=(self_type const &) = delete;
 
   /** Apply the regular expression.
    *
@@ -48,7 +53,7 @@ public:
    *
    * @see capture_count
    */
-  int operator()(swoc::TextView text, pcre2_match_data* match) const;
+  int operator()(swoc::TextView text, pcre2_match_data *match) const;
 
   /// @return The number of capture groups in the expression.
   size_t capture_count() const;
@@ -67,11 +72,11 @@ public:
    * @param options Compile time options.
    * @return An instance if successful, errors if not.
    */
-  static swoc::Rv<self_type> parse(swoc::TextView const& str, Options const& options);
+  static swoc::Rv<self_type> parse(swoc::TextView const &str, Options const &options);
 
 protected:
   RxpHandle _rxp; /// Compiled regular expression.
 
   /// Internal constructor used by @a parse.
-  Rxp(pcre2_code* rxp) : _rxp(rxp) {}
+  Rxp(pcre2_code *rxp) : _rxp(rxp) {}
 };

--- a/plugin/include/txn_box/accl_util.h
+++ b/plugin/include/txn_box/accl_util.h
@@ -23,7 +23,7 @@ class Comparison;
 template <class T> class reversed_view;
 
 ///
-/// @brief PATRICIA algorithm implementation using binary trees.
+/// @brief PATRICA algorithm implementation using binary trees.
 ///        This Data Structure allows to search for N key in exactly N nodes, providing a log(N) bit
 ///        comparision with a single full key comparision per search. The key(or view) is stored in the node,
 ///        nodes are traversed according to the bits of the key, this implementation does NOT uses the key
@@ -389,7 +389,7 @@ template <typename View> class reversed_view
 {
   /// haven't test more than this types.
   static_assert(swoc::meta::is_any_of<View, std::string, std::string_view, swoc::TextView>::value, "Type not supported");
-  // TODO: remove ^^ once is_any_of_v is available. 
+  // TODO: remove ^^ once is_any_of_v is available.
   // static_assert(swoc::meta::is_any_of_v<View, std::string, std::string_view, swoc::TextView>, "Type not supported");
 
 public:
@@ -432,7 +432,7 @@ public:
   private:
     typename View::reverse_iterator _iter;
   };
-  
+
   reversed_view() noexcept = default;
 
   explicit reversed_view(View view) noexcept : _view(view) {}
@@ -475,7 +475,7 @@ public:
   template <typename T> friend std::ostream &operator<<(std::ostream &os, reversed_view<T> const &v);
   template <typename T> friend bool operator==(reversed_view<T> const &lhs, reversed_view<T> const &rhs);
 
-  // To be removed. POC for testing purposes. 
+  // To be removed. POC for testing purposes.
   View
   get_view() const noexcept
   {

--- a/plugin/include/txn_box/accl_util.h
+++ b/plugin/include/txn_box/accl_util.h
@@ -161,12 +161,11 @@ get_bit(Key const &key, int position)
   }
   typename Key::const_pointer ptr = &*std::begin(key);
   assert(ptr != nullptr);
-  int const byte_number           = position / 8;
-  int const position_in_byte      = position - (byte_number * 8);
-  auto byte                       = get_byte<Key>(ptr, byte_number);
+  int const byte_number      = position / 8;
+  int const position_in_byte = position - (byte_number * 8);
+  auto byte                  = get_byte<Key>(ptr, byte_number);
   return ((byte) >> (7 - position_in_byte)) & 1;
 }
-
 
 template <typename Key>
 static auto
@@ -399,7 +398,11 @@ public:
   // Define our own iterator which show a reverse view of the original.
   struct iterator {
     explicit iterator(typename View::reverse_iterator iter) : _iter(iter) {}
-    const typename View::value_type &operator*() const { return *_iter; }
+    const typename View::value_type &
+    operator*() const
+    {
+      return *_iter;
+    }
 
     // TODO: Work on some operator to provide a better api (operator+, operator+=, etc)
     iterator &
@@ -437,7 +440,7 @@ public:
 
   explicit reversed_view(View view) noexcept : _view(view) {}
   bool
-  operator==(View const& v) const noexcept
+  operator==(View const &v) const noexcept
   {
     return v == _view;
   }
@@ -513,8 +516,8 @@ operator==(reversed_view<View> const &lhs, reversed_view<View> const &rhs)
 class string_tree_map
 {
 public:
-  using value_type = swoc::TextView;
-  using key_type   = swoc::TextView;
+  using value_type  = swoc::TextView;
+  using key_type    = swoc::TextView;
   using search_type = std::vector<std::pair<key_type, value_type>>;
 
   bool

--- a/plugin/include/txn_box/common.h
+++ b/plugin/include/txn_box/common.h
@@ -236,14 +236,16 @@ template < typename L, typename T, typename R > using EnableForTypes = std::enab
  */
 template < typename T, typename R > using EnableForFeatureTypes = std::enable_if_t<FeatureTypeList::contains<typename std::decay<T>::type>, R>;
 
+using Sonar = FeatureTypeList::template apply<std::variant>;
+
 /** Feature.
  * This is a wrapper on the variant type containing all the distinct feature types.
  * All of these are small and fixed size, any external storage (e.g. the text for a full)
  * is stored separately.
  *
- * @internal This is needed to deal with self-reference in the underlying variant. Some nested
- * types need to refer to @c Feature but the variant itself can't be forward declared. Instead
- * this struct is and is then used as an empty wrapper on the actual variant.
+ * @internal This is needed to deal with self-reference in the underlying variant. Some nested types
+ * need to refer to @c Feature but the variant itself can't be forward declared. Instead this struct
+ * is declared as an empty wrapper on the actual variant which can be forward declared.
  */
 struct Feature : public FeatureTypeList::template apply<std::variant> {
   using self_type = Feature; ///< Self reference type.
@@ -816,12 +818,11 @@ BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, FeatureTuple cons
 BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, Feature const &feature);
 BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, ValueMask const &mask);
 BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, feature_type_for<DURATION> const& d);
-//BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ActiveType const& type);
 }
 swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const& spec, Hook hook);
 swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, ActiveType const& type);
 
-namespace std { namespace chrono {
+namespace std::chrono {
 using days = duration<hours::rep, ratio<86400>>;
 using weeks = duration<hours::rep, ratio<86400*7>>;
-}} // namespace std::chrono
+} // namespace std::chrono

--- a/plugin/include/txn_box/common.h
+++ b/plugin/include/txn_box/common.h
@@ -1,9 +1,9 @@
 /** @file
-  * Common types and utilities needed by all compilation units.
-  *
-  * Copyright 2019, Oath Inc.
-  * SPDX-License-Identifier: Apache-2.0
-  */
+ * Common types and utilities needed by all compilation units.
+ *
+ * Copyright 2019, Oath Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 #pragma once
 
@@ -25,21 +25,30 @@ constexpr swoc::TextView DEBUG_TAG = "txn_box";
 // Forward declares
 class Config;
 class Context;
-using TSCont =  struct tsapi_cont *;
+using TSCont = struct tsapi_cont *;
 
-namespace YAML { class Node; }
+namespace YAML
+{
+class Node;
+}
 
 /// Generate an @c Errata from a format string and arguments.
-template < typename ... Args > swoc::Errata Error(std::string_view const& fmt, Args && ... args) {
+template <typename... Args>
+swoc::Errata
+Error(std::string_view const &fmt, Args &&... args)
+{
   return std::move(swoc::Errata().note_v(swoc::Severity::ERROR, fmt, std::forward_as_tuple(args...)));
 }
 
-template < typename ... Args > swoc::Errata Warning(std::string_view const& fmt, Args && ... args) {
+template <typename... Args>
+swoc::Errata
+Warning(std::string_view const &fmt, Args &&... args)
+{
   return std::move(swoc::Errata().note_v(swoc::Severity::WARN, fmt, std::forward_as_tuple(args...)));
 }
 
 /// Separate a name and argument for a directive or extractor.
-extern swoc::Rv<swoc::TextView> parse_arg(swoc::TextView & key);
+extern swoc::Rv<swoc::TextView> parse_arg(swoc::TextView &key);
 
 /** Data for a feature that is a full / string.
  *
@@ -51,35 +60,37 @@ extern swoc::Rv<swoc::TextView> parse_arg(swoc::TextView & key);
  * copying while providing safe access to (possibly) transient data. This enables copy on use
  * rather than always copying.
  */
-class FeatureView : public swoc::TextView {
-  using self_type = FeatureView;
+class FeatureView : public swoc::TextView
+{
+  using self_type  = FeatureView;
   using super_type = swoc::TextView;
+
 public:
-  bool _direct_p = false; ///< String is in externally controlled memory.
+  bool _direct_p  = false; ///< String is in externally controlled memory.
   bool _literal_p = false; ///< String is in transaction static memory.
-  bool _cstr_p = false; ///< There is a null char immediately after the view.
+  bool _cstr_p    = false; ///< There is a null char immediately after the view.
 
   using super_type::super_type; ///< Import constructors.
-  using super_type::operator=; ///< Import assignment.
+  using super_type::operator=;  ///< Import assignment.
 
   /** Return a literal feature view.
    *
    * @param view Text of the literal.
    * @return A @c FeatureView marked as a literal.
    */
-  static self_type Literal(TextView const& view);
+  static self_type Literal(TextView const &view);
 
   /** Create a direct feature view.
    *
    * @param view Base view.
    * @return A @c FeatureView for @a view that is direct.
    */
-  static self_type Direct(TextView const& view);
+  static self_type Direct(TextView const &view);
 };
 
 /// YAML tag type for literal (no feature extraction).
-static constexpr swoc::TextView LITERAL_TAG { "!literal" };
-static constexpr swoc::TextView DURATION_TAG {"!duration"};
+static constexpr swoc::TextView LITERAL_TAG{"!literal"};
+static constexpr swoc::TextView DURATION_TAG{"!duration"};
 
 // Self referential types, forward declared.
 struct Cons;
@@ -95,13 +106,18 @@ using FeatureTuple = swoc::MemSpan<Feature>;
  * - Extension types such that non-framework code can have its own feature (sub) type.
  * This should be subclassed.
  */
-class Generic {
+class Generic
+{
 public:
   swoc::TextView _tag; ///< Sub type identifier.
 
-  Generic(swoc::TextView const& tag) : _tag(tag) {}
+  Generic(swoc::TextView const &tag) : _tag(tag) {}
   virtual ~Generic() {}
-  virtual swoc::TextView description() const { return _tag; }
+  virtual swoc::TextView
+  description() const
+  {
+    return _tag;
+  }
 
   /** Extract a non-Generic feature from @a this.
    *
@@ -112,7 +128,11 @@ public:
    */
   virtual Feature extract() const;
 
-  virtual bool is_nil() const { return false; }
+  virtual bool
+  is_nil() const
+  {
+    return false;
+  }
 };
 
 /// Enumeration of types of values, e.g. those returned by a feature string or extractor.
@@ -123,70 +143,68 @@ public:
 /// - @c Feature::value_type
 enum ValueType : int8_t {
   NO_VALUE = 0, ///< No value, uninitialized
-  NIL, ///< Config level no data.
-  STRING, ///< View of a string.
-  INTEGER, ///< Integer.
-  BOOLEAN, ///< Boolean.
-  FLOAT, ///< Floating point.
-  IP_ADDR, ///< IP Address
-  DURATION, ///< Duration (time span).
-  TIMEPOINT, ///< Timestamp, specific moment on a clock.
-  CONS, ///< Pointer to cons cell.
-  TUPLE, ///< Array of features (@c FeatureTuple)
-  GENERIC, ///< Extended type.
+  NIL,          ///< Config level no data.
+  STRING,       ///< View of a string.
+  INTEGER,      ///< Integer.
+  BOOLEAN,      ///< Boolean.
+  FLOAT,        ///< Floating point.
+  IP_ADDR,      ///< IP Address
+  DURATION,     ///< Duration (time span).
+  TIMEPOINT,    ///< Timestamp, specific moment on a clock.
+  CONS,         ///< Pointer to cons cell.
+  TUPLE,        ///< Array of features (@c FeatureTuple)
+  GENERIC,      ///< Extended type.
 };
 
 /// Empty struct to represent a NIL / NULL runtime value.
-struct nil_value {};
+struct nil_value {
+};
 
 class ActiveType; // Forward declare
 
-namespace std {
-template <> struct tuple_size<ValueType> : public std::integral_constant<size_t, static_cast<size_t>(ValueType::GENERIC) + 1> {};
+namespace std
+{
+template <> struct tuple_size<ValueType> : public std::integral_constant<size_t, static_cast<size_t>(ValueType::GENERIC) + 1> {
+};
 }; // namespace std
 
 // *** @c FeatureTypeList, @c FeatureType, and @c FeatureindexList must be kept in parallel synchronization! ***
 /// Type list of feature types.
-using FeatureTypeList = swoc::meta::type_list<
-      std::monostate
-    , nil_value
-    , FeatureView
-    , intmax_t
-    , bool
-    , double
-    , swoc::IPAddr
-    , std::chrono::nanoseconds
-    , std::chrono::system_clock::time_point
-    , Cons *
-    , FeatureTuple
-    , Generic*
-    >;
+using FeatureTypeList =
+  swoc::meta::type_list<std::monostate, nil_value, FeatureView, intmax_t, bool, double, swoc::IPAddr, std::chrono::nanoseconds,
+                        std::chrono::system_clock::time_point, Cons *, FeatureTuple, Generic *>;
 
 /// Variant index to feature type.
-constexpr std::array<ValueType, FeatureTypeList::size> FeatureIndexToValue {
-  NO_VALUE
-   , NIL
-   , STRING
-   , INTEGER
-   , BOOLEAN
-   , FLOAT
-   , IP_ADDR
-   , DURATION
-   , TIMEPOINT
-   , CONS
-   , TUPLE
-   , GENERIC };
+constexpr std::array<ValueType, FeatureTypeList::size> FeatureIndexToValue{
+  NO_VALUE, NIL, STRING, INTEGER, BOOLEAN, FLOAT, IP_ADDR, DURATION, TIMEPOINT, CONS, TUPLE, GENERIC};
 
-namespace detail {
-template < typename GENERATOR, size_t ... IDX> constexpr
-std::initializer_list<std::result_of_t<GENERATOR(size_t)>> indexed_init_list(GENERATOR && g, std::index_sequence<IDX...> &&) { return { g(IDX)... }; }
-template < size_t N, typename GENERATOR> constexpr
-std::initializer_list<std::result_of_t<GENERATOR(size_t)>> indexed_init_list(GENERATOR && g) { return indexed_init_list(std::forward<GENERATOR>(g), std::make_index_sequence<N>());}
+namespace detail
+{
+template <typename GENERATOR, size_t... IDX>
+constexpr std::initializer_list<std::result_of_t<GENERATOR(size_t)>>
+indexed_init_list(GENERATOR &&g, std::index_sequence<IDX...> &&)
+{
+  return {g(IDX)...};
+}
+template <size_t N, typename GENERATOR>
+constexpr std::initializer_list<std::result_of_t<GENERATOR(size_t)>>
+indexed_init_list(GENERATOR &&g)
+{
+  return indexed_init_list(std::forward<GENERATOR>(g), std::make_index_sequence<N>());
+}
 
-template < typename GENERATOR, size_t ... IDX> constexpr
-std::array<std::result_of_t<GENERATOR(size_t)>, sizeof...(IDX)> indexed_array(GENERATOR && g, std::index_sequence<IDX...> &&) { return std::array<std::result_of_t<GENERATOR(size_t)>, sizeof...(IDX)> { g(IDX)... }; }
-template < size_t N, typename GENERATOR> constexpr
-std::array<std::result_of_t<GENERATOR(size_t)>, N> indexed_array(GENERATOR && g) { return indexed_array(std::forward<GENERATOR>(g), std::make_index_sequence<N>()); }
+template <typename GENERATOR, size_t... IDX>
+constexpr std::array<std::result_of_t<GENERATOR(size_t)>, sizeof...(IDX)>
+indexed_array(GENERATOR &&g, std::index_sequence<IDX...> &&)
+{
+  return std::array<std::result_of_t<GENERATOR(size_t)>, sizeof...(IDX)>{g(IDX)...};
+}
+template <size_t N, typename GENERATOR>
+constexpr std::array<std::result_of_t<GENERATOR(size_t)>, N>
+indexed_array(GENERATOR &&g)
+{
+  return indexed_array(std::forward<GENERATOR>(g), std::make_index_sequence<N>());
+}
 
 } // namespace detail
 
@@ -195,8 +213,10 @@ std::array<std::result_of_t<GENERATOR(size_t)>, N> indexed_array(GENERATOR && g)
  * @param type Value type (enumeration).
  * @return Index in @c FeatureData for that feature type.
  */
-inline constexpr unsigned IndexFor(ValueType type) {
-    auto IDX = detail::indexed_array<std::tuple_size<ValueType>::value>([](unsigned idx) { return idx; });
+inline constexpr unsigned
+IndexFor(ValueType type)
+{
+  auto IDX = detail::indexed_array<std::tuple_size<ValueType>::value>([](unsigned idx) { return idx; });
   return IDX[static_cast<unsigned>(type)];
 };
 
@@ -218,7 +238,8 @@ inline constexpr unsigned IndexFor(ValueType type) {
  * types can be defined before such a template. This is generally done when those types are
  * usable types, with the template for a generic failure response for non-usable types.
  */
-template < typename L, typename T, typename R > using EnableForTypes = std::enable_if_t<L::template contains<typename std::decay<T>::type>, R>;
+template <typename L, typename T, typename R>
+using EnableForTypes = std::enable_if_t<L::template contains<typename std::decay<T>::type>, R>;
 
 /** Helper template for handling @c Feature variants.
  * @tparam T The type to check against the variant type list.
@@ -234,7 +255,8 @@ template < typename L, typename T, typename R > using EnableForTypes = std::enab
  * types can be defined before such a template. This is generally done when those types are
  * usable types, with the template for a generic failure response for non-usable types.
  */
-template < typename T, typename R > using EnableForFeatureTypes = std::enable_if_t<FeatureTypeList::contains<typename std::decay<T>::type>, R>;
+template <typename T, typename R>
+using EnableForFeatureTypes = std::enable_if_t<FeatureTypeList::contains<typename std::decay<T>::type>, R>;
 
 using Sonar = FeatureTypeList::template apply<std::variant>;
 
@@ -248,17 +270,16 @@ using Sonar = FeatureTypeList::template apply<std::variant>;
  * is declared as an empty wrapper on the actual variant which can be forward declared.
  */
 struct Feature : public FeatureTypeList::template apply<std::variant> {
-  using self_type = Feature; ///< Self reference type.
-  using super_type = FeatureTypeList::template apply<std::variant>; ///< Parent type.
-  using variant_type = super_type; ///< The base variant type.
+  using self_type    = Feature;                                       ///< Self reference type.
+  using super_type   = FeatureTypeList::template apply<std::variant>; ///< Parent type.
+  using variant_type = super_type;                                    ///< The base variant type.
 
   /// Convenience meta-function to convert a @c FeatureData index to the specific feature type.
   /// @tparam F ValueType enumeration value.
-  template < ValueType F > using type_for = std::variant_alternative_t<IndexFor(F), variant_type>;
+  template <ValueType F> using type_for = std::variant_alternative_t<IndexFor(F), variant_type>;
 
   // Inherit variant constructors.
   using super_type::super_type;
-
 
   /** The value type of @a this.
    *
@@ -266,7 +287,9 @@ struct Feature : public FeatureTypeList::template apply<std::variant> {
    *
    * This is the direct type of the feature, without regard to containment.
    */
-  ValueType value_type() const {
+  ValueType
+  value_type() const
+  {
     return FeatureIndexToValue[this->index()];
   }
 
@@ -312,69 +335,93 @@ struct Feature : public FeatureTypeList::template apply<std::variant> {
    * list elements are rendered, separated by the @a glue. The primary use of this is to force
    * an arbitrary feature to be a string.
    */
-  self_type join(Context & ctx, swoc::TextView const& glue) const;
+  self_type join(Context &ctx, swoc::TextView const &glue) const;
 };
 
-bool operator == (Feature const& lhs, Feature const& rhs);
-inline bool operator != (Feature const& lhs, Feature const& rhs) { return !(lhs == rhs);}
-bool operator < (Feature const& lhs, Feature const& rhs);
-inline bool operator > (Feature const& lhs, Feature const& rhs) { return rhs < lhs;}
-bool operator <= (Feature const& lhs, Feature const& rhs);
-inline bool operator >= (Feature const& lhs, Feature const& rhs) { return rhs <= lhs;}
+bool operator==(Feature const &lhs, Feature const &rhs);
+inline bool
+operator!=(Feature const &lhs, Feature const &rhs)
+{
+  return !(lhs == rhs);
+}
+bool operator<(Feature const &lhs, Feature const &rhs);
+inline bool
+operator>(Feature const &lhs, Feature const &rhs)
+{
+  return rhs < lhs;
+}
+bool operator<=(Feature const &lhs, Feature const &rhs);
+inline bool
+operator>=(Feature const &lhs, Feature const &rhs)
+{
+  return rhs <= lhs;
+}
 
 /// @cond NO_DOXYGEN
 // These are overloads for variant visitors so that other call sites can use @c Feature
 // directly without having to reach in to the @c variant_type.
-namespace std {
-template < typename VISITOR > auto visit(VISITOR&& visitor, Feature & feature) -> decltype(visit(std::forward<VISITOR>(visitor), static_cast<Feature::variant_type &>(feature))) {
+namespace std
+{
+template <typename VISITOR>
+auto
+visit(VISITOR &&visitor, Feature &feature)
+  -> decltype(visit(std::forward<VISITOR>(visitor), static_cast<Feature::variant_type &>(feature)))
+{
   return visit(std::forward<VISITOR>(visitor), static_cast<Feature::variant_type &>(feature));
 }
 
-template < typename VISITOR > auto visit(VISITOR&& visitor, Feature const& feature) -> decltype(visit(std::forward<VISITOR>(visitor), static_cast<Feature::variant_type const&>(feature))) {
-  return visit(std::forward<VISITOR>(visitor), static_cast<Feature::variant_type const&>(feature));
+template <typename VISITOR>
+auto
+visit(VISITOR &&visitor, Feature const &feature)
+  -> decltype(visit(std::forward<VISITOR>(visitor), static_cast<Feature::variant_type const &>(feature)))
+{
+  return visit(std::forward<VISITOR>(visitor), static_cast<Feature::variant_type const &>(feature));
 }
 } // namespace std
 /// @endcond
 
 /// @deprecated - use @c f.value_type()
-inline ValueType ValueTypeOf(Feature const& f) { return f.value_type(); }
+inline ValueType
+ValueTypeOf(Feature const &f)
+{
+  return f.value_type();
+}
 
-namespace detail {
+namespace detail
+{
 // Need to document this, and then move it in to libswoc.
 // This walks a typelist and compute the index of a given type @c F in the typelist.
 // The utility is to convert from a feature type in the feature variant to the index in the variant.
 // This is used almost entirely for error reporting.
-template<typename T, typename... Rest>
-struct TypeListIndex;
+template <typename T, typename... Rest> struct TypeListIndex;
 
-template<typename T, typename... Rest>
-struct TypeListIndex<T, T, Rest...> : std::integral_constant<std::size_t, 0> {
+template <typename T, typename... Rest> struct TypeListIndex<T, T, Rest...> : std::integral_constant<std::size_t, 0> {
 };
 
-template<typename T, typename U, typename... Rest>
-struct TypeListIndex<T, U, Rest...> : std::integral_constant<std::size_t,
-    1 + TypeListIndex<T, Rest...>::value> {
+template <typename T, typename U, typename... Rest>
+struct TypeListIndex<T, U, Rest...> : std::integral_constant<std::size_t, 1 + TypeListIndex<T, Rest...>::value> {
 };
 
-template < typename F > struct TypeListIndexWrapper {
-  template < typename ... Args > struct IDX : std::integral_constant<size_t, TypeListIndex<F, Args...>::value> {};
+template <typename F> struct TypeListIndexWrapper {
+  template <typename... Args> struct IDX : std::integral_constant<size_t, TypeListIndex<F, Args...>::value> {
+  };
 };
 
-template < typename F > using TypeListIndexer = FeatureTypeList::template apply<detail::TypeListIndexWrapper<F>::template IDX>;
+template <typename F> using TypeListIndexer = FeatureTypeList::template apply<detail::TypeListIndexWrapper<F>::template IDX>;
 
-}
+} // namespace detail
 
 /** Convert a feature type to a feature index.
  *
  * @tparam F Feature type.
  */
-template < typename F > static constexpr size_t index_for_type = detail::TypeListIndexer<F>::value;
+template <typename F> static constexpr size_t index_for_type = detail::TypeListIndexer<F>::value;
 
 /** Convert a feature type to a @c ValueType value.
  *
  * @tparam F Feature type.
  */
-template < typename F > static constexpr ValueType value_type_of = ValueType(index_for_type<F>);
+template <typename F> static constexpr ValueType value_type_of = ValueType(index_for_type<F>);
 
 /// Nil value feature.
 /// @internal Default constructor doesn't work in the Intel compiler, must be explicit.
@@ -397,42 +444,65 @@ using ValueMask = std::bitset<std::tuple_size<ValueType>::value>;
 /** The active type.
  * This is a mask of feature types, representing the possible types of the active feature.
  */
-class ActiveType {
+class ActiveType
+{
   using self_type = ActiveType;
+
 public:
   struct TupleOf {
     ValueMask _mask;
     TupleOf() = default;
     explicit TupleOf(ValueMask mask) : _mask(mask) {}
-    template < typename ... Rest > TupleOf(ValueType vt, Rest && ... rest ) : TupleOf(rest...) {
-      _mask[vt] = true;
-    }
+    template <typename... Rest> TupleOf(ValueType vt, Rest &&... rest) : TupleOf(rest...) { _mask[vt] = true; }
   };
-  ActiveType() = default;
-  ActiveType(self_type const& that) = default;
-  ActiveType(ValueMask vtypes) : _base_type(vtypes) {};
-  template < typename ... Rest > ActiveType(ValueType vt, Rest && ... rest );
-  template < typename ... Rest > ActiveType(TupleOf const& tt, Rest && ... rest );
+  ActiveType()                      = default;
+  ActiveType(self_type const &that) = default;
+  ActiveType(ValueMask vtypes) : _base_type(vtypes){};
+  template <typename... Rest> ActiveType(ValueType vt, Rest &&... rest);
+  template <typename... Rest> ActiveType(TupleOf const &tt, Rest &&... rest);
 
-  self_type & operator=(ValueType vt);
-  self_type & operator=(TupleOf const& tt);
-  self_type & operator|=(ValueType vt);
-  self_type & operator|=(ValueMask vtypes) { _base_type |= vtypes; return *this; }
-  self_type & operator|=(TupleOf const& tt);
+  self_type &operator=(ValueType vt);
+  self_type &operator=(TupleOf const &tt);
+  self_type &operator|=(ValueType vt);
+  self_type &
+  operator|=(ValueMask vtypes)
+  {
+    _base_type |= vtypes;
+    return *this;
+  }
+  self_type &operator|=(TupleOf const &tt);
 
-  bool operator==(self_type const& that) { return _base_type == that._base_type && _tuple_type == that._tuple_type; }
-  bool operator!=(self_type const& that) { return ! (*this == that); }
+  bool
+  operator==(self_type const &that)
+  {
+    return _base_type == that._base_type && _tuple_type == that._tuple_type;
+  }
+  bool
+  operator!=(self_type const &that)
+  {
+    return !(*this == that);
+  }
 
   /// Check if this is any type and therefore has a value.
-  bool has_value() const { return _base_type.any(); }
+  bool
+  has_value() const
+  {
+    return _base_type.any();
+  }
 
-  bool can_satisfy(ValueType vt) const {
+  bool
+  can_satisfy(ValueType vt) const
+  {
     return _base_type[vt];
   }
-  bool can_satisfy(ValueMask vmask) const {
+  bool
+  can_satisfy(ValueMask vmask) const
+  {
     return (_base_type & vmask).any();
   }
-  bool can_satisfy(self_type const& that) const {
+  bool
+  can_satisfy(self_type const &that) const
+  {
     auto c = _base_type & that._base_type;
     // TUPLE is a common type if the tuple element types have a common type or no type is specified
     // for the TUPLE, which means just check for being a TUPLE.
@@ -442,13 +512,32 @@ public:
     return c.any();
   }
 
-  ValueMask base_types() const { return _base_type; }
-  ValueMask tuple_types() const { return _tuple_type; }
+  ValueMask
+  base_types() const
+  {
+    return _base_type;
+  }
+  ValueMask
+  tuple_types() const
+  {
+    return _tuple_type;
+  }
 
-  self_type & mark_cfg_const() { _cfg_const_p = true; return *this; }
-  bool is_cfg_const() const { return _cfg_const_p; }
+  self_type &
+  mark_cfg_const()
+  {
+    _cfg_const_p = true;
+    return *this;
+  }
+  bool
+  is_cfg_const() const
+  {
+    return _cfg_const_p;
+  }
 
-  static self_type any_type() {
+  static self_type
+  any_type()
+  {
     self_type zret;
     zret._base_type.set();
     zret._tuple_type.set();
@@ -456,42 +545,50 @@ public:
   }
 
 protected:
-  ValueMask _base_type; ///< Base type of the feature.
-  ValueMask _tuple_type; ///< Types of the elements of a tuple.
+  ValueMask _base_type;      ///< Base type of the feature.
+  ValueMask _tuple_type;     ///< Types of the elements of a tuple.
   bool _cfg_const_p = false; ///< Config time constant.
-  friend swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, ActiveType const& type);
+  friend swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, ActiveType const &type);
 };
 
-template<typename... Rest>
-ActiveType::ActiveType(ValueType vt, Rest&& ... rest) : ActiveType(rest...) {
+template <typename... Rest> ActiveType::ActiveType(ValueType vt, Rest &&... rest) : ActiveType(rest...)
+{
   _base_type[vt] = true;
 }
 
-template < typename ... Rest >
-ActiveType::ActiveType(TupleOf const& tt, Rest && ... rest ) : ActiveType(rest...) {
+template <typename... Rest> ActiveType::ActiveType(TupleOf const &tt, Rest &&... rest) : ActiveType(rest...)
+{
   _tuple_type |= tt._mask;
   _base_type[TUPLE] = true;
 }
 
-inline auto ActiveType::operator=(ValueType vt) -> self_type & {
+inline auto
+ActiveType::operator=(ValueType vt) -> self_type &
+{
   _base_type.reset();
   _base_type[vt] = true;
   return *this;
 }
 
-inline auto ActiveType::operator=(TupleOf const& tt) -> self_type & {
+inline auto
+ActiveType::operator=(TupleOf const &tt) -> self_type &
+{
   _base_type.reset();
   _base_type[TUPLE] = true;
-  _tuple_type = tt._mask;
+  _tuple_type       = tt._mask;
   return *this;
 }
 
-inline auto ActiveType::operator|=(ValueType vt) -> self_type & {
+inline auto
+ActiveType::operator|=(ValueType vt) -> self_type &
+{
   _base_type[vt] = true;
   return *this;
 }
 
-inline auto ActiveType::operator|=(TupleOf const& tt) -> self_type & {
+inline auto
+ActiveType::operator|=(TupleOf const &tt) -> self_type &
+{
   _base_type[TUPLE] = true;
   _tuple_type |= tt._mask;
   return *this;
@@ -512,7 +609,9 @@ inline auto ActiveType::operator|=(TupleOf const& tt) -> self_type & {
  * @see ValueType
  * @see FeatureMask
  */
-inline ValueMask MaskFor(ValueType type) {
+inline ValueMask
+MaskFor(ValueType type)
+{
   ValueMask mask;
   mask[IndexFor(type)] = true;
   return mask;
@@ -526,12 +625,14 @@ inline ValueMask MaskFor(ValueType type) {
  *
  * This is enabled only if all types in @a P are @c ValueType.
  */
-template < typename ... P > auto MaskFor(P  ... parms) -> std::enable_if_t<std::conjunction_v<std::is_same<ValueType, P>...>, ValueMask> {
+template <typename... P>
+auto
+MaskFor(P... parms) -> std::enable_if_t<std::conjunction_v<std::is_same<ValueType, P>...>, ValueMask>
+{
   ValueMask mask;
-  ( (mask[IndexFor(parms)] = true) ,  ...);
+  ((mask[IndexFor(parms)] = true), ...);
   return mask;
 }
-
 
 /** Create a @c FeatureMask containing @a types.
  *
@@ -550,7 +651,9 @@ template < typename ... P > auto MaskFor(P  ... parms) -> std::enable_if_t<std::
  * @see ValueType
  * @see FeatureMask
  */
-inline ValueMask MaskFor(std::initializer_list<ValueType> const& types) {
+inline ValueMask
+MaskFor(std::initializer_list<ValueType> const &types)
+{
   ValueMask mask;
   for (auto type : types) {
     mask[IndexFor(type)] = true;
@@ -560,7 +663,7 @@ inline ValueMask MaskFor(std::initializer_list<ValueType> const& types) {
 
 /// Convenience meta-function to convert a @c FeatureData index to the specific feature type.
 /// @tparam F ValueType enumeration value.
-template < ValueType F > using feature_type_for = Feature::type_for<F>;
+template <ValueType F> using feature_type_for = Feature::type_for<F>;
 
 /** Compute a feature mask from a list of types.
  *
@@ -570,25 +673,34 @@ template < ValueType F > using feature_type_for = Feature::type_for<F>;
  * @internal This can't be @c constexpr because the underlying type @c std::bitset doesn't have a
  * @c constexpr constructor.
  */
-template < typename ... F > ValueMask MaskFor() {
+template <typename... F>
+ValueMask
+MaskFor()
+{
   ValueMask mask;
-  ( (mask[index_for_type<F>] = true) , ...);
+  ((mask[index_for_type<F>] = true), ...);
   return mask;
 }
 
-template < typename ... F > struct ValueMaskFor {
-  static inline const ValueMask value { MaskFor<F ...>() };
+template <typename... F> struct ValueMaskFor {
+  static inline const ValueMask value{MaskFor<F...>()};
 };
 
 /// Check if @a feature is nil.
-inline bool is_nil(Feature const& feature) {
+inline bool
+is_nil(Feature const &feature)
+{
   if (auto gf = std::get_if<GENERIC>(&feature)) {
     return (*gf)->is_nil();
   }
   return feature.index() == IndexFor(NIL);
 }
 /// Check if @a feature is empty (nil or an empty string).
-inline bool is_empty(Feature const& feature) { return IndexFor(NIL) == feature.index() || (IndexFor(STRING) == feature.index() && std::get<IndexFor(STRING)>(feature).empty()); }
+inline bool
+is_empty(Feature const &feature)
+{
+  return IndexFor(NIL) == feature.index() || (IndexFor(STRING) == feature.index() && std::get<IndexFor(STRING)>(feature).empty());
+}
 
 /** Get the first element for @a feature.
  *
@@ -597,7 +709,7 @@ inline bool is_empty(Feature const& feature) { return IndexFor(NIL) == feature.i
  * sequence.
  *
  */
-Feature car(Feature const& feature);
+Feature car(Feature const &feature);
 
 /** Drop the first element in @a feature.
  *
@@ -606,17 +718,19 @@ Feature car(Feature const& feature);
  * Otherwise a sequence not containing the first element of @a feature.
  *
  */
-Feature & cdr(Feature & feature);
+Feature &cdr(Feature &feature);
 
-inline void clear(Feature & feature) {
-  if (auto gf = std::get_if<GENERIC>(&feature) ; gf) {
+inline void
+clear(Feature &feature)
+{
+  if (auto gf = std::get_if<GENERIC>(&feature); gf) {
     (*gf)->~Generic();
   }
   feature = NIL_FEATURE;
 }
 
-static constexpr swoc::TextView ACTIVE_FEATURE_KEY { "..." };
-static constexpr swoc::TextView UNMATCHED_FEATURE_KEY {"*" };
+static constexpr swoc::TextView ACTIVE_FEATURE_KEY{"..."};
+static constexpr swoc::TextView UNMATCHED_FEATURE_KEY{"*"};
 
 /// Conversion between @c ValueType and printable names.
 extern swoc::Lexicon<ValueType> const ValueTypeNames;
@@ -626,24 +740,26 @@ extern swoc::Lexicon<ValueType> const ValueTypeNames;
 /// directive is valid from the current hook. Special hooks that can't be scheduled from a
 /// transaction go before @c TXN_START so they are always "in the past".
 enum class Hook {
-  INVALID, ///< Invalid hook (default initialization value).
-  POST_LOAD, ///< After configuration has been loaded.
+  INVALID,     ///< Invalid hook (default initialization value).
+  POST_LOAD,   ///< After configuration has been loaded.
   POST_ACTIVE, ///< After the configuration has become active.
-  MSG, ///< During plugin message handling (implicit).
-  TXN_START, ///< Transaction start.
-  CREQ, ///< Read Request from user agent.
-  PRE_REMAP, ///< Before remap.
-  REMAP, ///< Remap (implicit).
-  POST_REMAP, ///< After remap.
-  PREQ, ///< Send request from proxy to upstream.
-  URSP, ///< Read response from upstream.
-  PRSP, ///< Send response to user agent from proxy.
-  TXN_CLOSE ///< Transaction close.
+  MSG,         ///< During plugin message handling (implicit).
+  TXN_START,   ///< Transaction start.
+  CREQ,        ///< Read Request from user agent.
+  PRE_REMAP,   ///< Before remap.
+  REMAP,       ///< Remap (implicit).
+  POST_REMAP,  ///< After remap.
+  PREQ,        ///< Send request from proxy to upstream.
+  URSP,        ///< Read response from upstream.
+  PRSP,        ///< Send response to user agent from proxy.
+  TXN_CLOSE    ///< Transaction close.
 };
 
 /// Make @c tuple_size work for the @c Hook enum.
-namespace std {
-template<> struct tuple_size<Hook> : public std::integral_constant<size_t, static_cast<size_t>(Hook::TXN_CLOSE)+1> {};
+namespace std
+{
+template <> struct tuple_size<Hook> : public std::integral_constant<size_t, static_cast<size_t>(Hook::TXN_CLOSE) + 1> {
+};
 }; // namespace std
 
 /** Convert a @c Hook enumeration to an unsigned value.
@@ -651,7 +767,9 @@ template<> struct tuple_size<Hook> : public std::integral_constant<size_t, stati
  * @param id Enumeration to convert.
  * @return Numeric value of @a id.
  */
-inline constexpr unsigned IndexFor(Hook id) {
+inline constexpr unsigned
+IndexFor(Hook id)
+{
   return static_cast<unsigned>(id);
 }
 
@@ -670,7 +788,9 @@ using HookMask = std::bitset<std::tuple_size<Hook>::value>;
  *   static const HookMask Mask { MaskFor(Hook::PRE_REMAP) };
  * @endcode
  */
-inline HookMask MaskFor(Hook hook) {
+inline HookMask
+MaskFor(Hook hook)
+{
   HookMask mask;
   mask[IndexFor(hook)] = true;
   return mask;
@@ -693,7 +813,9 @@ inline HookMask MaskFor(Hook hook) {
  * @see ValueType
  * @see HookMask
  */
-inline HookMask MaskFor(std::initializer_list<Hook> const& hooks) {
+inline HookMask
+MaskFor(std::initializer_list<Hook> const &hooks)
+{
   HookMask mask;
   for (auto hook : hooks) {
     mask[IndexFor(hook)] = true;
@@ -701,27 +823,39 @@ inline HookMask MaskFor(std::initializer_list<Hook> const& hooks) {
   return mask;
 }
 
-template < typename E > struct MaskTypeFor { };
-template <> struct MaskTypeFor<Hook> { using type = HookMask; };
-template <> struct MaskTypeFor<ValueType> { using type = ValueMask; };
+template <typename E> struct MaskTypeFor {
+};
+template <> struct MaskTypeFor<Hook> {
+  using type = HookMask;
+};
+template <> struct MaskTypeFor<ValueType> {
+  using type = ValueMask;
+};
 
-template < typename ... P > auto MaskFor(P  ... parms) -> std::enable_if_t<std::conjunction_v<std::is_same<Hook, P>...>, HookMask> {
+template <typename... P>
+auto
+MaskFor(P... parms) -> std::enable_if_t<std::conjunction_v<std::is_same<Hook, P>...>, HookMask>
+{
   HookMask mask;
-  ( (mask[IndexFor(parms)] = true) ,  ...);
+  ((mask[IndexFor(parms)] = true), ...);
   return mask;
 }
 
 /// Name lookup for hook values.
 extern swoc::Lexicon<Hook> HookName;
 
-inline FeatureView FeatureView::Literal(TextView const& view) {
-  self_type zret { view };
+inline FeatureView
+FeatureView::Literal(TextView const &view)
+{
+  self_type zret{view};
   zret._literal_p = true;
   return zret;
 }
 
-inline FeatureView FeatureView::Direct(TextView const& view) {
-  self_type zret { view };
+inline FeatureView
+FeatureView::Direct(TextView const &view)
+{
+  self_type zret{view};
   zret._direct_p = true;
   return zret;
 }
@@ -729,8 +863,8 @@ inline FeatureView FeatureView::Direct(TextView const& view) {
 /// Conversion enumeration for checking boolean strings.
 enum BoolTag {
   INVALID = -1,
-  False = 0,
-  True = 1,
+  False   = 0,
+  True    = 1,
 };
 /// Mapping of strings to boolean values.
 /// This is for handling various synonymns in a consistent manner.
@@ -741,17 +875,16 @@ struct Global {
   swoc::Errata _preload_errata;
   int TxnArgIdx = -1;
   std::vector<std::string> _args; ///< Global configuration arguments.
-  TSCont _cont; ///< Global continuation to start transaction handling.
+  TSCont _cont;                   ///< Global continuation to start transaction handling.
   /// Amount of reserved storage requested by remap directives.
   /// This is not always correct, @c Context must handle overflows gracefully.
-  std::atomic<size_t> _remap_ctx_storage_required {0 };
+  std::atomic<size_t> _remap_ctx_storage_required{0};
 
   void reserve_txn_arg();
 
   // -- Reserved keys -- //
   /// Standard name for nested directives and therefore reserved globally.
   static constexpr swoc::TextView DO_KEY = "do";
-
 };
 
 /// Global data.
@@ -760,31 +893,31 @@ extern Global G;
 /// Reserved storage descriptor.
 struct ReservedSpan {
   size_t offset = 0; ///< Offset for start of storage.
-  size_t n = 0; ///< Storage size;
+  size_t n      = 0; ///< Storage size;
 };
 
 /// Used for clean up in @c Config and @c Context.
 /// A list of these is used to perform additional cleanup for extensions to the basic object.
 struct Finalizer {
-  using self_type = Finalizer; ///< Self reference type.
-  void * _ptr = nullptr; ///< Pointer to object to destroy.
-  std::function<void (void*)> _f; ///< Functor to destroy @a _ptr.
+  using self_type = Finalizer;    ///< Self reference type.
+  void *_ptr      = nullptr;      ///< Pointer to object to destroy.
+  std::function<void(void *)> _f; ///< Functor to destroy @a _ptr.
 
-  self_type * _prev = nullptr; ///< List support.
-  self_type * _next = nullptr; ///< List support.
-  using Linkage = swoc::IntrusiveLinkage<Finalizer>; ///< For @c IntrusiveDList
+  self_type *_prev = nullptr;                           ///< List support.
+  self_type *_next = nullptr;                           ///< List support.
+  using Linkage    = swoc::IntrusiveLinkage<Finalizer>; ///< For @c IntrusiveDList
 
-  Finalizer(void* ptr, std::function<void (void*)> && f);
+  Finalizer(void *ptr, std::function<void(void *)> &&f);
 };
 
-inline Finalizer::Finalizer(void* ptr, std::function<void (void*)> && f) : _ptr(ptr), _f(std::move(f)) {}
+inline Finalizer::Finalizer(void *ptr, std::function<void(void *)> &&f) : _ptr(ptr), _f(std::move(f)) {}
 
 /** Scoping value change.
  *
  * @tparam T Type of variable to scope.
  */
-template < typename T > struct let {
-  T & _var; ///< Reference to scoped variable.
+template <typename T> struct let {
+  T &_var;  ///< Reference to scoped variable.
   T _value; ///< Original value.
 
   /** Construct a scope.
@@ -792,37 +925,48 @@ template < typename T > struct let {
    * @param var Variable to scope.
    * @param value temporary value to assign.
    */
-  let(T & var, T const& value);
+  let(T &var, T const &value);
 
   /** Construct a scope.
    *
    * @param var Variable to scope.
    * @param value temporary value to assign.
    */
-  let(T & var, T && value);
+  let(T &var, T &&value);
 
   ~let();
 };
 
-template < typename T > let<T>::let(T& var, T const& value) : _var(var), _value(var)  { _var = value; }
-template < typename T > let<T>::let(T& var, T && value) : _var(var), _value(std::move(var))  { _var = value; }
+template <typename T> let<T>::let(T &var, T const &value) : _var(var), _value(var)
+{
+  _var = value;
+}
+template <typename T> let<T>::let(T &var, T &&value) : _var(var), _value(std::move(var))
+{
+  _var = value;
+}
 
-template < typename T > let<T>::~let() { _var = _value; }
+template <typename T> let<T>::~let()
+{
+  _var = _value;
+}
 
 // BufferWriter support.
-namespace swoc {
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, feature_type_for<NO_VALUE>);
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, feature_type_for<NIL>);
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, ValueType type);
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, FeatureTuple const& t);
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, Feature const &feature);
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, ValueMask const &mask);
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, feature_type_for<DURATION> const& d);
-}
-swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const& spec, Hook hook);
-swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, ActiveType const& type);
+namespace swoc
+{
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, feature_type_for<NO_VALUE>);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, feature_type_for<NIL>);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ValueType type);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, FeatureTuple const &t);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Feature const &feature);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ValueMask const &mask);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, feature_type_for<DURATION> const &d);
+} // namespace swoc
+swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, Hook hook);
+swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const &spec, ActiveType const &type);
 
-namespace std::chrono {
-using days = duration<hours::rep, ratio<86400>>;
-using weeks = duration<hours::rep, ratio<86400*7>>;
+namespace std::chrono
+{
+using days  = duration<hours::rep, ratio<86400>>;
+using weeks = duration<hours::rep, ratio<86400 * 7>>;
 } // namespace std::chrono

--- a/plugin/include/txn_box/common.h
+++ b/plugin/include/txn_box/common.h
@@ -122,7 +122,8 @@ public:
 /// - @c FeatureTypelist
 /// - @c Feature::value_type
 enum ValueType : int8_t {
-  NIL = 0, ///< Explicitly no data.
+  NO_VALUE = 0, ///< No value, uninitialized
+  NIL, ///< Config level no data.
   STRING, ///< View of a string.
   INTEGER, ///< Integer.
   BOOLEAN, ///< Boolean.
@@ -135,6 +136,9 @@ enum ValueType : int8_t {
   GENERIC, ///< Extended type.
 };
 
+/// Empty struct to represent a NIL / NULL runtime value.
+struct nil_value {};
+
 class ActiveType; // Forward declare
 
 namespace std {
@@ -145,6 +149,7 @@ template <> struct tuple_size<ValueType> : public std::integral_constant<size_t,
 /// Type list of feature types.
 using FeatureTypeList = swoc::meta::type_list<
       std::monostate
+    , nil_value
     , FeatureView
     , intmax_t
     , bool
@@ -159,7 +164,8 @@ using FeatureTypeList = swoc::meta::type_list<
 
 /// Variant index to feature type.
 constexpr std::array<ValueType, FeatureTypeList::size> FeatureIndexToValue {
-    NIL
+  NO_VALUE
+   , NIL
    , STRING
    , INTEGER
    , BOOLEAN
@@ -370,7 +376,7 @@ template < typename F > static constexpr ValueType value_type_of = ValueType(ind
 
 /// Nil value feature.
 /// @internal Default constructor doesn't work in the Intel compiler, must be explicit.
-static constexpr Feature NIL_FEATURE{};
+static constexpr Feature NIL_FEATURE{nil_value{}};
 
 /** Standard cons cell.
  *
@@ -803,12 +809,13 @@ template < typename T > let<T>::~let() { _var = _value; }
 
 // BufferWriter support.
 namespace swoc {
-BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, std::monostate);
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ValueType type);
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, FeatureTuple const& t);
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Feature const &feature);
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ValueMask const &mask);
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, feature_type_for<DURATION> const& d);
+BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, feature_type_for<NO_VALUE>);
+BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, feature_type_for<NIL>);
+BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, ValueType type);
+BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, FeatureTuple const& t);
+BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, Feature const &feature);
+BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, ValueMask const &mask);
+BufferWriter &bwformat(BufferWriter& w, bwf::Spec const& spec, feature_type_for<DURATION> const& d);
 //BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ActiveType const& type);
 }
 swoc::BufferWriter &bwformat(swoc::BufferWriter &w, swoc::bwf::Spec const& spec, Hook hook);

--- a/plugin/include/txn_box/ts_fwd.h
+++ b/plugin/include/txn_box/ts_fwd.h
@@ -7,5 +7,5 @@
 
 #pragma once
 
-using TSCont = struct tsapi_cont *;
+using TSCont    = struct tsapi_cont *;
 using TSHttpTxn = struct tsapi_httptxn *;

--- a/plugin/include/txn_box/ts_util.h
+++ b/plugin/include/txn_box/ts_util.h
@@ -848,6 +848,15 @@ const swoc::TextView URL_SCHEME_HTTP { TS_URL_SCHEME_HTTP, static_cast<size_t>(T
 const swoc::TextView URL_SCHEME_HTTPS { TS_URL_SCHEME_HTTPS, static_cast<size_t>(TS_URL_LEN_HTTPS) };
 
 extern const swoc::Lexicon<TSRecordDataType> TSRecordDataTypeNames;
+
+/** Search a query string for the value for a specific @a key.
+ *
+ * @param query_str Query string to search.
+ * @param search_key Key to find.
+ * @param caseless_p Match key caseinsensitive?
+ * @return
+ */
+extern swoc::TextView query_value_for(swoc::TextView query_str, swoc::TextView search_key, bool caseless_p = false);
 }; // namespace ts
 
 namespace swoc {

--- a/plugin/include/txn_box/ts_util.h
+++ b/plugin/include/txn_box/ts_util.h
@@ -27,12 +27,14 @@ Hook Convert_TS_Event_To_TxB_Hook(TSEvent ev);
 /// TxB values are compact so an array works fine.
 extern std::array<TSHttpHookID, std::tuple_size<Hook>::value> TS_Hook;
 
-namespace ts {
-
+namespace ts
+{
 class SSLContext;
 
-template<typename ... Args>
-void DebugMsg(swoc::TextView fmt, Args&& ... args) {
+template <typename... Args>
+void
+DebugMsg(swoc::TextView fmt, Args &&... args)
+{
   swoc::LocalBufferWriter<1024> w;
   auto arg_pack = std::forward_as_tuple(args...);
   w.print_v(fmt, arg_pack);
@@ -54,10 +56,11 @@ void DebugMsg(swoc::TextView fmt, Args&& ... args) {
  * @internal - why isn't this a @c std::unique_ptr with a specialized destructor? Because we
  * need the length?
  */
-class String {
+class String
+{
 public:
   String() = default; ///< Construct an empty instance.
-  ~String(); ///< Clean up string.
+  ~String();          ///< Clean up string.
 
   /** Construct from a TS allocated string.
    *
@@ -74,15 +77,25 @@ protected:
 
 inline ts::String::String(char *s, int64_t size) : _view{s, static_cast<size_t>(size)} {}
 
-inline String::~String() { if (_view.data()) { TSfree(const_cast<char *>(_view.data())); }}
+inline String::~String()
+{
+  if (_view.data()) {
+    TSfree(const_cast<char *>(_view.data()));
+  }
+}
 
-inline String::operator swoc::TextView() const { return _view; }
+inline String::operator swoc::TextView() const
+{
+  return _view;
+}
 
 /// TS configuration variable data as supported by the API.
 using ConfVarData = std::variant<std::monostate, intmax_t, double, swoc::TextView>;
 
 /// Convert to an absolute path in the TS configuration directory.
-inline swoc::file::path make_absolute(swoc::file::path&& path) {
+inline swoc::file::path
+make_absolute(swoc::file::path &&path)
+{
   if (path.is_relative()) {
     path = swoc::file::path(TSConfigDirGet()) / path;
   }
@@ -90,7 +103,9 @@ inline swoc::file::path make_absolute(swoc::file::path&& path) {
 }
 
 /// Convert to an absolute path in the TS configuration directory.
-inline swoc::file::path& make_absolute(swoc::file::path& path) {
+inline swoc::file::path &
+make_absolute(swoc::file::path &path)
+{
   if (path.is_relative()) {
     path = swoc::file::path(TSConfigDirGet()) / path;
   }
@@ -99,7 +114,13 @@ inline swoc::file::path& make_absolute(swoc::file::path& path) {
 
 /// Clean up an TS @c TSIOBuffer
 struct IOBufferDeleter {
-  void operator()(TSIOBuffer buff) { if (buff) { TSIOBufferDestroy(buff); }}
+  void
+  operator()(TSIOBuffer buff)
+  {
+    if (buff) {
+      TSIOBufferDestroy(buff);
+    }
+  }
 };
 
 /// Smart pointer to TS IO Buffer.
@@ -108,7 +129,8 @@ using IOBuffer = std::unique_ptr<std::remove_pointer<TSIOBuffer>::type, IOBuffer
 /** Generic base class for objects in the TS Header heaps.
  * All of these are represented by a buffer and a location.
  */
-class HeapObject {
+class HeapObject
+{
 public:
   HeapObject() = default;
 
@@ -123,26 +145,29 @@ public:
   /// Get the memory location handle.
   TSMLoc mloc() const;
 
-  HeapObject& clear();
+  HeapObject &clear();
 
 protected:
   TSMBuffer _buff = nullptr; ///< TS buffer handle.
-  TSMLoc _loc = nullptr; ///< TS memory locatio handle.
+  TSMLoc _loc     = nullptr; ///< TS memory locatio handle.
 };
 
-inline HeapObject& HeapObject::clear() {
+inline HeapObject &
+HeapObject::clear()
+{
   _buff = nullptr;
-  _loc = nullptr;
+  _loc  = nullptr;
   return *this;
 }
 
 class HttpHeader;
 
 /// A URL object.
-class URL : public HeapObject {
+class URL : public HeapObject
+{
   friend class HttpHeader;
 
-  using self_type = URL; ///< Self reference type.
+  using self_type  = URL;        ///< Self reference type.
   using super_type = HeapObject; ///< Parent type.
 public:
   URL() = default;
@@ -155,7 +180,7 @@ public:
    * @param w Destination buffer.
    * @return @a w
    */
-  swoc::BufferWriter& write_full(swoc::BufferWriter& w) const;
+  swoc::BufferWriter &write_full(swoc::BufferWriter &w) const;
 
   /** Get the network location
    *
@@ -171,10 +196,10 @@ public:
    *
    * @note If the port is not explicitly set, it is computed based on the scheme.
    */
-  in_port_t port() const; ///< Port.
-  swoc::TextView scheme() const; ///< View of the URL scheme.
-  swoc::TextView path() const; ///< View of the URL path.
-  swoc::TextView query() const; ///< View of the query.
+  in_port_t port() const;          ///< Port.
+  swoc::TextView scheme() const;   ///< View of the URL scheme.
+  swoc::TextView path() const;     ///< View of the URL path.
+  swoc::TextView query() const;    ///< View of the query.
   swoc::TextView fragment() const; ///< View of the fragment.
 
   /** Set the scheme for the URL.
@@ -182,18 +207,22 @@ public:
    * @param scheme Scheme as text.
    * @return @a this
    */
-  self_type& scheme_set(swoc::TextView const& scheme);
+  self_type &scheme_set(swoc::TextView const &scheme);
 
   /** Set the host in the URL.
    *
    * @param host Host.
    * @return @a this.
    */
-  self_type& host_set(swoc::TextView const& host);
+  self_type &host_set(swoc::TextView const &host);
 
-  static bool is_port_canonical(swoc::TextView const& scheme, in_port_t port);
+  static bool is_port_canonical(swoc::TextView const &scheme, in_port_t port);
 
-  bool is_port_canonical() const { return this->is_port_canonical(this->scheme(), this->port()); }
+  bool
+  is_port_canonical() const
+  {
+    return this->is_port_canonical(this->scheme(), this->port());
+  }
 
   /** Set the @a port in the URL.
    *
@@ -202,38 +231,44 @@ public:
    *
    * @note If the port matches the computed port of the scheme, it is not explicitly set.
    */
-  self_type& port_set(in_port_t port);
+  self_type &port_set(in_port_t port);
 
-  self_type& path_set(swoc::TextView path) {
+  self_type &
+  path_set(swoc::TextView path)
+  {
     TSUrlPathSet(_buff, _loc, path.data(), path.size());
     return *this;
   }
 
-  self_type& query_set(swoc::TextView text);
-  self_type& fragment_set(swoc::TextView text);
+  self_type &query_set(swoc::TextView text);
+  self_type &fragment_set(swoc::TextView text);
 };
 
-class HttpField : public HeapObject {
+class HttpField : public HeapObject
+{
   friend class HttpHeader;
 
-  using self_type = HttpField; ///< Self reference type.
+  using self_type  = HttpField;  ///< Self reference type.
   using super_type = HeapObject; ///< Parent type.
 public:
   HttpField() = default;
 
-  HttpField(self_type const&) = delete;
+  HttpField(self_type const &) = delete;
 
-  HttpField(self_type&& that) : super_type(that), _hdr(that._hdr) {
+  HttpField(self_type &&that) : super_type(that), _hdr(that._hdr)
+  {
     that._buff = nullptr;
-    that._hdr = nullptr;
-    that._loc = nullptr;
+    that._hdr  = nullptr;
+    that._loc  = nullptr;
   }
 
-  self_type& operator=(self_type const&) = delete;
+  self_type &operator=(self_type const &) = delete;
 
-  self_type& operator=(self_type&& that) {
+  self_type &
+  operator=(self_type &&that)
+  {
     this->~self_type();
-    new(this) self_type(std::move(that));
+    new (this) self_type(std::move(that));
     return *this;
   }
 
@@ -261,10 +296,10 @@ public:
    *
    * Duplicates are fields with the same name.
    */
-  self_type next_dup() const {
-    return this->is_valid()
-           ? self_type{_buff, _hdr, TSMimeHdrFieldNextDup(_buff, _hdr, _loc)}
-           : self_type{};
+  self_type
+  next_dup() const
+  {
+    return this->is_valid() ? self_type{_buff, _hdr, TSMimeHdrFieldNextDup(_buff, _hdr, _loc)} : self_type{};
   }
 
   /** Get the number of duplicates for this field.
@@ -273,9 +308,17 @@ public:
    */
   unsigned dup_count() const;
 
-  bool operator==(self_type const& that) { return _loc == that._loc; }
+  bool
+  operator==(self_type const &that)
+  {
+    return _loc == that._loc;
+  }
 
-  bool operator!=(self_type const& that) { return _loc != that._loc; }
+  bool
+  operator!=(self_type const &that)
+  {
+    return _loc != that._loc;
+  }
 
 protected:
   HttpField(TSMBuffer buff, TSMLoc hdr_loc, TSMLoc field_loc);
@@ -283,10 +326,11 @@ protected:
   TSMLoc _hdr = nullptr;
 };
 
-class HttpHeader : public HeapObject {
+class HttpHeader : public HeapObject
+{
   friend class HttpTxn;
 
-  using self_type = HttpHeader; ///< Self reference type.
+  using self_type  = HttpHeader; ///< Self reference type.
   using super_type = HeapObject; ///< Parent type.
 public:
   HttpHeader() = default;
@@ -322,12 +366,14 @@ public:
    * @param name Field name.
    * @return @a this.
    */
-  self_type& field_remove(swoc::TextView name);
+  self_type &field_remove(swoc::TextView name);
 };
 
-class HttpRequest : public HttpHeader {
-  using self_type = HttpRequest;
+class HttpRequest : public HttpHeader
+{
+  using self_type  = HttpRequest;
   using super_type = HttpHeader;
+
 public:
   /// Make super type constructors available.
   using super_type::super_type;
@@ -343,7 +389,7 @@ public:
    * @param arena Temporary memory to write the URL.
    * @return A view of the URL in @a arena.
    */
-  swoc::BufferWriter& effective_url(swoc::BufferWriter& w);
+  swoc::BufferWriter &effective_url(swoc::BufferWriter &w);
 
   swoc::TextView method() const;
 
@@ -375,7 +421,7 @@ public:
    * then it is unmodified and the @c Host field is set to @a host. If the URL has a host and
    * there is no @c Host field, only the URL is updated. The port is not updated.
    */
-  bool host_set(swoc::TextView const& host);
+  bool host_set(swoc::TextView const &host);
 
   /** Set the port.
    *
@@ -387,9 +433,11 @@ public:
   bool port_set(in_port_t port);
 };
 
-class HttpResponse : public HttpHeader {
-  using self_type = HttpResponse;
+class HttpResponse : public HttpHeader
+{
+  using self_type  = HttpResponse;
   using super_type = HttpHeader;
+
 public:
   /// Make super type constructors available.
   using super_type::super_type;
@@ -411,7 +459,8 @@ public:
 /** Wrapper for a TS C API session.
  *
  */
-class HttpSsn {
+class HttpSsn
+{
   friend class HttpTxn;
 
 public:
@@ -432,7 +481,7 @@ public:
    *
    * This is more efficient then obtaining the stack and then searching for @a tag.
    */
-  swoc::TextView proto_contains(swoc::TextView const& tag) const;
+  swoc::TextView proto_contains(swoc::TextView const &tag) const;
 
   /** Retrieve the protocol stack for @a this session in to @a tags.
    *
@@ -463,27 +512,48 @@ protected:
   HttpSsn(TSHttpSsn ssn) : _ssn(ssn) {}
 };
 
-class TxnConfigVar {
+class TxnConfigVar
+{
   using self_type = TxnConfigVar; ///< Self reference type.
 public:
-  TxnConfigVar(swoc::TextView const& name, TSOverridableConfigKey key, TSRecordDataType type);
+  TxnConfigVar(swoc::TextView const &name, TSOverridableConfigKey key, TSRecordDataType type);
 
-  swoc::TextView name() const { return _name; }
+  swoc::TextView
+  name() const
+  {
+    return _name;
+  }
 
-  TSOverridableConfigKey key() const { return _key; }
+  TSOverridableConfigKey
+  key() const
+  {
+    return _key;
+  }
 
-  TSRecordDataType type() const { return _ts_type; }
+  TSRecordDataType
+  type() const
+  {
+    return _ts_type;
+  }
 
   bool is_valid(intmax_t) const { return _ts_type == TS_RECORDDATATYPE_INT; }
 
-  bool is_valid(swoc::TextView const&) const { return _ts_type == TS_RECORDDATATYPE_STRING; }
+  bool
+  is_valid(swoc::TextView const &) const
+  {
+    return _ts_type == TS_RECORDDATATYPE_STRING;
+  }
 
-  bool is_valid(double) const { return _ts_type == TS_RECORDDATATYPE_FLOAT; }
+  bool
+  is_valid(double) const
+  {
+    return _ts_type == TS_RECORDDATATYPE_FLOAT;
+  }
 
-  template<typename T> bool is_valid(typename std::decay<T>::type) { return false; }
+  template <typename T> bool is_valid(typename std::decay<T>::type) { return false; }
 
 protected:
-  std::string _name; ///< Name.
+  std::string _name;           ///< Name.
   TSOverridableConfigKey _key; ///< override index value.
   TSRecordDataType _ts_type{TS_RECORDDATATYPE_NULL};
 };
@@ -492,7 +562,8 @@ protected:
  * This provides various utility methods, rather than having free functions that all take a
  * transaction instance.
  */
-class HttpTxn {
+class HttpTxn
+{
   using self_type = HttpTxn; ///< Self reference type.
 public:
   HttpTxn() = default;
@@ -554,7 +625,7 @@ public:
    * @param key Cache key for the retrieved object.
    * @return Errors, if any.
    */
-  swoc::Errata cache_key_assign(swoc::TextView const& key);
+  swoc::Errata cache_key_assign(swoc::TextView const &key);
 
   /// @return The session object for @a this transaction.
   HttpSsn ssn() const;
@@ -564,7 +635,7 @@ public:
    * @param addr Address to use for the upstream.
    * @return Errors, if any.
    */
-  bool set_upstream_addr(swoc::IPAddr const& addr) const;
+  bool set_upstream_addr(swoc::IPAddr const &addr) const;
 
   /** Assign @a n to the integer transaction overridable configuration @a var
    *
@@ -574,7 +645,7 @@ public:
    *
    * @note This does not check if @a var is in fact an integer, the caller must assure that.
    */
-  swoc::Errata override_assign(TxnConfigVar const& var, intmax_t n);
+  swoc::Errata override_assign(TxnConfigVar const &var, intmax_t n);
 
   /** Assign @a n to the string transaction overridable configuration @a var
    *
@@ -584,7 +655,7 @@ public:
    *
    * @note This does not check if @a var is in fact an string, the caller must assure that.
    */
-  swoc::Errata override_assign(TxnConfigVar const& var, swoc::TextView const& text);
+  swoc::Errata override_assign(TxnConfigVar const &var, swoc::TextView const &text);
 
   /** Assign @a n to the double transaction overridable configuration @a var
    *
@@ -594,16 +665,16 @@ public:
    *
    * @note This does not check if @a var is in fact an double, the caller must assure that.
    */
-  swoc::Errata override_assign(TxnConfigVar const& var, double f);
+  swoc::Errata override_assign(TxnConfigVar const &var, double f);
 
-  swoc::Rv<ConfVarData> override_fetch(TxnConfigVar const& var);
+  swoc::Rv<ConfVarData> override_fetch(TxnConfigVar const &var);
 
   /** Look up the transaction overridable configuration variable @a name.
    *
    * @param name Variable name.
    * @return The variable, or @a nullptr if @a name is not found to be a valid.
    */
-  static TxnConfigVar *find_override(swoc::TextView const& name);
+  static TxnConfigVar *find_override(swoc::TextView const &name);
 
   /** Retrieve transaction arg @a idx
    *
@@ -619,14 +690,14 @@ public:
    */
   void arg_assign(int idx, void *value);
 
-  static swoc::Rv<int> reserve_arg(swoc::TextView const& name, swoc::TextView const& description);
+  static swoc::Rv<int> reserve_arg(swoc::TextView const &name, swoc::TextView const &description);
 
   /** Perform DSO load time intialization.
    *
    * @param errata Current errors.
    * @return @a errata, updated with any additional errors.
    */
-  static swoc::Errata& init(swoc::Errata& errata);
+  static swoc::Errata &init(swoc::Errata &errata);
 
   /** Gets the number of transactions between the Traffic Server proxy and the
    *  origin server from a single session. Any value greater than zero indicates connection reuse.
@@ -654,20 +725,21 @@ protected:
    * @param text String to duplicate.
    * @return The duplicated string.
    */
-  swoc::MemSpan<char> ts_dup(swoc::TextView const& text);
+  swoc::MemSpan<char> ts_dup(swoc::TextView const &text);
 
-  static void config_bool_record(swoc::Errata& errata, swoc::TextView name);
+  static void config_bool_record(swoc::Errata &errata, swoc::TextView name);
 
-  static void config_integer_record(swoc::Errata& errata, swoc::TextView name);
+  static void config_integer_record(swoc::Errata &errata, swoc::TextView name);
 
-  static void config_integer_record(swoc::Errata& errata, swoc::TextView name, int min, int max);
+  static void config_integer_record(swoc::Errata &errata, swoc::TextView name, int min, int max);
 
-  static void config_string_record(swoc::Errata& errata, swoc::TextView name);
+  static void config_string_record(swoc::Errata &errata, swoc::TextView name);
 };
 
 /// An SSL context for a session.
-class SSLContext {
-  using self_type = SSLContext;
+class SSLContext
+{
+  using self_type     = SSLContext;
   struct ssl_st *_obj = nullptr;
 
   friend class HttpSsn;
@@ -693,7 +765,11 @@ protected:
   SSLContext(ssl_st *obj) : _obj(obj) {}
 };
 
-inline bool SSLContext::is_valid() const { return _obj != nullptr; }
+inline bool
+SSLContext::is_valid() const
+{
+  return _obj != nullptr;
+}
 
 // ----
 
@@ -702,20 +778,20 @@ inline bool SSLContext::is_valid() const { return _obj != nullptr; }
  * @param name Name to look up.
  * @return The SSL NID if found, @c NID_undef if not.
  */
-int ssl_nid(swoc::TextView const& name);
+int ssl_nid(swoc::TextView const &name);
 
 /** Get the stat index.
  *
  * @param name Stat name.
  * @return Index of the stat or negative if not found.
  */
-int plugin_stat_index(swoc::TextView const& name);
+int plugin_stat_index(swoc::TextView const &name);
 
 int plugin_stat_value(int idx);
 
 void plugin_stat_update(int idx, intmax_t value);
 
-swoc::Rv<int> plugin_stat_define(swoc::TextView const& name, int value, bool persistent_p);
+swoc::Rv<int> plugin_stat_define(swoc::TextView const &name, int value, bool persistent_p);
 
 /** Generate a NOTE log entry.
  *
@@ -723,7 +799,7 @@ swoc::Rv<int> plugin_stat_define(swoc::TextView const& name, int value, bool per
  *
  * @note Earlier versions of ATS will generate ERROR because NOTE
  */
-void Log_Note(swoc::TextView const& text);
+void Log_Note(swoc::TextView const &text);
 
 /** Generate a WARNING log entry.
  *
@@ -731,91 +807,119 @@ void Log_Note(swoc::TextView const& text);
  *
  * @warning Earlier versions of ATS will generate ERROR because WARNING
  */
-void Log_Warning(swoc::TextView const& text);
+void Log_Warning(swoc::TextView const &text);
 
 /** Generate a Error log entry.
  *
  * @param text Text of the message.
  */
-void Log_Error(swoc::TextView const& text);
+void Log_Error(swoc::TextView const &text);
 // ----
 
 struct TaskHandle {
   /// Wrapper for data needed when the event is dispatched.
   struct Data {
-    std::function<void()> _f; ///< Functor to dispatch.
+    std::function<void()> _f;         ///< Functor to dispatch.
     std::atomic<bool> _active = true; ///< Set @c false if the task has been canceled.
 
     /// Construct from functor @a f.
-    Data(std::function<void()>&& f) : _f(std::move(f)) {}
+    Data(std::function<void()> &&f) : _f(std::move(f)) {}
   };
 
   TSAction _action = nullptr; ///< Internal handle returned from task scheduling.
-  TSCont _cont = nullptr; ///< Continuation for @a _action.
+  TSCont _cont     = nullptr; ///< Continuation for @a _action.
 
   /// Cancel the task.
   void cancel();
 };
 
-TaskHandle PerformAsTask(std::function<void()>&& task);
+TaskHandle PerformAsTask(std::function<void()> &&task);
 
-TaskHandle PerformAsTaskEvery(std::function<void()>&& task, std::chrono::milliseconds period);
+TaskHandle PerformAsTaskEvery(std::function<void()> &&task, std::chrono::milliseconds period);
 
 inline HeapObject::HeapObject(TSMBuffer buff, TSMLoc loc) : _buff(buff), _loc(loc) {}
 
-inline bool HeapObject::is_valid() const { return _buff != nullptr && _loc != nullptr; }
+inline bool
+HeapObject::is_valid() const
+{
+  return _buff != nullptr && _loc != nullptr;
+}
 
-inline TSMBuffer HeapObject::mbuff() const { return _buff; }
+inline TSMBuffer
+HeapObject::mbuff() const
+{
+  return _buff;
+}
 
-inline TSMLoc HeapObject::mloc() const { return _loc; }
+inline TSMLoc
+HeapObject::mloc() const
+{
+  return _loc;
+}
 
 inline URL::URL(TSMBuffer buff, TSMLoc loc) : super_type(buff, loc) {}
 
-inline swoc::TextView URL::path() const {
+inline swoc::TextView
+URL::path() const
+{
   int length;
   auto text = TSUrlPathGet(_buff, _loc, &length);
   return {text, static_cast<size_t>(length)};
 }
 
-inline swoc::TextView URL::query() const {
+inline swoc::TextView
+URL::query() const
+{
   int length;
   auto text = TSUrlHttpQueryGet(_buff, _loc, &length);
   return text ? swoc::TextView{text, static_cast<size_t>(length)} : swoc::TextView{};
 }
 
-inline swoc::TextView URL::fragment() const {
+inline swoc::TextView
+URL::fragment() const
+{
   int length;
   auto text = TSUrlHttpFragmentGet(_buff, _loc, &length);
   return text ? swoc::TextView{text, static_cast<size_t>(length)} : swoc::TextView{};
 }
 
-inline URL &URL::host_set(swoc::TextView const& host) {
+inline URL &
+URL::host_set(swoc::TextView const &host)
+{
   if (this->is_valid()) {
     TSUrlHostSet(_buff, _loc, host.data(), host.size());
   }
   return *this;
 }
 
-inline auto URL::port_set(in_port_t port) -> self_type & {
+inline auto
+URL::port_set(in_port_t port) -> self_type &
+{
   TSUrlPortSet(_buff, _loc, port);
   return *this;
 }
 
-inline URL &URL::scheme_set(swoc::TextView const& scheme) {
+inline URL &
+URL::scheme_set(swoc::TextView const &scheme)
+{
   if (this->is_valid()) {
     TSUrlSchemeSet(_buff, _loc, scheme.data(), scheme.size());
   }
   return *this;
 }
 
-inline URL &URL::query_set(swoc::TextView text) {
+inline URL &
+URL::query_set(swoc::TextView text)
+{
   if (this->is_valid()) {
     TSUrlHttpQuerySet(_buff, _loc, text.data(), text.size());
   }
   return *this;
 }
 
-inline URL &URL::fragment_set(swoc::TextView text) {
+inline URL &
+URL::fragment_set(swoc::TextView text)
+{
   if (this->is_valid()) {
     TSUrlHttpFragmentSet(_buff, _loc, text.data(), text.size());
   }
@@ -826,26 +930,43 @@ inline HttpField::HttpField(TSMBuffer buff, TSMLoc hdr_loc, TSMLoc field_loc) : 
 
 inline HttpHeader::HttpHeader(TSMBuffer buff, TSMLoc loc) : super_type(buff, loc) {}
 
-inline TxnConfigVar::TxnConfigVar(swoc::TextView const &name, TSOverridableConfigKey key
-                           , TSRecordDataType type) : _name(name), _key(key), _ts_type(type) {}
+inline TxnConfigVar::TxnConfigVar(swoc::TextView const &name, TSOverridableConfigKey key, TSRecordDataType type)
+  : _name(name), _key(key), _ts_type(type)
+{
+}
 
-inline TSHttpStatus HttpResponse::status() const { return TSHttpHdrStatusGet(_buff, _loc); }
+inline TSHttpStatus
+HttpResponse::status() const
+{
+  return TSHttpHdrStatusGet(_buff, _loc);
+}
 
 inline HttpTxn::HttpTxn(TSHttpTxn txn) : _txn(txn) {}
 
-inline HttpTxn::operator TSHttpTxn() const { return _txn; }
+inline HttpTxn::operator TSHttpTxn() const
+{
+  return _txn;
+}
 
-inline HttpSsn HttpTxn::ssn() const { return _txn ? TSHttpTxnSsnGet(_txn) : nullptr; }
+inline HttpSsn
+HttpTxn::ssn() const
+{
+  return _txn ? TSHttpTxnSsnGet(_txn) : nullptr;
+}
 
-inline unsigned HttpSsn::txn_count() const { return TSHttpSsnTransactionCount(_ssn); };
+inline unsigned
+HttpSsn::txn_count() const
+{
+  return TSHttpSsnTransactionCount(_ssn);
+};
 
-const swoc::TextView HTTP_FIELD_HOST { TS_MIME_FIELD_HOST, static_cast<size_t>(TS_MIME_LEN_HOST) };
-const swoc::TextView HTTP_FIELD_LOCATION { TS_MIME_FIELD_LOCATION, static_cast<size_t>(TS_MIME_LEN_LOCATION) };
-const swoc::TextView HTTP_FIELD_CONTENT_LENGTH { TS_MIME_FIELD_CONTENT_LENGTH, static_cast<size_t>(TS_MIME_LEN_CONTENT_LENGTH) };
-const swoc::TextView HTTP_FIELD_CONTENT_TYPE { TS_MIME_FIELD_CONTENT_TYPE, static_cast<size_t>(TS_MIME_LEN_CONTENT_TYPE) };
+const swoc::TextView HTTP_FIELD_HOST{TS_MIME_FIELD_HOST, static_cast<size_t>(TS_MIME_LEN_HOST)};
+const swoc::TextView HTTP_FIELD_LOCATION{TS_MIME_FIELD_LOCATION, static_cast<size_t>(TS_MIME_LEN_LOCATION)};
+const swoc::TextView HTTP_FIELD_CONTENT_LENGTH{TS_MIME_FIELD_CONTENT_LENGTH, static_cast<size_t>(TS_MIME_LEN_CONTENT_LENGTH)};
+const swoc::TextView HTTP_FIELD_CONTENT_TYPE{TS_MIME_FIELD_CONTENT_TYPE, static_cast<size_t>(TS_MIME_LEN_CONTENT_TYPE)};
 
-const swoc::TextView URL_SCHEME_HTTP { TS_URL_SCHEME_HTTP, static_cast<size_t>(TS_URL_LEN_HTTP) };
-const swoc::TextView URL_SCHEME_HTTPS { TS_URL_SCHEME_HTTPS, static_cast<size_t>(TS_URL_LEN_HTTPS) };
+const swoc::TextView URL_SCHEME_HTTP{TS_URL_SCHEME_HTTP, static_cast<size_t>(TS_URL_LEN_HTTP)};
+const swoc::TextView URL_SCHEME_HTTPS{TS_URL_SCHEME_HTTPS, static_cast<size_t>(TS_URL_LEN_HTTPS)};
 
 extern const swoc::Lexicon<TSRecordDataType> TSRecordDataTypeNames;
 
@@ -859,19 +980,40 @@ extern const swoc::Lexicon<TSRecordDataType> TSRecordDataTypeNames;
 extern swoc::TextView query_value_for(swoc::TextView query_str, swoc::TextView search_key, bool caseless_p = false);
 }; // namespace ts
 
-namespace swoc {
-  BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, TSHttpStatus status);
-  BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, TSRecordDataType);
-  BufferWriter& bwformat(BufferWriter& w, bwf::Spec const& spec, ts::ConfVarData const&);
+namespace swoc
+{
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, TSHttpStatus status);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, TSRecordDataType);
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ts::ConfVarData const &);
 } // namespace swoc
 
-namespace std {
-
+namespace std
+{
 // Structured binding support for @c HeapObject.
-template<> class tuple_size<ts::HeapObject> : public std::integral_constant<size_t, 2> {};
-template<> class tuple_element<0, ts::HeapObject> { public: using type = TSMBuffer; };
-template<> class tuple_element<1, ts::HeapObject> { public: using type = TSMLoc; };
-template < size_t IDX > typename tuple_element<IDX, ts::HeapObject>::type get(ts::HeapObject const&);
-template <> inline TSMBuffer get<0>(ts::HeapObject const& obj) { return obj.mbuff(); }
-template <> inline TSMLoc get<1>(ts::HeapObject const& obj) { return obj.mloc(); }
+template <> class tuple_size<ts::HeapObject> : public std::integral_constant<size_t, 2>
+{
+};
+template <> class tuple_element<0, ts::HeapObject>
+{
+public:
+  using type = TSMBuffer;
+};
+template <> class tuple_element<1, ts::HeapObject>
+{
+public:
+  using type = TSMLoc;
+};
+template <size_t IDX> typename tuple_element<IDX, ts::HeapObject>::type get(ts::HeapObject const &);
+template <>
+inline TSMBuffer
+get<0>(ts::HeapObject const &obj)
+{
+  return obj.mbuff();
+}
+template <>
+inline TSMLoc
+get<1>(ts::HeapObject const &obj)
+{
+  return obj.mloc();
+}
 } // namespace std

--- a/plugin/include/txn_box/yaml_util.h
+++ b/plugin/include/txn_box/yaml_util.h
@@ -18,37 +18,78 @@
 // for ( auto const& [ key, value ] : node ) { ... }
 // for ( auto [ key, value ] : node) { ... }
 // lvalue reference doesn't work because the iterator returns a value, not a reference.
-namespace std {
-template<> class tuple_size<YAML::const_iterator::value_type> : public std::integral_constant<size_t, 2> {};
-template<> class tuple_element<0, YAML::const_iterator::value_type> { public: using type = const YAML::Node; };
-template<> class tuple_element<1, YAML::const_iterator::value_type> { public: using type = const YAML::Node; };
+namespace std
+{
+template <> class tuple_size<YAML::const_iterator::value_type> : public std::integral_constant<size_t, 2>
+{
+};
+template <> class tuple_element<0, YAML::const_iterator::value_type>
+{
+public:
+  using type = const YAML::Node;
+};
+template <> class tuple_element<1, YAML::const_iterator::value_type>
+{
+public:
+  using type = const YAML::Node;
+};
 
-template<> class tuple_size<YAML::iterator::value_type> : public std::integral_constant<size_t, 2> {};
-template<> class tuple_element<0, YAML::iterator::value_type> { public: using type = YAML::Node; };
-template<> class tuple_element<1, YAML::iterator::value_type> { public: using type = YAML::Node; };
+template <> class tuple_size<YAML::iterator::value_type> : public std::integral_constant<size_t, 2>
+{
+};
+template <> class tuple_element<0, YAML::iterator::value_type>
+{
+public:
+  using type = YAML::Node;
+};
+template <> class tuple_element<1, YAML::iterator::value_type>
+{
+public:
+  using type = YAML::Node;
+};
 } // namespace std
 
-template < size_t IDX > YAML::Node const& get(YAML::const_iterator::value_type const& v);
-template <> inline YAML::Node const& get<0>(YAML::const_iterator::value_type const& v) { return v
-.first; }
-template <> inline YAML::Node const& get<1>(YAML::const_iterator::value_type const& v) { return v
-.second; }
+template <size_t IDX> YAML::Node const &get(YAML::const_iterator::value_type const &v);
+template <>
+inline YAML::Node const &
+get<0>(YAML::const_iterator::value_type const &v)
+{
+  return v.first;
+}
+template <>
+inline YAML::Node const &
+get<1>(YAML::const_iterator::value_type const &v)
+{
+  return v.second;
+}
 
-template < size_t IDX > YAML::Node get(YAML::iterator::value_type& v);
-template <> inline YAML::Node get<0>(YAML::iterator::value_type& v) { return v.first; }
-template <> inline YAML::Node get<1>(YAML::iterator::value_type& v) { return v.second; }
+template <size_t IDX> YAML::Node get(YAML::iterator::value_type &v);
+template <>
+inline YAML::Node
+get<0>(YAML::iterator::value_type &v)
+{
+  return v.first;
+}
+template <>
+inline YAML::Node
+get<1>(YAML::iterator::value_type &v)
+{
+  return v.second;
+}
 
 // Providing formatting for the node mark - this prints out just the line.
-namespace swoc {
+namespace swoc
+{
 inline BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &, YAML::Mark const &mark) {
+bwformat(BufferWriter &w, bwf::Spec const &, YAML::Mark const &mark)
+{
   return w.print("Line {}", mark.line);
 }
 
 } // namespace swoc
 
 /// Merge key value for YAML map merging.
-static const std::string YAML_MERGE_KEY { "<<" };
+static const std::string YAML_MERGE_KEY{"<<"};
 /** Perform YAML merging on the tree starting at @a root.
  *
  * @param root Root node.
@@ -61,10 +102,10 @@ static const std::string YAML_MERGE_KEY { "<<" };
  */
 YAML::Node yaml_merge(YAML::Node root);
 
-swoc::Rv<YAML::Node> yaml_load(swoc::file::path const& path);
+swoc::Rv<YAML::Node> yaml_load(swoc::file::path const &path);
 
-namespace YAML {
-
+namespace YAML
+{
 // Need these to pass views in to node indexing.
 template <> struct convert<std::string_view> {
   static Node

--- a/plugin/src/Accelerator.cc
+++ b/plugin/src/Accelerator.cc
@@ -20,12 +20,10 @@ std::array<Accelerator::Builder, Accelerator::N_ACCELERATORS> Accelerator::_fact
 
 // --- //
 
-namespace {
-[[maybe_unused]] bool INITIALIZED = [] () -> bool {
-  return true;
-} ();
+namespace
+{
+[[maybe_unused]] bool INITIALIZED = []() -> bool { return true; }();
 
 // --- //
 
 } // namespace
-

--- a/plugin/src/Context.cc
+++ b/plugin/src/Context.cc
@@ -22,7 +22,9 @@ using swoc::ArenaWriter;
 using namespace swoc::literals;
 
 /* ------------------------------------------------------------------------------------ */
-bool Expr::bwf_ex::operator()(std::string_view &literal, Extractor::Spec &spec) {
+bool
+Expr::bwf_ex::operator()(std::string_view &literal, Extractor::Spec &spec)
+{
   bool zret = false;
   if (_iter->_type == swoc::bwf::Spec::LITERAL_TYPE) {
     literal = _iter->_ext;
@@ -39,14 +41,15 @@ bool Expr::bwf_ex::operator()(std::string_view &literal, Extractor::Spec &spec) 
 }
 /* ------------------------------------------------------------------------------------ */
 
-Context::Context(std::shared_ptr<Config> const& cfg) : _cfg(cfg) {
-  size_t reserved_size = G._remap_ctx_storage_required + ( cfg ? cfg->reserved_ctx_storage_size() : 0);
+Context::Context(std::shared_ptr<Config> const &cfg) : _cfg(cfg)
+{
+  size_t reserved_size = G._remap_ctx_storage_required + (cfg ? cfg->reserved_ctx_storage_size() : 0);
   // This is arranged so @a _arena destructor will clean up properly, nothing more need be done.
   _arena.reset(swoc::MemArena::construct_self_contained(4000 + reserved_size));
 
-  _rxp_ctx = pcre2_general_context_create([](PCRE2_SIZE size
-                                             , void *ctx) -> void * { return static_cast<self_type *>(ctx)->_arena->alloc(size).data(); }
-                                          , [](void *, void *) -> void {}, this);
+  _rxp_ctx = pcre2_general_context_create(
+    [](PCRE2_SIZE size, void *ctx) -> void * { return static_cast<self_type *>(ctx)->_arena->alloc(size).data(); },
+    [](void *, void *) -> void {}, this);
   if (cfg) {
     /// Make sure there are sufficient capture groups.
     this->rxp_match_require(cfg->_capture_groups);
@@ -59,19 +62,26 @@ Context::Context(std::shared_ptr<Config> const& cfg) : _cfg(cfg) {
   }
 }
 
-Context::~Context() {
+Context::~Context()
+{
   // Invoke all the finalizers to do additional cleanup.
-  for ( auto && f : _finalizers ) {
+  for (auto &&f : _finalizers) {
     f._f(f._ptr);
     std::destroy_at(&f._f); // clean up the cleaner too, just in case.
   }
 }
 
-swoc::Errata Context::Callback::invoke(Context& ctx) { return _drtv->invoke(ctx); }
+swoc::Errata
+Context::Callback::invoke(Context &ctx)
+{
+  return _drtv->invoke(ctx);
+}
 
-Errata Context::on_hook_do(Hook hook_idx, Directive *drtv) {
-  auto & info { _hooks[IndexFor(hook_idx)] };
-  if (! info.hook_set_p) { // no hook to invoke this directive, set one up.
+Errata
+Context::on_hook_do(Hook hook_idx, Directive *drtv)
+{
+  auto &info{_hooks[IndexFor(hook_idx)]};
+  if (!info.hook_set_p) { // no hook to invoke this directive, set one up.
     if (hook_idx >= _cur_hook) {
       TSHttpTxnHookAdd(_txn, TS_Hook[IndexFor(hook_idx)], _cont);
       info.hook_set_p = true;
@@ -83,27 +93,31 @@ Errata Context::on_hook_do(Hook hook_idx, Directive *drtv) {
   return {};
 }
 
-Errata Context::invoke_callbacks() {
+Errata
+Context::invoke_callbacks()
+{
   // Bit of subtlety here - directives / callbacks can be added to the list due to the action of the
   // invoked directive from this list. However, because this is an intrusive list and items are only
   // added to the end, the @c next pointer for the current item will be updated before the loop
   // iteration occurs and therefore new directives will be invoked.
-  auto & info { _hooks[IndexFor(_cur_hook)] };
-  for ( auto & cb : info.cb_list ) {
+  auto &info{_hooks[IndexFor(_cur_hook)]};
+  for (auto &cb : info.cb_list) {
     _terminal_p = false; // reset before each scheduled callback.
     cb.invoke(*this);
   }
   return {};
 }
 
-Errata Context::invoke_for_hook(Hook hook) {
+Errata
+Context::invoke_for_hook(Hook hook)
+{
   _cur_hook = hook;
   this->clear_cache();
 
   // Run the top level directives in the config first.
   if (_cfg) {
     for (auto const &handle : _cfg->hook_directives(hook)) {
-      _terminal_p = false; // reset before each top level invocation.
+      _terminal_p = false;   // reset before each top level invocation.
       handle->invoke(*this); // need to log errors here.
     }
   }
@@ -114,8 +128,10 @@ Errata Context::invoke_for_hook(Hook hook) {
   return {};
 }
 
-Errata Context::invoke_for_remap(Config &rule_cfg, TSRemapRequestInfo *rri) {
-  _cur_hook = Hook::REMAP;
+Errata
+Context::invoke_for_remap(Config &rule_cfg, TSRemapRequestInfo *rri)
+{
+  _cur_hook   = Hook::REMAP;
   _remap_info = rri;
   this->clear_cache();
   this->rxp_match_require(rule_cfg._capture_groups);
@@ -133,69 +149,81 @@ Errata Context::invoke_for_remap(Config &rule_cfg, TSRemapRequestInfo *rri) {
   // Now the global config directives for REMAP
   if (_cfg) {
     for (auto const &handle : _cfg->hook_directives(_cur_hook)) {
-      _terminal_p = false; // reset before each top level invocation.
+      _terminal_p = false;   // reset before each top level invocation.
       handle->invoke(*this); // need to log errors here.
     }
   }
   this->invoke_callbacks(); // Any accumulated callbacks.
 
   // Revert from remap style invocation.
-  _cur_hook = Hook::INVALID;
+  _cur_hook   = Hook::INVALID;
   _remap_info = nullptr;
 
   return {};
 }
 
-void Context::operator()(swoc::BufferWriter& w, Extractor::Spec const& spec) {
+void
+Context::operator()(swoc::BufferWriter &w, Extractor::Spec const &spec)
+{
   spec._exf->format(w, spec, *this);
 }
 
-Feature Expr::bwf_visitor::operator()(const Composite &comp) {
-  return _ctx.render_transient([&](BufferWriter & w) {
-    w.print_nfv(_ctx, bwf_ex{comp._specs}, Context::ArgPack(_ctx));
-  } );
+Feature
+Expr::bwf_visitor::operator()(const Composite &comp)
+{
+  return _ctx.render_transient([&](BufferWriter &w) { w.print_nfv(_ctx, bwf_ex{comp._specs}, Context::ArgPack(_ctx)); });
 }
 
-Feature Expr::bwf_visitor::operator()(List const & list) {
+Feature
+Expr::bwf_visitor::operator()(List const &list)
+{
   feature_type_for<TUPLE> expr_tuple = _ctx.alloc_span<Feature>(list._exprs.size());
-  unsigned idx = 0;
-  for ( auto const& expr : list._exprs ) {
-    Feature feature { _ctx.extract(expr) };
+  unsigned idx                       = 0;
+  for (auto const &expr : list._exprs) {
+    Feature feature{_ctx.extract(expr)};
     _ctx.commit(feature);
     expr_tuple[idx++] = feature;
   }
   return expr_tuple;
 }
 
-Feature Context::extract(Expr const &expr) {
+Feature
+Context::extract(Expr const &expr)
+{
   auto value = std::visit(Expr::bwf_visitor(*this), expr._raw);
-  for ( auto const& mod : expr._mods) {
+  for (auto const &mod : expr._mods) {
     value = (*mod)(*this, value);
   }
   return value;
 }
 
-FeatureView Context::extract_view(const Expr& expr, std::initializer_list<ViewOption> opts) {
+FeatureView
+Context::extract_view(const Expr &expr, std::initializer_list<ViewOption> opts)
+{
   FeatureView zret;
 
   bool commit_p = false;
-  bool cstr_p = false;
-  for ( auto opt : opts ) {
+  bool cstr_p   = false;
+  for (auto opt : opts) {
     switch (opt) {
-      case EX_COMMIT: commit_p = true; break;
-      case EX_C_STR: cstr_p = true; break;
+    case EX_COMMIT:
+      commit_p = true;
+      break;
+    case EX_C_STR:
+      cstr_p = true;
+      break;
     }
   }
 
   auto f = this->extract(expr);
   if (IndexFor(STRING) == f.index()) {
     auto view = std::get<IndexFor(STRING)>(f);
-    if (cstr_p && ! view._cstr_p) {
-      if (! view._literal_p && ! view._direct_p) { // in temporary memory
+    if (cstr_p && !view._cstr_p) {
+      if (!view._literal_p && !view._direct_p) { // in temporary memory
         // If there's room, just add the null terminator.
         if (auto span = _arena->remnant().rebind<char>(); span.data() == view.data_end()) {
           _arena->alloc(1);
-          span[0] = '\0';
+          span[0]      = '\0';
           view._cstr_p = true;
         } else {
           _arena->alloc(view.size()); // commit the view data and copy.
@@ -207,9 +235,9 @@ FeatureView Context::extract_view(const Expr& expr, std::initializer_list<ViewOp
         auto span = _arena->require(view.size() + 1).remnant().rebind<char>();
         memcpy(span, view);
         span[view.size()] = '\0';
-        view = span.view();
+        view              = span.view();
         view.remove_suffix(1); // drop null from view.
-        view._cstr_p = true;
+        view._cstr_p    = true;
         view._literal_p = false;
       }
     }
@@ -218,35 +246,37 @@ FeatureView Context::extract_view(const Expr& expr, std::initializer_list<ViewOp
     ArenaWriter w{*_arena};
     if (cstr_p) {
       w.print("{}\0", f);
-      zret = TextView{w.view()}.remove_suffix(1);
+      zret         = TextView{w.view()}.remove_suffix(1);
       zret._cstr_p = true;
     } else {
       w.print("{}", f);
       zret = w.view();
     }
   }
-  if (commit_p && ! zret._literal_p && ! zret._direct_p) {
+  if (commit_p && !zret._literal_p && !zret._direct_p) {
     _arena->alloc(zret.size() + (zret._cstr_p ? 1 : 0));
     zret._literal_p = true;
   }
   return zret;
 }
 
-FeatureView Context::commit(FeatureView const& view) {
-  FeatureView zret { view };
+FeatureView
+Context::commit(FeatureView const &view)
+{
+  FeatureView zret{view};
   if (view._literal_p) { // already committed.
   } else if (view._direct_p) {
-    auto span { _arena->alloc(view.size())};
+    auto span{_arena->alloc(view.size())};
     memcpy(span, view);
-    zret = span.view(); // update full to be the localized copy.
-    zret._direct_p = false;
+    zret            = span.view(); // update full to be the localized copy.
+    zret._direct_p  = false;
     zret._literal_p = true;
-  } else if ( auto r { _arena->remnant() } ; r.contains(view.data())) {
+  } else if (auto r{_arena->remnant()}; r.contains(view.data())) {
     // it's in transient memory, finalize it.
     // Need to commit everything before it as well.
     size_t n = (view.data() - r.rebind<char>().data()) + view.size();
     _arena->alloc(n);
-    _transient = (n >= _transient ? 0 : _transient - n);
+    _transient      = (n >= _transient ? 0 : _transient - n);
     zret._literal_p = true;
   } else if (_arena->contains(view.data())) { // it's already been committed, mark it so.
     zret._literal_p = true;
@@ -254,42 +284,54 @@ FeatureView Context::commit(FeatureView const& view) {
   return zret;
 }
 
-Feature& Context::commit(Feature &feature) {
-  if (auto fv = std::get_if<STRING>(&feature) ; fv != nullptr) {
+Feature &
+Context::commit(Feature &feature)
+{
+  if (auto fv = std::get_if<STRING>(&feature); fv != nullptr) {
     feature = this->commit(*fv);
   }
   return feature;
 }
 
-ts::HttpRequest Context::ua_req_hdr() {
+ts::HttpRequest
+Context::ua_req_hdr()
+{
   if (!_ua_req.is_valid()) {
     _ua_req = _txn.ua_req_hdr();
   }
   return _ua_req;
 }
 
-ts::HttpRequest Context::proxy_req_hdr() {
+ts::HttpRequest
+Context::proxy_req_hdr()
+{
   if (!_proxy_req.is_valid()) {
     _proxy_req = _txn.preq_hdr();
   }
   return _proxy_req;
 }
 
-ts::HttpResponse Context::upstream_rsp_hdr() {
+ts::HttpResponse
+Context::upstream_rsp_hdr()
+{
   if (!_upstream_rsp.is_valid()) {
     _upstream_rsp = _txn.ursp_hdr();
   }
   return _upstream_rsp;
 }
 
-ts::HttpResponse Context::proxy_rsp_hdr() {
+ts::HttpResponse
+Context::proxy_rsp_hdr()
+{
   if (!_proxy_rsp.is_valid()) {
     _proxy_rsp = _txn.prsp_hdr();
   }
   return _proxy_rsp;
 }
 
-Context::self_type &Context::enable_hooks(TSHttpTxn txn) {
+Context::self_type &
+Context::enable_hooks(TSHttpTxn txn)
+{
   // Create a continuation to hold the data.
   _cont = TSContCreate(ts_callback, TSContMutexGet(reinterpret_cast<TSCont>(txn)));
   TSContDataSet(_cont, this);
@@ -312,13 +354,15 @@ Context::self_type &Context::enable_hooks(TSHttpTxn txn) {
   return *this;
 }
 
-int Context::ts_callback(TSCont cont, TSEvent evt, void *) {
-  self_type * self = static_cast<self_type*>(TSContDataGet(cont));
-  auto txn = self->_txn; // cache for TXN_CLOSE.
+int
+Context::ts_callback(TSCont cont, TSEvent evt, void *)
+{
+  self_type *self      = static_cast<self_type *>(TSContDataGet(cont));
+  auto txn             = self->_txn; // cache for TXN_CLOSE.
   self->_global_status = TS_EVENT_HTTP_CONTINUE;
 
   // Run the directives.
-  Hook hook { Convert_TS_Event_To_TxB_Hook(evt) };
+  Hook hook{Convert_TS_Event_To_TxB_Hook(evt)};
   if (Hook::INVALID != hook) {
     self->invoke_for_hook(hook);
   }
@@ -334,32 +378,40 @@ int Context::ts_callback(TSCont cont, TSEvent evt, void *) {
   return TS_SUCCESS;
 }
 
-Context & Context::rxp_match_require(unsigned n) {
+Context &
+Context::rxp_match_require(unsigned n)
+{
   if (_rxp_n < n) {
     // Bump up at least 7, or 50%, or at least @a n.
-    n = std::max(_rxp_n + 7, n);
-    n = std::max((3 * _rxp_n) / 2 , n);
+    n            = std::max(_rxp_n + 7, n);
+    n            = std::max((3 * _rxp_n) / 2, n);
     _rxp_working = pcre2_match_data_create(n, _rxp_ctx);
-    _rxp_active = pcre2_match_data_create(n, _rxp_ctx);
-    _rxp_n = n;
+    _rxp_active  = pcre2_match_data_create(n, _rxp_ctx);
+    _rxp_n       = n;
   }
   return *this;
 }
 
-void Context::set_literal_capture(swoc::TextView text) {
+void
+Context::set_literal_capture(swoc::TextView text)
+{
   auto ovector = pcre2_get_ovector_pointer(_rxp_active);
-  ovector[0] = 0;
-  ovector[1] = text.size()-1;
-  _rxp_src = text;
+  ovector[0]   = 0;
+  ovector[1]   = text.size() - 1;
+  _rxp_src     = text;
 }
 
-pcre2_match_data * Context::rxp_commit_match(swoc::TextView const&src) {
+pcre2_match_data *
+Context::rxp_commit_match(swoc::TextView const &src)
+{
   _rxp_src = src;
   std::swap(_rxp_active, _rxp_working);
   return _rxp_active;
 }
 
-Feature const&Context::load_txn_var(swoc::TextView const&name) {
+Feature const &
+Context::load_txn_var(swoc::TextView const &name)
+{
   auto spot = _txn_vars.find(name);
   if (spot == _txn_vars.end()) {
     // Later, need to search ssn and global variables and retrieve those if found.
@@ -368,7 +420,9 @@ Feature const&Context::load_txn_var(swoc::TextView const&name) {
   return spot->_value;
 }
 
-Context::self_type&Context::store_txn_var(swoc::TextView const&name, Feature&value) {
+Context::self_type &
+Context::store_txn_var(swoc::TextView const &name, Feature &value)
+{
   auto spot = _txn_vars.find(name);
   this->commit(value);
   if (spot == _txn_vars.end()) {
@@ -379,22 +433,26 @@ Context::self_type&Context::store_txn_var(swoc::TextView const&name, Feature&val
   return *this;
 }
 
-TextView Context::localize_as_c_str(swoc::TextView text) {
+TextView
+Context::localize_as_c_str(swoc::TextView text)
+{
   // If it's empty or isn't already a C string, make a copy that is.
   if (text.empty() || '\0' != text.back()) {
     auto span = _arena->alloc_span<char>(text.size() + 1);
     memcpy(span, text);
     span[text.size()] = '\0';
-    text = span.view();
+    text              = span.view();
   }
   return text;
 }
 
-MemSpan<void> Context::overflow_storage_for(const ReservedSpan& span) {
+MemSpan<void>
+Context::overflow_storage_for(const ReservedSpan &span)
+{
   using T = decltype(_overflow_spans)::value_type;
   // Is this offset already in the list?
-  auto spot = std::find_if(_overflow_spans.begin(), _overflow_spans.end(),
-                           [&](auto const& item) { return item._offset == span.offset; });
+  auto spot =
+    std::find_if(_overflow_spans.begin(), _overflow_spans.end(), [&](auto const &item) { return item._offset == span.offset; });
   if (spot != _overflow_spans.end()) {
     return spot->_storage;
   }
@@ -411,20 +469,26 @@ MemSpan<void> Context::overflow_storage_for(const ReservedSpan& span) {
   return item->_storage;
 }
 
-swoc::MemSpan<char> Context::transient_buffer(size_t required) {
+swoc::MemSpan<char>
+Context::transient_buffer(size_t required)
+{
   this->commit_transient();
-  auto span { _arena->require(required).remnant().rebind<char>() };
+  auto span{_arena->require(required).remnant().rebind<char>()};
   _transient = TRANSIENT_ACTIVE;
   return span;
 }
 
-Context::self_type& Context::transient_require(size_t n) {
+Context::self_type &
+Context::transient_require(size_t n)
+{
   this->commit_transient();
   _arena->require(n);
   return *this;
 }
 
-Context::self_type& Context::commit_transient() {
+Context::self_type &
+Context::commit_transient()
+{
   if (_transient == TRANSIENT_ACTIVE) {
     throw std::logic_error("Recursive use of transient buffer in context");
   } else if (_transient) {
@@ -434,15 +498,22 @@ Context::self_type& Context::commit_transient() {
   return *this;
 }
 
-unsigned Context::ArgPack::count() const {
+unsigned
+Context::ArgPack::count() const
+{
   return pcre2_get_ovector_count(_ctx._rxp_active);
 }
 
-BufferWriter& Context::ArgPack::print(BufferWriter &w
-                                      , swoc::bwf::Spec const &spec, unsigned idx) const {
+BufferWriter &
+Context::ArgPack::print(BufferWriter &w, swoc::bwf::Spec const &spec, unsigned idx) const
+{
   auto ovector = pcre2_get_ovector_pointer(_ctx._rxp_active);
   idx *= 2; // To account for offset pairs.
-  return bwformat(w, spec, _ctx._rxp_src.substr(ovector[idx], ovector[idx+1] - ovector[idx]));
+  return bwformat(w, spec, _ctx._rxp_src.substr(ovector[idx], ovector[idx + 1] - ovector[idx]));
 }
 
-std::any Context::ArgPack::capture(unsigned) const { return "Bogus"_sv; }
+std::any
+Context::ArgPack::capture(unsigned) const
+{
+  return "Bogus"_sv;
+}

--- a/plugin/src/Directive.cc
+++ b/plugin/src/Directive.cc
@@ -16,14 +16,18 @@ using swoc::Rv;
 using swoc::TextView;
 
 /* ------------------------------------------------------------------------------------ */
-DirectiveList& DirectiveList::push_back(Directive::Handle &&d) {
+DirectiveList &
+DirectiveList::push_back(Directive::Handle &&d)
+{
   _directives.emplace_back(std::move(d));
   return *this;
 }
 
-Errata DirectiveList::invoke(Context &ctx) {
+Errata
+DirectiveList::invoke(Context &ctx)
+{
   Errata zret;
-  for ( auto const& drtv : _directives ) {
+  for (auto const &drtv : _directives) {
     zret.note(drtv->invoke(ctx));
     if (ctx.is_terminal()) {
       break;
@@ -33,7 +37,11 @@ Errata DirectiveList::invoke(Context &ctx) {
 }
 
 // Do nothing.
-swoc::Errata NilDirective::invoke(Context &) { return {}; }
+swoc::Errata
+NilDirective::invoke(Context &)
+{
+  return {};
+}
 /* ------------------------------------------------------------------------------------ */
 
 /* ------------------------------------------------------------------------------------ */

--- a/plugin/src/Ex_Base.cc
+++ b/plugin/src/Ex_Base.cc
@@ -27,66 +27,83 @@ using swoc::Rv;
 namespace bwf = swoc::bwf;
 using namespace swoc::literals;
 /* ------------------------------------------------------------------------------------ */
-class Ex_var : public Extractor {
+class Ex_var : public Extractor
+{
 public:
-  static constexpr TextView NAME { "var" };
+  static constexpr TextView NAME{"var"};
 
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Extractor::Spec const&) override;
+  Feature extract(Context &ctx, Extractor::Spec const &) override;
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_var::validate(class Config & cfg, struct Extractor::Spec & spec, const class swoc::TextView & arg) {
-  auto name = cfg.alloc_span<feature_type_for<STRING>>(1);
+Rv<ActiveType>
+Ex_var::validate(class Config &cfg, struct Extractor::Spec &spec, const class swoc::TextView &arg)
+{
+  auto name       = cfg.alloc_span<feature_type_for<STRING>>(1);
   spec._data.span = name.rebind<void>();
-  name[0] = cfg.localize(arg);
+  name[0]         = cfg.localize(arg);
   return ActiveType::any_type();
 }
 
-Feature Ex_var::extract(Context &ctx, Spec const& spec) {
+Feature
+Ex_var::extract(Context &ctx, Spec const &spec)
+{
   return ctx.load_txn_var(spec._data.span.rebind<feature_type_for<STRING>>()[0]);
 }
 
-BufferWriter& Ex_var::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_var::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_is_internal : public Extractor {
+class Ex_is_internal : public Extractor
+{
 public:
-  static constexpr TextView NAME { "is-internal" }; ///< Extractor name.
+  static constexpr TextView NAME{"is-internal"}; ///< Extractor name.
 
   /// Check argument and indicate possible feature types.
-  Rv<ActiveType> validate(Config &, Spec &, swoc::TextView const&) override { return ActiveType{BOOLEAN}; }
+  Rv<ActiveType>
+  validate(Config &, Spec &, swoc::TextView const &) override
+  {
+    return ActiveType{BOOLEAN};
+  }
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 
   /// Required text formatting access.
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context & ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-auto Ex_is_internal::extract(Context &ctx, Spec const&) -> Feature {
+auto
+Ex_is_internal::extract(Context &ctx, Spec const &) -> Feature
+{
   return ctx._txn.is_internal();
 }
 
-BufferWriter& Ex_is_internal::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_is_internal::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
 /// Random integer extractor.
-class Ex_random : public Extractor {
-  using self_type = Ex_random; ///< Self reference type.
+class Ex_random : public Extractor
+{
+  using self_type  = Ex_random; ///< Self reference type.
   using super_type = Extractor; ///< Parent type.
 public:
-  static constexpr TextView NAME { "random" }; ///< Extractor name.
+  static constexpr TextView NAME{"random"}; ///< Extractor name.
 
   /// Verify the arguments are a valid integer range.
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Extractor::Spec const& spec) override;
+  Feature extract(Context &ctx, Extractor::Spec const &spec) override;
 
 protected:
   /// Random generator.
@@ -96,21 +113,25 @@ protected:
 
 thread_local std::mt19937 Ex_random::_engine(std::chrono::high_resolution_clock::now().time_since_epoch().count());
 
-Feature Ex_random::extract(Context &, Extractor::Spec const& spec) {
+Feature
+Ex_random::extract(Context &, Extractor::Spec const &spec)
+{
   auto values = spec._data.span.rebind<feature_type_for<INTEGER>>();
   return std::uniform_int_distribution{values[0], values[1]}(_engine);
 };
 
-Rv<ActiveType> Ex_random::validate(Config &cfg, Extractor::Spec &spec, TextView const &arg) {
-  auto values = cfg.alloc_span<feature_type_for<INTEGER>>(2);
-  spec._data.span = values; // remember where the storage is.
+Rv<ActiveType>
+Ex_random::validate(Config &cfg, Extractor::Spec &spec, TextView const &arg)
+{
+  auto values                   = cfg.alloc_span<feature_type_for<INTEGER>>(2);
+  spec._data.span               = values;      // remember where the storage is.
   feature_type_for<INTEGER> min = 0, max = 99; // temporaries for parsing output.
   // Config storage for parsed output.
   values[0] = min;
   values[1] = max;
   // Parse the parameter.
   if (arg) {
-    auto max_arg { arg };
+    auto max_arg{arg};
     auto min_arg = max_arg.split_prefix_at(",-");
     TextView parsed;
     if (min_arg) {
@@ -134,43 +155,57 @@ Rv<ActiveType> Ex_random::validate(Config &cfg, Extractor::Spec &spec, TextView 
   // Update the stored values now that *both* input values are validated.
   values[0] = min;
   values[1] = max;
-  return { INTEGER };
+  return {INTEGER};
 }
 /* ------------------------------------------------------------------------------------ */
-template < typename T, const TextView* KEY> class Ex_duration : public Extractor {
-  using self_type = Ex_duration; ///< Self reference type.
-  using super_type = Extractor; ///< Parent type.
-  using ftype = feature_type_for<DURATION>;
-public:
-  static constexpr TextView NAME { *KEY };
+template <typename T, const TextView *KEY> class Ex_duration : public Extractor
+{
+  using self_type  = Ex_duration; ///< Self reference type.
+  using super_type = Extractor;   ///< Parent type.
+  using ftype      = feature_type_for<DURATION>;
 
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+public:
+  static constexpr TextView NAME{*KEY};
+
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Extractor::Spec const& spec) override;
+  Feature extract(Context &ctx, Extractor::Spec const &spec) override;
   /// Extract the feature from the config.
-  Feature extract(Config& cfg, Extractor::Spec const& spec) override;
+  Feature extract(Config &cfg, Extractor::Spec const &spec) override;
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-template < typename T, const TextView* KEY > Feature Ex_duration<T,KEY>::extract(Context &, Extractor::Spec const& spec) {
+template <typename T, const TextView *KEY>
+Feature
+Ex_duration<T, KEY>::extract(Context &, Extractor::Spec const &spec)
+{
   return spec._data.span.rebind<ftype>()[0];
 }
 
-template < typename T, const TextView* KEY > Feature Ex_duration<T,KEY>::extract(Config &, Extractor::Spec const& spec) {
+template <typename T, const TextView *KEY>
+Feature
+Ex_duration<T, KEY>::extract(Config &, Extractor::Spec const &spec)
+{
   return spec._data.span.rebind<ftype>()[0];
 }
 
-template < typename T, const TextView* KEY > BufferWriter& Ex_duration<T,KEY>::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx) {
+template <typename T, const TextView *KEY>
+BufferWriter &
+Ex_duration<T, KEY>::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-template < typename T, const TextView* KEY> Rv<ActiveType> Ex_duration<T,KEY>::validate(Config &cfg, Extractor::Spec &spec, TextView const &arg) {
-  auto span = cfg.alloc_span<ftype>(1);
+template <typename T, const TextView *KEY>
+Rv<ActiveType>
+Ex_duration<T, KEY>::validate(Config &cfg, Extractor::Spec &spec, TextView const &arg)
+{
+  auto span       = cfg.alloc_span<ftype>(1);
   spec._data.span = span; // remember where the storage is.
 
-  if (! arg) {
+  if (!arg) {
     return Error(R"("{}" extractor requires an integer argument.)", NAME);
   }
 
@@ -182,17 +217,18 @@ template < typename T, const TextView* KEY> Rv<ActiveType> Ex_duration<T,KEY>::v
 
   span[0] = T{n};
 
-  ActiveType zret { DURATION };
+  ActiveType zret{DURATION};
   zret.mark_cfg_const();
   return zret;
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_txn_conf : public Extractor {
-  using self_type = Ex_txn_conf; ///< Self reference type.
-  using super_type = Extractor; ///< Parent type.
-  using store_type = ts::TxnConfigVar*; ///< Storage type for config var record.
+class Ex_txn_conf : public Extractor
+{
+  using self_type  = Ex_txn_conf;        ///< Self reference type.
+  using super_type = Extractor;          ///< Parent type.
+  using store_type = ts::TxnConfigVar *; ///< Storage type for config var record.
 public:
-  static constexpr TextView NAME { "txn-conf" };
+  static constexpr TextView NAME{"txn-conf"};
 
   /** Validate the use of the extractor in a feature string.
    *
@@ -202,121 +238,155 @@ public:
    * @return The value type for @a spec and @a arg.
    *
    */
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Extractor::Spec const& spec) override;
+  Feature extract(Context &ctx, Extractor::Spec const &spec) override;
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_txn_conf::validate(Config &cfg, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_txn_conf::validate(Config &cfg, Spec &spec, const TextView &arg)
+{
   auto var = ts::HttpTxn::find_override(arg);
   if (nullptr == var) {
     return Error(R"("{}" is not a recognized transaction overridable configuration variable name.)", arg);
   }
-  auto ptr = cfg.alloc_span<store_type>(1);
-  ptr[0] = var;
+  auto ptr        = cfg.alloc_span<store_type>(1);
+  ptr[0]          = var;
   spec._data.span = ptr.rebind<void>(); // remember where the pointer is.
-  ValueType vt = NIL;
-  switch(var->type()) {
-    case TS_RECORDDATATYPE_INT : vt = INTEGER;
-      break;
-    case TS_RECORDDATATYPE_FLOAT : vt = FLOAT;
-      break;
-    case TS_RECORDDATATYPE_STRING : vt = STRING;
-      break;
-    default: break;
+  ValueType vt    = NIL;
+  switch (var->type()) {
+  case TS_RECORDDATATYPE_INT:
+    vt = INTEGER;
+    break;
+  case TS_RECORDDATATYPE_FLOAT:
+    vt = FLOAT;
+    break;
+  case TS_RECORDDATATYPE_STRING:
+    vt = STRING;
+    break;
+  default:
+    break;
   }
   return ActiveType{vt};
 }
 
-Feature Ex_txn_conf::extract(Context &ctx, const Extractor::Spec &spec) {
+Feature
+Ex_txn_conf::extract(Context &ctx, const Extractor::Spec &spec)
+{
   Feature zret;
-  auto var = spec._data.span.rebind<store_type>()[0];
-  auto && [ value , errata ] = ctx._txn.override_fetch(*var);
+  auto var               = spec._data.span.rebind<store_type>()[0];
+  auto &&[value, errata] = ctx._txn.override_fetch(*var);
   if (errata.is_ok()) {
     switch (value.index()) {
-      case 0: break;
-      case 1: zret = std::get<1>(value); break;
-      case 2: zret = std::get<2>(value); break;
-      case 3:
-        FeatureView v = std::get<3>(value);
-        v._direct_p = true;
-        zret = v;
-        break;
+    case 0:
+      break;
+    case 1:
+      zret = std::get<1>(value);
+      break;
+    case 2:
+      zret = std::get<2>(value);
+      break;
+    case 3:
+      FeatureView v = std::get<3>(value);
+      v._direct_p   = true;
+      zret          = v;
+      break;
     }
   }
   return zret;
 }
 
-BufferWriter & Ex_txn_conf::format(BufferWriter &w, const Spec &spec, Context &ctx) {
+BufferWriter &
+Ex_txn_conf::format(BufferWriter &w, const Spec &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
 /// The active feature.
-class Ex_active_feature : public Extractor {
-  using self_type = Ex_active_feature; ///< Self reference type.
-  using super_type = Extractor; ///< Parent type.
+class Ex_active_feature : public Extractor
+{
+  using self_type  = Ex_active_feature; ///< Self reference type.
+  using super_type = Extractor;         ///< Parent type.
 public:
   static constexpr TextView NAME = ACTIVE_FEATURE_KEY;
-  Rv<ActiveType> validate(Config & cfg, Spec &, TextView const&) override { return cfg.active_type(); }
-  Feature extract(Context& ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Rv<ActiveType>
+  validate(Config &cfg, Spec &, TextView const &) override
+  {
+    return cfg.active_type();
+  }
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_active_feature::extract(class Context & ctx, const struct Extractor::Spec &) {
+Feature
+Ex_active_feature::extract(class Context &ctx, const struct Extractor::Spec &)
+{
   return ctx._active;
 }
 
-BufferWriter& Ex_active_feature::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_active_feature::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, ctx._active);
 }
 
 /* ------------------------------------------------------------------------------------ */
 /// Remnant capture group.
-class Ex_unmatched_group : public Extractor {
-  using self_type = Ex_unmatched_group; ///< Self reference type.
-  using super_type = Extractor; ///< Parent type.
+class Ex_unmatched_group : public Extractor
+{
+  using self_type  = Ex_unmatched_group; ///< Self reference type.
+  using super_type = Extractor;          ///< Parent type.
 public:
   static constexpr TextView NAME = UNMATCHED_FEATURE_KEY;
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  Feature extract(Context& ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_unmatched_group::extract(class Context & ctx, const struct Extractor::Spec &) {
+Feature
+Ex_unmatched_group::extract(class Context &ctx, const struct Extractor::Spec &)
+{
   return ctx._remainder;
 }
 
-BufferWriter& Ex_unmatched_group::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_unmatched_group::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, ctx._remainder);
 }
 
 Rv<ActiveType>
-Ex_unmatched_group::validate(Config&, Extractor::Spec&, TextView const&) { return {STRING }; }
+Ex_unmatched_group::validate(Config &, Extractor::Spec &, TextView const &)
+{
+  return {STRING};
+}
 
 /* ------------------------------------------------------------------------------------ */
-class Ex_env : public StringExtractor {
-  using self_type = Ex_env; ///< Self reference type.
+class Ex_env : public StringExtractor
+{
+  using self_type  = Ex_env;          ///< Self reference type.
   using super_type = StringExtractor; ///< Parent type.
 public:
   static constexpr TextView NAME = "env";
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  Feature extract(Config& ctx, Spec const& spec) override;
-  Feature extract(Context& ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  Feature extract(Config &ctx, Spec const &spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
 Rv<ActiveType>
-Ex_env::validate(Config& cfg, Extractor::Spec& spec, TextView const& arg) {
-  auto span = cfg.alloc_span<TextView>(1);
+Ex_env::validate(Config &cfg, Extractor::Spec &spec, TextView const &arg)
+{
+  auto span       = cfg.alloc_span<TextView>(1);
   spec._data.span = span;
-  TextView & value = span[0];
+  TextView &value = span[0];
   char c_arg[arg.size() + 1];
   memcpy(c_arg, arg.data(), arg.size());
   c_arg[arg.size()] = 0;
-  if ( auto txt = ::getenv(c_arg) ; txt != nullptr ) {
+  if (auto txt = ::getenv(c_arg); txt != nullptr) {
     value = cfg.localize(txt);
   } else {
     value = "";
@@ -325,33 +395,48 @@ Ex_env::validate(Config& cfg, Extractor::Spec& spec, TextView const& arg) {
   return ActiveType{STRING}.mark_cfg_const();
 }
 
-Feature Ex_env::extract(Config&, const Spec& spec) {
+Feature
+Ex_env::extract(Config &, const Spec &spec)
+{
   return FeatureView::Literal(spec._data.span.rebind<TextView>()[0]);
 }
 
-Feature Ex_env::extract(Context&, const Spec& spec) {
+Feature
+Ex_env::extract(Context &, const Spec &spec)
+{
   return FeatureView::Literal(spec._data.span.rebind<TextView>()[0]);
 }
 
-BufferWriter& Ex_env::format(BufferWriter &w, Spec const &spec, Context &) {
+BufferWriter &
+Ex_env::format(BufferWriter &w, Spec const &spec, Context &)
+{
   return bwformat(w, spec, spec._data.span.rebind<TextView>()[0]);
 }
 
 /* ------------------------------------------------------------------------------------ */
-BufferWriter& Ex_this::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_this::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-Feature Ex_this::extract(class Context & ctx, Extractor::Spec const & spec) {
+Feature
+Ex_this::extract(class Context &ctx, Extractor::Spec const &spec)
+{
   return _fg ? _fg->extract(ctx, spec._ext) : NIL_FEATURE;
 }
 
-swoc::Rv<ActiveType> Ex_this::validate(Config& cfg, Extractor::Spec&, TextView const&) { return cfg.active_type(); }
+swoc::Rv<ActiveType>
+Ex_this::validate(Config &cfg, Extractor::Spec &, TextView const &)
+{
+  return cfg.active_type();
+}
 /* ------------------------------------------------------------------------------------ */
 // Needs to be external visible.
 Ex_this ex_this;
 
-namespace {
+namespace
+{
 // Extractors aren't constructed, they are always named references to singletons.
 // These are the singletons.
 Ex_var var;
@@ -366,7 +451,7 @@ Ex_env env;
 static constexpr TextView NANOSECONDS = "nanoseconds";
 Ex_duration<std::chrono::nanoseconds, &NANOSECONDS> nanoseconds;
 static constexpr TextView MILLISECONDS = "milliseconds";
-Ex_duration<std::chrono::milliseconds , &MILLISECONDS> milliseconds;
+Ex_duration<std::chrono::milliseconds, &MILLISECONDS> milliseconds;
 static constexpr TextView SECONDS = "seconds";
 Ex_duration<std::chrono::seconds, &SECONDS> seconds;
 static constexpr TextView MINUTES = "minutes";
@@ -381,7 +466,7 @@ Ex_duration<std::chrono::weeks, &WEEKS> weeks;
 Ex_active_feature ex_with_feature;
 Ex_unmatched_group unmatched_group;
 
-[[maybe_unused]] bool INITIALIZED = [] () -> bool {
+[[maybe_unused]] bool INITIALIZED = []() -> bool {
   Extractor::define(Ex_this::NAME, &ex_this);
   Extractor::define(Ex_active_feature::NAME, &ex_with_feature);
   Extractor::define(Ex_unmatched_group::NAME, &unmatched_group);
@@ -404,5 +489,5 @@ Ex_unmatched_group unmatched_group;
   Extractor::define(Ex_env::NAME, &env);
 
   return true;
-} ();
+}();
 } // namespace

--- a/plugin/src/Ex_HTTP.cc
+++ b/plugin/src/Ex_HTTP.cc
@@ -28,22 +28,24 @@ using namespace swoc::literals;
 
 /* ------------------------------------------------------------------------------------ */
 /// Utility functions.
-namespace {
-
+namespace
+{
 struct URLLocation {
-  ts::URL & url;
+  ts::URL &url;
 };
 
 struct ReqLocation {
-  ts::HttpRequest & req;
+  ts::HttpRequest &req;
 };
 
 } // namespace
 
-namespace swoc {
-
-BufferWriter & bwformat(BufferWriter & w, bwf::Spec const&, URLLocation const& url_loc) {
-  ts::URL & url { url_loc.url };
+namespace swoc
+{
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &, URLLocation const &url_loc)
+{
+  ts::URL &url{url_loc.url};
   auto host_name = url.host();
   if (!host_name.empty()) {
     auto port = url.port();
@@ -58,29 +60,35 @@ BufferWriter & bwformat(BufferWriter & w, bwf::Spec const&, URLLocation const& u
 
 } // namespace swoc
 /* ------------------------------------------------------------------------------------ */
-class Ex_ua_req_method : public StringExtractor {
+class Ex_ua_req_method : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-method" };
+  static constexpr TextView NAME{"ua-req-method"};
 
-  Feature extract(Context & ctx, Spec const& spec)  override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_ua_req_method::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
+Feature
+Ex_ua_req_method::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     return FeatureView::Direct(hdr.method());
   }
   return NIL_FEATURE;
 }
 
-class Ex_proxy_req_method : public StringExtractor {
+class Ex_proxy_req_method : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-method" };
+  static constexpr TextView NAME{"proxy-req-method"};
 
-  Feature extract(Context & ctx, Spec const& spec)  override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_proxy_req_method::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
+Feature
+Ex_proxy_req_method::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     return FeatureView::Direct(hdr.method());
   }
   return NIL_FEATURE;
@@ -90,25 +98,30 @@ Feature Ex_proxy_req_method::extract(Context &ctx, Spec const&) {
  * The C API doesn't provide direct access to a string for the URL, therefore the string
  * obtained here is transient.
  */
-class Ex_ua_req_url : public Extractor {
+class Ex_ua_req_url : public Extractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-url" };
+  static constexpr TextView NAME{"ua-req-url"};
 
-  Feature extract(Context & ctx, Spec const& spec)  override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_ua_req_url::extract(Context& ctx, const Spec&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
+Feature
+Ex_ua_req_url::extract(Context &ctx, const Spec &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
-      return ctx.render_transient([&](BufferWriter & w) { url.write_full(w); });
+      return ctx.render_transient([&](BufferWriter &w) { url.write_full(w); });
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_ua_req_url::format(BufferWriter &w, Spec const &, Context &ctx) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
+BufferWriter &
+Ex_ua_req_url::format(BufferWriter &w, Spec const &, Context &ctx)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       url.write_full(w);
     }
@@ -116,99 +129,119 @@ BufferWriter& Ex_ua_req_url::format(BufferWriter &w, Spec const &, Context &ctx)
   return w;
 }
 // ----
-class Ex_pre_remap_url : public Extractor {
+class Ex_pre_remap_url : public Extractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-url" };
+  static constexpr TextView NAME{"pre-remap-url"};
 
-  Feature extract(Context & ctx, Spec const& spec)  override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_pre_remap_url::extract(Context& ctx, const Spec&) {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
-    return ctx.render_transient([&](BufferWriter & w) { url.write_full(w); });
+Feature
+Ex_pre_remap_url::extract(Context &ctx, const Spec &)
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
+    return ctx.render_transient([&](BufferWriter &w) { url.write_full(w); });
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_pre_remap_url::format(BufferWriter &w, Spec const &, Context &ctx) {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
+BufferWriter &
+Ex_pre_remap_url::format(BufferWriter &w, Spec const &, Context &ctx)
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     url.write_full(w);
   }
   return w;
 }
 // ----
-class Ex_remap_target_url : public Extractor {
+class Ex_remap_target_url : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-target-url" };
+  static constexpr TextView NAME{"remap-target-url"};
 
-  Feature extract(Context & ctx, Spec const& spec)  override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_remap_target_url::extract(Context& ctx, const Spec&) {
-  if ( ctx._remap_info ) {
+Feature
+Ex_remap_target_url::extract(Context &ctx, const Spec &)
+{
+  if (ctx._remap_info) {
     if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
-      return ctx.render_transient([&](BufferWriter & w) { url.write_full(w); });
+      return ctx.render_transient([&](BufferWriter &w) { url.write_full(w); });
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_remap_target_url::format(BufferWriter &w, Spec const &, Context &ctx) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl } ; url.is_valid()) {
+BufferWriter &
+Ex_remap_target_url::format(BufferWriter &w, Spec const &, Context &ctx)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
       url.write_full(w);
     }
   }
   return w;
 }
 // ----
-class Ex_remap_replacement_url : public Extractor {
+class Ex_remap_replacement_url : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-replacement-url" };
+  static constexpr TextView NAME{"remap-replacement-url"};
 
-  Feature extract(Context & ctx, Spec const& spec)  override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_remap_replacement_url::extract(Context& ctx, const Spec&) {
-  if ( ctx._remap_info ) {
+Feature
+Ex_remap_replacement_url::extract(Context &ctx, const Spec &)
+{
+  if (ctx._remap_info) {
     if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
-      return ctx.render_transient([&](BufferWriter & w) { url.write_full(w); });
+      return ctx.render_transient([&](BufferWriter &w) { url.write_full(w); });
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_remap_replacement_url::format(BufferWriter &w, Spec const &, Context &ctx) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl } ; url.is_valid()) {
+BufferWriter &
+Ex_remap_replacement_url::format(BufferWriter &w, Spec const &, Context &ctx)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
       url.write_full(w);
     }
   }
   return w;
 }
 // ----
-class Ex_proxy_req_url : public Extractor {
+class Ex_proxy_req_url : public Extractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-url" };
+  static constexpr TextView NAME{"proxy-req-url"};
 
-  Feature extract(Context & ctx, Spec const& spec)  override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_proxy_req_url::extract(Context& ctx, const Spec&) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
+Feature
+Ex_proxy_req_url::extract(Context &ctx, const Spec &)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
-      return ctx.render_transient([&](BufferWriter & w) { url.write_full(w); });
+      return ctx.render_transient([&](BufferWriter &w) { url.write_full(w); });
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_proxy_req_url::format(BufferWriter &w, Spec const &, Context &ctx) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
+BufferWriter &
+Ex_proxy_req_url::format(BufferWriter &w, Spec const &, Context &ctx)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       url.write_full(w);
     }
@@ -216,80 +249,95 @@ BufferWriter& Ex_proxy_req_url::format(BufferWriter &w, Spec const &, Context &c
   return w;
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_ua_req_scheme : public StringExtractor {
+class Ex_ua_req_scheme : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-scheme" };
+  static constexpr TextView NAME{"ua-req-scheme"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_ua_req_scheme::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if ( auto url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_ua_req_scheme::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (auto url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.scheme());
     }
   }
   return NIL_FEATURE;
 }
 
-class Ex_pre_remap_scheme : public StringExtractor {
+class Ex_pre_remap_scheme : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-scheme" };
+  static constexpr TextView NAME{"pre-remap-scheme"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_pre_remap_scheme::extract(Context &ctx, Spec const&) {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
+Feature
+Ex_pre_remap_scheme::extract(Context &ctx, Spec const &)
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     return FeatureView::Direct(url.scheme());
   }
   return NIL_FEATURE;
 }
 
-class Ex_remap_target_scheme : public StringExtractor {
+class Ex_remap_target_scheme : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "remap-target-scheme" };
+  static constexpr TextView NAME{"remap-target-scheme"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_target_scheme::extract(Context &ctx, Spec const&) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl } ; url.is_valid()) {
+Feature
+Ex_remap_target_scheme::extract(Context &ctx, Spec const &)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
       return FeatureView::Direct(url.scheme());
     }
   }
   return NIL_FEATURE;
 }
 
-class Ex_remap_replacement_scheme : public StringExtractor {
+class Ex_remap_replacement_scheme : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "remap-replacement-scheme" };
+  static constexpr TextView NAME{"remap-replacement-scheme"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_replacement_scheme::extract(Context &ctx, Spec const&) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl } ; url.is_valid()) {
+Feature
+Ex_remap_replacement_scheme::extract(Context &ctx, Spec const &)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
       return FeatureView::Direct(url.scheme());
     }
   }
   return NIL_FEATURE;
 }
 
-class Ex_proxy_req_scheme : public StringExtractor {
+class Ex_proxy_req_scheme : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-scheme" };
+  static constexpr TextView NAME{"proxy-req-scheme"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_proxy_req_scheme::extract(Context &ctx, Spec const&) {
+Feature
+Ex_proxy_req_scheme::extract(Context &ctx, Spec const &)
+{
   FeatureView zret;
   zret._direct_p = true;
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.scheme());
     }
   }
@@ -297,40 +345,48 @@ Feature Ex_proxy_req_scheme::extract(Context &ctx, Spec const&) {
 }
 /* ------------------------------------------------------------------------------------ */
 /// The network location in the URL.
-class Ex_ua_req_loc : public StringExtractor {
-  using self_type = Ex_ua_req_loc;
+class Ex_ua_req_loc : public StringExtractor
+{
+  using self_type  = Ex_ua_req_loc;
   using super_type = StringExtractor;
-public:
-  static constexpr TextView NAME { "ua-req-loc" };
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+public:
+  static constexpr TextView NAME{"ua-req-loc"};
+
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_ua_req_loc::format(BufferWriter &w, Spec const & spec, Context &ctx) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if (auto field { hdr.field(ts::HTTP_FIELD_HOST)} ; field.is_valid()) {
+BufferWriter &
+Ex_ua_req_loc::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (auto field{hdr.field(ts::HTTP_FIELD_HOST)}; field.is_valid()) {
       bwformat(w, spec, field.value());
-    } else if (auto url { hdr.url() } ; url.is_valid()) {
+    } else if (auto url{hdr.url()}; url.is_valid()) {
       bwformat(w, spec, URLLocation{url});
     }
   }
   return w;
 }
 // ----
-class Ex_proxy_req_loc : public StringExtractor {
-  using self_type = Ex_proxy_req_loc;
+class Ex_proxy_req_loc : public StringExtractor
+{
+  using self_type  = Ex_proxy_req_loc;
   using super_type = StringExtractor;
-public:
-  static constexpr TextView NAME { "proxy-req-loc" };
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+public:
+  static constexpr TextView NAME{"proxy-req-loc"};
+
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_proxy_req_loc::format(BufferWriter &w, Spec const & spec, Context &ctx) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if (auto field { hdr.field(ts::HTTP_FIELD_HOST)} ; field.is_valid()) {
+BufferWriter &
+Ex_proxy_req_loc::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (auto field{hdr.field(ts::HTTP_FIELD_HOST)}; field.is_valid()) {
       bwformat(w, spec, field.value());
-    } else if (auto url { hdr.url() } ; url.is_valid()) {
+    } else if (auto url{hdr.url()}; url.is_valid()) {
       bwformat(w, spec, URLLocation{url});
     }
   }
@@ -338,73 +394,91 @@ BufferWriter& Ex_proxy_req_loc::format(BufferWriter &w, Spec const & spec, Conte
 }
 /* ------------------------------------------------------------------------------------ */
 /// Host name.
-class Ex_ua_req_host : public Extractor {
+class Ex_ua_req_host : public Extractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-host" };
+  static constexpr TextView NAME{"ua-req-host"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const&) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &) override;
 };
 
-Feature Ex_ua_req_host::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
+Feature
+Ex_ua_req_host::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     return FeatureView::Direct(hdr.host());
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_ua_req_host::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ua_req_host::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_proxy_req_host : public Extractor {
+class Ex_proxy_req_host : public Extractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-host" };
+  static constexpr TextView NAME{"proxy-req-host"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const&) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &) override;
 };
 
-Feature Ex_proxy_req_host::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
+Feature
+Ex_proxy_req_host::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     return FeatureView::Direct(hdr.host());
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_proxy_req_host::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_req_host::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_pre_remap_host : public Extractor {
+class Ex_pre_remap_host : public Extractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-host" };
+  static constexpr TextView NAME{"pre-remap-host"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_pre_remap_host::extract(Context &ctx, Spec const&) {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
+Feature
+Ex_pre_remap_host::extract(Context &ctx, Spec const &)
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     return FeatureView::Direct(url.host());
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_pre_remap_host::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_pre_remap_host::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_remap_target_host : public Extractor {
+class Ex_remap_target_host : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-target-host" };
+  static constexpr TextView NAME{"remap-target-host"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_target_host::extract(Context &ctx, Spec const&) {
-  if ( ctx._remap_info ) {
+Feature
+Ex_remap_target_host::extract(Context &ctx, Spec const &)
+{
+  if (ctx._remap_info) {
     if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
       return FeatureView::Direct(url.host());
     }
@@ -412,19 +486,24 @@ Feature Ex_remap_target_host::extract(Context &ctx, Spec const&) {
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_remap_target_host::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_remap_target_host::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_remap_replacement_host : public Extractor {
+class Ex_remap_replacement_host : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-replacement-host" };
+  static constexpr TextView NAME{"remap-replacement-host"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_replacement_host::extract(Context &ctx, Spec const&) {
+Feature
+Ex_remap_replacement_host::extract(Context &ctx, Spec const &)
+{
   if (ctx._remap_info) {
     if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
       return FeatureView::Direct(url.host());
@@ -433,147 +512,182 @@ Feature Ex_remap_replacement_host::extract(Context &ctx, Spec const&) {
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_remap_replacement_host::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_remap_replacement_host::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
 /// Destination IP port.
-class Ex_ua_req_port : public Extractor {
+class Ex_ua_req_port : public Extractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-port" };
+  static constexpr TextView NAME{"ua-req-port"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_ua_req_port::extract(Context &ctx, Spec const&) {
+Feature
+Ex_ua_req_port::extract(Context &ctx, Spec const &)
+{
   Feature zret;
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());
     }
   }
   return zret;
 }
 
-BufferWriter& Ex_ua_req_port::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ua_req_port::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_proxy_req_port : public Extractor {
+class Ex_proxy_req_port : public Extractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-port" };
+  static constexpr TextView NAME{"proxy-req-port"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_proxy_req_port::extract(Context &ctx, Spec const&) {
+Feature
+Ex_proxy_req_port::extract(Context &ctx, Spec const &)
+{
   Feature zret;
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());
     }
   }
   return zret;
 }
-BufferWriter& Ex_proxy_req_port::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_req_port::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
 /// URL path.
-class Ex_ua_req_path : public Extractor {
+class Ex_ua_req_path : public Extractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-path" };
+  static constexpr TextView NAME{"ua-req-path"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_ua_req_path::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_ua_req_path::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.path());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_ua_req_path::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ua_req_path::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_pre_remap_path : public Extractor {
+class Ex_pre_remap_path : public Extractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-path" };
+  static constexpr TextView NAME{"pre-remap-path"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_pre_remap_path::extract(Context &ctx, Spec const&) {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
+Feature
+Ex_pre_remap_path::extract(Context &ctx, Spec const &)
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     return FeatureView::Direct(url.path());
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_pre_remap_path::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_pre_remap_path::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_remap_target_path : public Extractor {
+class Ex_remap_target_path : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-target-path" };
+  static constexpr TextView NAME{"remap-target-path"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_target_path::extract(Context &ctx, Spec const&) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl } ; url.is_valid()) {
+Feature
+Ex_remap_target_path::extract(Context &ctx, Spec const &)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
       return FeatureView::Direct(url.path());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_remap_target_path::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_remap_target_path::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_remap_replacement_path : public Extractor {
+class Ex_remap_replacement_path : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-replacement-path" };
+  static constexpr TextView NAME{"remap-replacement-path"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_replacement_path::extract(Context &ctx, Spec const&) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl } ; url.is_valid()) {
+Feature
+Ex_remap_replacement_path::extract(Context &ctx, Spec const &)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
       return FeatureView::Direct(url.path());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_remap_replacement_path::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_remap_replacement_path::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_proxy_req_path : public Extractor {
+class Ex_proxy_req_path : public Extractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-path" };
+  static constexpr TextView NAME{"proxy-req-path"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_proxy_req_path::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_proxy_req_path::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.path());
     }
   }
@@ -584,22 +698,25 @@ Feature Ex_proxy_req_path::extract(Context &ctx, Spec const&) {
 // These have the @c extract method because it can be done as a @c Direct
 // value and that's better than running through the formatting.
 
-class QueryValueExtractor : public Extractor {
+class QueryValueExtractor : public Extractor
+{
 public:
-  Rv<ActiveType> validate(Config& cfg, Spec& spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 
 protected:
   TextView _arg;
 
   /// @return The key (name) for the extractor.
-  virtual TextView const& key() const = 0;
+  virtual TextView const &key() const = 0;
   /// @return The appropriate query string.
-  virtual TextView query_string(Context& ctx) const = 0;
+  virtual TextView query_string(Context &ctx) const = 0;
 };
 
-Rv<ActiveType> QueryValueExtractor::validate(Config& cfg, Spec& spec, const TextView& arg) {
+Rv<ActiveType>
+QueryValueExtractor::validate(Config &cfg, Spec &spec, const TextView &arg)
+{
   if (arg.empty()) {
     return Error("Extractor \"{}\" requires a key name argument.", this->key());
   }
@@ -607,7 +724,9 @@ Rv<ActiveType> QueryValueExtractor::validate(Config& cfg, Spec& spec, const Text
   return ActiveType{NIL, STRING};
 }
 
-Feature QueryValueExtractor::extract(Context& ctx, const Spec& spec) {
+Feature
+QueryValueExtractor::extract(Context &ctx, const Spec &spec)
+{
   auto qs = this->query_string(ctx);
   if (qs.empty()) {
     return NIL_FEATURE;
@@ -624,40 +743,53 @@ Feature QueryValueExtractor::extract(Context& ctx, const Spec& spec) {
 
 // --
 
-class Ex_ua_req_query : public StringExtractor {
+class Ex_ua_req_query : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-query" };
+  static constexpr TextView NAME{"ua-req-query"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_ua_req_query::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_ua_req_query::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.query());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_ua_req_query::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ua_req_query::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_ua_req_query_value : public QueryValueExtractor {
+class Ex_ua_req_query_value : public QueryValueExtractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-query-value" };
+  static constexpr TextView NAME{"ua-req-query-value"};
+
 protected:
-  TextView const& key() const override;
-  TextView query_string(Context& ctx) const override;
+  TextView const &key() const override;
+  TextView query_string(Context &ctx) const override;
 };
 
-TextView const& Ex_ua_req_query_value::key() const { return NAME; }
+TextView const &
+Ex_ua_req_query_value::key() const
+{
+  return NAME;
+}
 
-TextView Ex_ua_req_query_value::query_string(Context& ctx) const {
-  if (auto hdr { ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if (ts::URL url { hdr.url() } ; url.is_valid()) {
+TextView
+Ex_ua_req_query_value::query_string(Context &ctx) const
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return url.query();
     }
   }
@@ -666,37 +798,50 @@ TextView Ex_ua_req_query_value::query_string(Context& ctx) const {
 
 // --
 
-class Ex_pre_remap_query : public StringExtractor {
+class Ex_pre_remap_query : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-query" };
+  static constexpr TextView NAME{"pre-remap-query"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_pre_remap_query::extract(Context &ctx, Spec const&) {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
+Feature
+Ex_pre_remap_query::extract(Context &ctx, Spec const &)
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     return FeatureView::Direct(url.query());
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_pre_remap_query::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_pre_remap_query::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_pre_remap_req_query_value : public QueryValueExtractor {
+class Ex_pre_remap_req_query_value : public QueryValueExtractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-req-query-value" };
+  static constexpr TextView NAME{"pre-remap-req-query-value"};
+
 protected:
-  TextView const& key() const override;
-  TextView query_string(Context& ctx) const override;
+  TextView const &key() const override;
+  TextView query_string(Context &ctx) const override;
 };
 
-TextView const& Ex_pre_remap_req_query_value::key() const { return NAME; }
+TextView const &
+Ex_pre_remap_req_query_value::key() const
+{
+  return NAME;
+}
 
-TextView Ex_pre_remap_req_query_value::query_string(Context& ctx) const {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
+TextView
+Ex_pre_remap_req_query_value::query_string(Context &ctx) const
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     return url.query();
   }
   return {};
@@ -704,40 +849,53 @@ TextView Ex_pre_remap_req_query_value::query_string(Context& ctx) const {
 
 // --
 
-class Ex_proxy_req_query : public StringExtractor {
+class Ex_proxy_req_query : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-query" };
+  static constexpr TextView NAME{"proxy-req-query"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_proxy_req_query::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_proxy_req_query::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.query());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_proxy_req_query::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_req_query::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_proxy_req_query_value : public QueryValueExtractor {
+class Ex_proxy_req_query_value : public QueryValueExtractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-query-value" };
+  static constexpr TextView NAME{"proxy-req-query-value"};
+
 protected:
-  TextView const& key() const override;
-  TextView query_string(Context& ctx) const override;
+  TextView const &key() const override;
+  TextView query_string(Context &ctx) const override;
 };
 
-TextView const& Ex_proxy_req_query_value::key() const { return NAME; }
+TextView const &
+Ex_proxy_req_query_value::key() const
+{
+  return NAME;
+}
 
-TextView Ex_proxy_req_query_value::query_string(Context& ctx) const {
-  if (auto hdr { ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if (ts::URL url { hdr.url() } ; url.is_valid()) {
+TextView
+Ex_proxy_req_query_value::query_string(Context &ctx) const
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return url.query();
     }
   }
@@ -748,304 +906,370 @@ TextView Ex_proxy_req_query_value::query_string(Context& ctx) const {
 // Fragment.
 // These have the @c extract method because it can be done as a @c Direct
 // value and that's better than running through the formatting.
-class Ex_ua_req_fragment : public StringExtractor {
+class Ex_ua_req_fragment : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-fragment" };
+  static constexpr TextView NAME{"ua-req-fragment"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_ua_req_fragment::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_ua_req_fragment::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.fragment());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_ua_req_fragment::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ua_req_fragment::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_pre_remap_fragment : public StringExtractor {
+class Ex_pre_remap_fragment : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-fragment" };
+  static constexpr TextView NAME{"pre-remap-fragment"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_pre_remap_fragment::extract(Context &ctx, Spec const&) {
-  if ( auto url {ctx._txn.pristine_url_get() } ; url.is_valid()) {
+Feature
+Ex_pre_remap_fragment::extract(Context &ctx, Spec const &)
+{
+  if (auto url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     return FeatureView::Direct(url.fragment());
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_pre_remap_fragment::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_pre_remap_fragment::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-class Ex_proxy_req_fragment : public StringExtractor {
+class Ex_proxy_req_fragment : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-fragment" };
+  static constexpr TextView NAME{"proxy-req-fragment"};
 
-  Feature extract(Context & ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Feature Ex_proxy_req_fragment::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_proxy_req_fragment::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.fragment());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_proxy_req_fragment::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_req_fragment::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
 /* ------------------------------------------------------------------------------------ */
 /// The network location in the URL.
-class Ex_ua_req_url_loc : public StringExtractor {
+class Ex_ua_req_url_loc : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-url-loc" };
+  static constexpr TextView NAME{"ua-req-url-loc"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_ua_req_url_loc::format(BufferWriter &w, Spec const & spec, Context &ctx) {
-  if (auto hdr { ctx.ua_req_hdr()} ; hdr.is_valid()) {
-    if (auto url { hdr.url()} ; url.is_valid()) {
+BufferWriter &
+Ex_ua_req_url_loc::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (auto url{hdr.url()}; url.is_valid()) {
       bwformat(w, spec, URLLocation{url});
     }
   }
   return w;
 }
 // ----
-class Ex_proxy_req_url_loc : public StringExtractor {
+class Ex_proxy_req_url_loc : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-url-loc" };
+  static constexpr TextView NAME{"proxy-req-url-loc"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_proxy_req_url_loc::format(BufferWriter &w, Spec const & spec, Context &ctx) {
-  if (auto hdr { ctx.proxy_req_hdr()} ; hdr.is_valid()) {
-    if (auto url { hdr.url()} ; url.is_valid()) {
+BufferWriter &
+Ex_proxy_req_url_loc::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (auto url{hdr.url()}; url.is_valid()) {
       bwformat(w, spec, URLLocation{url});
     }
   }
   return w;
 }
 // ----
-class Ex_pre_remap_loc : public StringExtractor {
+class Ex_pre_remap_loc : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-req-loc" };
+  static constexpr TextView NAME{"pre-remap-req-loc"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_pre_remap_loc::format(BufferWriter &w, Spec const &spec, Context &ctx) {
-  if ( ts::URL url { ctx._txn.pristine_url_get() } ; url.is_valid()) {
+BufferWriter &
+Ex_pre_remap_loc::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
+  if (ts::URL url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     bwformat(w, spec, URLLocation{url});
   }
   return w;
 }
 // ----
-class Ex_remap_target_loc : public StringExtractor {
+class Ex_remap_target_loc : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "remap-target-loc" };
+  static constexpr TextView NAME{"remap-target-loc"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_remap_target_loc::format(BufferWriter &w, Spec const & spec, Context &ctx) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl } ; url.is_valid()) {
+BufferWriter &
+Ex_remap_target_loc::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
       bwformat(w, spec, URLLocation{url});
     }
   }
   return w;
 }
 // ----
-class Ex_remap_replacement_loc : public StringExtractor {
+class Ex_remap_replacement_loc : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "remap-replacement-loc" };
+  static constexpr TextView NAME{"remap-replacement-loc"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_remap_replacement_loc::format(BufferWriter &w, Spec const &spec, Context &ctx) {
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl } ; url.is_valid()) {
+BufferWriter &
+Ex_remap_replacement_loc::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
       bwformat(w, spec, URLLocation{url});
     }
   }
   return w;
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_ua_req_url_host : public Extractor {
+class Ex_ua_req_url_host : public Extractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-url-host" };
+  static constexpr TextView NAME{"ua-req-url-host"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_ua_req_url_host::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_ua_req_url_host::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.host());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_ua_req_url_host::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ua_req_url_host::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_proxy_req_url_host : public Extractor {
+class Ex_proxy_req_url_host : public Extractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-url-host" };
+  static constexpr TextView NAME{"proxy-req-url-host"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_proxy_req_url_host::extract(Context &ctx, Spec const&) {
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+Feature
+Ex_proxy_req_url_host::extract(Context &ctx, Spec const &)
+{
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       return FeatureView::Direct(url.host());
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_proxy_req_url_host::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_req_url_host::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_ua_req_url_port : public Extractor {
+class Ex_ua_req_url_port : public Extractor
+{
 public:
-  static constexpr TextView NAME { "ua-req-url-port" };
+  static constexpr TextView NAME{"ua-req-url-port"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_ua_req_url_port::extract(Context &ctx, Spec const&) {
+Feature
+Ex_ua_req_url_port::extract(Context &ctx, Spec const &)
+{
   FeatureView zret;
   zret._direct_p = true;
-  if ( auto hdr {ctx.ua_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+  if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       zret = url.host();
     }
   }
   return zret;
 }
 
-BufferWriter& Ex_ua_req_url_port::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ua_req_url_port::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_proxy_req_url_port : public Extractor {
+class Ex_proxy_req_url_port : public Extractor
+{
 public:
-  static constexpr TextView NAME { "proxy-req-url-port" };
+  static constexpr TextView NAME{"proxy-req-url-port"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_proxy_req_url_port::extract(Context &ctx, Spec const&) {
+Feature
+Ex_proxy_req_url_port::extract(Context &ctx, Spec const &)
+{
   FeatureView zret;
   zret._direct_p = true;
-  if ( auto hdr {ctx.proxy_req_hdr() } ; hdr.is_valid()) {
-    if ( ts::URL url { hdr.url() } ; url.is_valid()) {
+  if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
+    if (ts::URL url{hdr.url()}; url.is_valid()) {
       zret = url.host();
     }
   }
   return zret;
 }
 
-BufferWriter& Ex_proxy_req_url_port::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_req_url_port::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_pre_remap_port : public Extractor {
+class Ex_pre_remap_port : public Extractor
+{
 public:
-  static constexpr TextView NAME { "pre-remap-port" };
+  static constexpr TextView NAME{"pre-remap-port"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_pre_remap_port::extract(Context &ctx, Spec const&) {
+Feature
+Ex_pre_remap_port::extract(Context &ctx, Spec const &)
+{
   Feature zret;
-  if ( auto url {ctx._txn.pristine_url_get() } ; url.is_valid()) {
+  if (auto url{ctx._txn.pristine_url_get()}; url.is_valid()) {
     zret = static_cast<feature_type_for<INTEGER>>(url.port());
   }
   return zret;
 }
 
-BufferWriter& Ex_pre_remap_port::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_pre_remap_port::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_remap_target_port : public Extractor {
+class Ex_remap_target_port : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-target-port" };
+  static constexpr TextView NAME{"remap-target-port"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_target_port::extract(Context &ctx, Spec const&) {
+Feature
+Ex_remap_target_port::extract(Context &ctx, Spec const &)
+{
   Feature zret;
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl } ; url.is_valid()) {
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());
     }
   }
   return zret;
 }
 
-BufferWriter& Ex_remap_target_port::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_remap_target_port::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 // ----
-class Ex_remap_replacement_port : public Extractor {
+class Ex_remap_replacement_port : public Extractor
+{
 public:
-  static constexpr TextView NAME { "remap-replacement-port" };
+  static constexpr TextView NAME{"remap-replacement-port"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_remap_replacement_port::extract(Context &ctx, Spec const&) {
+Feature
+Ex_remap_replacement_port::extract(Context &ctx, Spec const &)
+{
   Feature zret;
-  if ( ctx._remap_info ) {
-    if (ts::URL url { ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl } ; url.is_valid()) {
+  if (ctx._remap_info) {
+    if (ts::URL url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl}; url.is_valid()) {
       zret = static_cast<feature_type_for<INTEGER>>(url.port());
     }
   }
   return zret;
 }
 
-BufferWriter& Ex_remap_replacement_port::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_remap_replacement_port::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
-class ExHttpField : public Extractor {
+class ExHttpField : public Extractor
+{
 public:
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 
 protected:
   struct Data {
@@ -1060,7 +1284,7 @@ protected:
   };
 
   /// @return The key (name) for the extractor.
-  virtual TextView const& key() const = 0;
+  virtual TextView const &key() const = 0;
 
   /** Get the appropriate @c HttpHeader.
    *
@@ -1069,38 +1293,42 @@ protected:
    *
    * This is used by subclasses to specify which HTTP header in the transaction is in play.
    */
-  virtual ts::HttpHeader hdr(Context & ctx) const = 0;
+  virtual ts::HttpHeader hdr(Context &ctx) const = 0;
 };
 
-Rv<ActiveType> ExHttpField::validate(Config& cfg, Extractor::Spec& spec, TextView const& arg) {
-  auto span = cfg.alloc_span<Data>(1);
+Rv<ActiveType>
+ExHttpField::validate(Config &cfg, Extractor::Spec &spec, TextView const &arg)
+{
+  auto span       = cfg.alloc_span<Data>(1);
   spec._data.span = span;
-  auto & data = span[0];
-  data.opt.all = 0;
-  data._arg = cfg.localize(arg);
+  auto &data      = span[0];
+  data.opt.all    = 0;
+  data._arg       = cfg.localize(arg);
   if (0 == strcasecmp(spec._ext, "by-field"_tv)) {
     data.opt.f.by_field = true;
   } else if (0 == strcasecmp(spec._ext, "by-value"_tv)) {
     data.opt.f.by_value = true;
   }
-  return ActiveType{ NIL, STRING, ActiveType::TupleOf(STRING) };
+  return ActiveType{NIL, STRING, ActiveType::TupleOf(STRING)};
 }
 
-Feature ExHttpField::extract(Context &ctx, const Spec &spec) {
-  Data & data = spec._data.span.rebind<Data>()[0];
+Feature
+ExHttpField::extract(Context &ctx, const Spec &spec)
+{
+  Data &data = spec._data.span.rebind<Data>()[0];
   if (data.opt.f.by_field) {
     return NIL_FEATURE;
   } else if (data.opt.f.by_value) {
     return NIL_FEATURE;
   }
 
-  if ( ts::HttpHeader hdr { this->hdr(ctx) } ; hdr.is_valid()) {
-    if ( auto field { hdr.field(data._arg) } ; field.is_valid()) {
+  if (ts::HttpHeader hdr{this->hdr(ctx)}; hdr.is_valid()) {
+    if (auto field{hdr.field(data._arg)}; field.is_valid()) {
       if (field.next_dup().is_valid()) {
-        auto n = field.dup_count();
+        auto n    = field.dup_count();
         auto span = ctx.alloc_span<Feature>(n);
-        for ( auto & item : span) {
-          item = field.value();
+        for (auto &item : span) {
+          item  = field.value();
           field = field.next_dup();
         }
         return span;
@@ -1113,151 +1341,205 @@ Feature ExHttpField::extract(Context &ctx, const Spec &spec) {
 };
 
 // -----
-class Ex_ua_req_field : public ExHttpField {
+class Ex_ua_req_field : public ExHttpField
+{
 public:
-  static constexpr TextView NAME { "ua-req-field" };
+  static constexpr TextView NAME{"ua-req-field"};
 
 protected:
-  TextView const& key() const override;
-  ts::HttpHeader hdr(Context & ctx) const override;
+  TextView const &key() const override;
+  ts::HttpHeader hdr(Context &ctx) const override;
 };
 
-TextView const& Ex_ua_req_field::key() const { return NAME; }
-ts::HttpHeader Ex_ua_req_field::hdr(Context & ctx) const {
+TextView const &
+Ex_ua_req_field::key() const
+{
+  return NAME;
+}
+ts::HttpHeader
+Ex_ua_req_field::hdr(Context &ctx) const
+{
   return ctx.ua_req_hdr();
 }
 // -----
-class Ex_proxy_req_field : public ExHttpField {
+class Ex_proxy_req_field : public ExHttpField
+{
 public:
-  static constexpr TextView NAME { "proxy-req-field" };
+  static constexpr TextView NAME{"proxy-req-field"};
 
 protected:
-  TextView const& key() const override;
-  ts::HttpHeader hdr(Context & ctx) const override;
+  TextView const &key() const override;
+  ts::HttpHeader hdr(Context &ctx) const override;
 };
 
-TextView const& Ex_proxy_req_field::key() const { return NAME; }
-ts::HttpHeader Ex_proxy_req_field::hdr(Context & ctx) const {
+TextView const &
+Ex_proxy_req_field::key() const
+{
+  return NAME;
+}
+ts::HttpHeader
+Ex_proxy_req_field::hdr(Context &ctx) const
+{
   return ctx.proxy_req_hdr();
 }
 // -----
-class Ex_proxy_rsp_field : public ExHttpField {
+class Ex_proxy_rsp_field : public ExHttpField
+{
 public:
-  static constexpr TextView NAME { "proxy-rsp-field" };
+  static constexpr TextView NAME{"proxy-rsp-field"};
 
 protected:
-  TextView const& key() const override;
-  ts::HttpHeader hdr(Context & ctx) const override;
+  TextView const &key() const override;
+  ts::HttpHeader hdr(Context &ctx) const override;
 };
 
-TextView const& Ex_proxy_rsp_field::key() const { return NAME; }
-ts::HttpHeader Ex_proxy_rsp_field::hdr(Context & ctx) const {
+TextView const &
+Ex_proxy_rsp_field::key() const
+{
+  return NAME;
+}
+ts::HttpHeader
+Ex_proxy_rsp_field::hdr(Context &ctx) const
+{
   return ctx.proxy_rsp_hdr();
 }
 // -----
-class Ex_upstream_rsp_field : public ExHttpField {
+class Ex_upstream_rsp_field : public ExHttpField
+{
 public:
-  static constexpr TextView NAME { "upstream-rsp-field" };
+  static constexpr TextView NAME{"upstream-rsp-field"};
 
 protected:
-  TextView const& key() const override;
-  ts::HttpHeader hdr(Context & ctx) const override;
+  TextView const &key() const override;
+  ts::HttpHeader hdr(Context &ctx) const override;
 };
 
-TextView const& Ex_upstream_rsp_field::key() const { return NAME; }
-ts::HttpHeader Ex_upstream_rsp_field::hdr(Context & ctx) const {
+TextView const &
+Ex_upstream_rsp_field::key() const
+{
+  return NAME;
+}
+ts::HttpHeader
+Ex_upstream_rsp_field::hdr(Context &ctx) const
+{
   return ctx.upstream_rsp_hdr();
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_upstream_rsp_status : public Extractor {
+class Ex_upstream_rsp_status : public Extractor
+{
 public:
-  static constexpr TextView NAME { "upstream-rsp-status" };
+  static constexpr TextView NAME{"upstream-rsp-status"};
 
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Extractor::Spec const&) override;
+  Feature extract(Context &ctx, Extractor::Spec const &) override;
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_upstream_rsp_status::validate(Config &, Spec &, TextView const&) {
-  return { INTEGER };
+Rv<ActiveType>
+Ex_upstream_rsp_status::validate(Config &, Spec &, TextView const &)
+{
+  return {INTEGER};
 }
 
-Feature Ex_upstream_rsp_status::extract(Context &ctx, Extractor::Spec const&) {
+Feature
+Ex_upstream_rsp_status::extract(Context &ctx, Extractor::Spec const &)
+{
   return static_cast<feature_type_for<INTEGER>>(ctx._txn.ursp_hdr().status());
 }
 
-BufferWriter& Ex_upstream_rsp_status::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_upstream_rsp_status::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, ctx._txn.ursp_hdr().status());
 }
 // ----
-class Ex_upstream_rsp_status_reason : public StringExtractor {
+class Ex_upstream_rsp_status_reason : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "upstream-rsp-status-reason" };
+  static constexpr TextView NAME{"upstream-rsp-status-reason"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_upstream_rsp_status_reason::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_upstream_rsp_status_reason::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, ctx._txn.ursp_hdr().reason());
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_proxy_rsp_status : public Extractor {
+class Ex_proxy_rsp_status : public Extractor
+{
 public:
-  static constexpr TextView NAME { "proxy-rsp-status" };
+  static constexpr TextView NAME{"proxy-rsp-status"};
 
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Extractor::Spec const&) override;
+  Feature extract(Context &ctx, Extractor::Spec const &) override;
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_proxy_rsp_status::validate(Config &, Spec &, TextView const&) {
-  return { INTEGER };
+Rv<ActiveType>
+Ex_proxy_rsp_status::validate(Config &, Spec &, TextView const &)
+{
+  return {INTEGER};
 }
 
-Feature Ex_proxy_rsp_status::extract(Context &ctx, Extractor::Spec const&) {
+Feature
+Ex_proxy_rsp_status::extract(Context &ctx, Extractor::Spec const &)
+{
   return static_cast<feature_type_for<INTEGER>>(ctx._txn.prsp_hdr().status());
 }
 
-BufferWriter& Ex_proxy_rsp_status::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_rsp_status::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, ctx._txn.prsp_hdr().status());
 }
 // ----
-class Ex_proxy_rsp_status_reason : public StringExtractor {
+class Ex_proxy_rsp_status_reason : public StringExtractor
+{
 public:
-  static constexpr TextView NAME { "proxy-rsp-status-reason" };
+  static constexpr TextView NAME{"proxy-rsp-status-reason"};
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-BufferWriter& Ex_proxy_rsp_status_reason::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_proxy_rsp_status_reason::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, ctx._txn.prsp_hdr().reason());
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_outbound_txn_count : public Extractor {
+class Ex_outbound_txn_count : public Extractor
+{
 public:
-  static constexpr TextView NAME { "outbound-txn-count" };
+  static constexpr TextView NAME{"outbound-txn-count"};
 
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Extractor::Spec const&) override;
+  Feature extract(Context &ctx, Extractor::Spec const &) override;
 };
 
-Rv<ActiveType> Ex_outbound_txn_count::validate(Config &, Spec &, TextView const&) {
-  return { INTEGER };
+Rv<ActiveType>
+Ex_outbound_txn_count::validate(Config &, Spec &, TextView const &)
+{
+  return {INTEGER};
 }
 
-Feature Ex_outbound_txn_count::extract(Context &ctx, Extractor::Spec const&) {
+Feature
+Ex_outbound_txn_count::extract(Context &ctx, Extractor::Spec const &)
+{
   return static_cast<feature_type_for<INTEGER>>(ctx._txn.outbound_txn_count());
 }
 /* ------------------------------------------------------------------------------------ */
-namespace {
+namespace
+{
 // Extractors aren't constructed, they are always named references to singletons.
 // These are the singletons.
 
@@ -1330,7 +1612,7 @@ Ex_outbound_txn_count outbound_txn_count;
 
 Ex_ua_req_query_value ua_req_query_value;
 
-[[maybe_unused]] bool INITIALIZED = [] () -> bool {
+[[maybe_unused]] bool INITIALIZED = []() -> bool {
   Extractor::define(Ex_ua_req_method::NAME, &ua_req_method);
   Extractor::define(Ex_proxy_req_method::NAME, &proxy_req_method);
 
@@ -1411,5 +1693,5 @@ Ex_ua_req_query_value ua_req_query_value;
   Extractor::define(Ex_upstream_rsp_field::NAME, &upstream_rsp_field);
 
   return true;
-} ();
+}();
 } // namespace

--- a/plugin/src/Ex_HTTP.cc
+++ b/plugin/src/Ex_HTTP.cc
@@ -1008,7 +1008,7 @@ Feature ExHttpField::extract(Context &ctx, const Spec &spec) {
       }
     }
   }
-  return {};
+  return NIL_FEATURE;
 };
 
 BufferWriter& ExHttpField::format(BufferWriter &w, Spec const &spec, Context &ctx) {

--- a/plugin/src/Ex_Ssn.cc
+++ b/plugin/src/Ex_Ssn.cc
@@ -122,13 +122,12 @@ Rv<ActiveType> Ex_has_inbound_protocol_prefix::validate(Config& cfg, Extractor::
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument to use as a protocol prefix.)", NAME);
   }
-  auto local = cfg.localize(arg, Config::LOCAL_CSTR);
-  spec._data = MemSpan<char>(const_cast<char*>(local.data()), local.size());
+  spec._data.text = cfg.localize(arg, Config::LOCAL_CSTR);
   return {BOOLEAN};
 }
 
 auto Ex_has_inbound_protocol_prefix::extract(Context &ctx, Spec const& spec) -> Feature {
-  return { ! ctx._txn.ssn().proto_contains(spec._data.view()).empty() };
+  return { ! ctx._txn.ssn().proto_contains(spec._data.text).empty() };
 }
 
 BufferWriter& Ex_has_inbound_protocol_prefix::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx) {
@@ -187,13 +186,12 @@ Rv<ActiveType> Ex_inbound_protocol::validate(Config &cfg, Spec &spec, const Text
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument to use as a protocol prefix.)", NAME);
   }
-  auto local = cfg.localize(arg, Config::LOCAL_CSTR);
-  spec._data = swoc::MemSpan<char>(const_cast<char*>(local.data()), local.size());
+  spec._data.text = cfg.localize(arg, Config::LOCAL_CSTR);
   return { STRING };
 }
 
 BufferWriter& Ex_inbound_protocol::format(BufferWriter &w, Spec const &spec, Context &ctx) {
-  auto tag = ctx._txn.ssn().proto_contains(spec._data.view());
+  auto tag = ctx._txn.ssn().proto_contains(spec._data.text);
   return bwformat(w, spec, tag);
 }
 /* ------------------------------------------------------------------------------------ */
@@ -235,14 +233,13 @@ Rv<ActiveType> Ex_inbound_cert_local_issuer_value::validate(Config &, Spec &spec
   if (NID_undef == nid) {
     return Error(R"("{}" is not a valid certificate issuer name in "{}" extractor.)", arg, NAME);
   }
-  // Sigh - abuse the memspan and use the size as the integer value.
-  spec._data = { nullptr, size_t(nid)};
+  spec._data.u = nid;
   return { STRING };
 }
 
 BufferWriter& Ex_inbound_cert_local_issuer_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.size();
+  auto nid = spec._data.u;
   return bwformat(w, spec, ssl_ctx.local_issuer_value(nid));
 }
 
@@ -266,14 +263,13 @@ Rv<ActiveType> Ex_inbound_cert_local_subject_value::validate(Config &, Spec &spe
   if (NID_undef == nid) {
     return Error(R"("{}" is not a valid certificate subject name in "{}" extractor.)", arg, NAME);
   }
-  // Sigh - abuse the memspan and use the size as the integer value.
-  spec._data = { nullptr, size_t(nid)};
+  spec._data.u = nid;
   return { STRING };
 }
 
 BufferWriter& Ex_inbound_cert_local_subject_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.size();
+  auto nid = spec._data.u;
   return bwformat(w, spec, ssl_ctx.local_subject_value(nid));
 }
 
@@ -298,13 +294,13 @@ Rv<ActiveType> Ex_inbound_cert_remote_issuer_value::validate(Config &, Spec &spe
     return Error(R"("{}" is not a valid certificate issuer name in "{}" extractor.)", arg, NAME);
   }
   // Sigh - abuse the memspan and use the size as the integer value.
-  spec._data = { nullptr, size_t(nid)};
+  spec._data.u = nid;
   return { STRING };
 }
 
 BufferWriter& Ex_inbound_cert_remote_issuer_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.size();
+  auto nid = spec._data.u;
   return bwformat(w, spec, ssl_ctx.remote_issuer_value(nid));
 }
 
@@ -329,13 +325,13 @@ Rv<ActiveType> Ex_inbound_cert_remote_subject_value::validate(Config &, Spec &sp
     return Error(R"("{}" is not a valid certificate subject name in "{}" extractor.)", arg, NAME);
   }
   // Sigh - abuse the memspan and use the size as the integer value.
-  spec._data = { nullptr, size_t(nid)};
+  spec._data.u = nid;
   return { STRING };
 }
 
 BufferWriter& Ex_inbound_cert_remote_subject_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.size();
+  auto nid = spec._data.u;
   return bwformat(w, spec, ssl_ctx.remote_subject_value(nid));
 }
 /* ------------------------------------------------------------------------------------ */

--- a/plugin/src/Ex_Ssn.cc
+++ b/plugin/src/Ex_Ssn.cc
@@ -25,22 +25,23 @@ using swoc::BufferWriter;
 using swoc::Errata;
 using swoc::Rv;
 using swoc::MemSpan;
-//namespace bwf = swoc::bwf;
-//using namespace swoc::literals;
+// namespace bwf = swoc::bwf;
+// using namespace swoc::literals;
 
 /* ------------------------------------------------------------------------------------ */
 /** Extract the number of transactions for the inbound session.
  */
-class Ex_inbound_txn_count : public Extractor {
+class Ex_inbound_txn_count : public Extractor
+{
 public:
   /// Extractor name.
-  static constexpr TextView NAME { "inbound-txn-count" };
+  static constexpr TextView NAME{"inbound-txn-count"};
 
   /** Validate argument and indicate extracted type.
    *
    * @return The active type and any errors.
    */
-  Rv<ActiveType> validate(Config&, Extractor::Spec&, TextView const&) override;
+  Rv<ActiveType> validate(Config &, Extractor::Spec &, TextView const &) override;
 
   /** Extract the transaction count.
    *
@@ -50,75 +51,95 @@ public:
    *
    * This is called when the extractor is a @c Direct feature and therefore typed.
    */
-  Feature extract(Context & ctx, Spec const& spec)  override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Rv<ActiveType> Ex_inbound_txn_count::validate(Config&, Extractor::Spec&, TextView const&) {
-  return ActiveType{ INTEGER }; // never a problem, just return the type.
+Rv<ActiveType>
+Ex_inbound_txn_count::validate(Config &, Extractor::Spec &, TextView const &)
+{
+  return ActiveType{INTEGER}; // never a problem, just return the type.
 }
-Feature Ex_inbound_txn_count::extract(Context &ctx, Spec const&) {
+Feature
+Ex_inbound_txn_count::extract(Context &ctx, Spec const &)
+{
   return feature_type_for<INTEGER>(ctx.inbound_ssn().txn_count());
 }
 /* ------------------------------------------------------------------------------------ */
 /// Extract the SNI name from the inbound session.
-class Ex_inbound_sni : public Extractor {
+class Ex_inbound_sni : public Extractor
+{
 public:
-  static constexpr TextView NAME { "inbound-sni" };
+  static constexpr TextView NAME{"inbound-sni"};
   /// Extract the SNI  name from the inbound session.
-  Feature extract(Context & ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Feature Ex_inbound_sni::extract(Context & ctx, Spec const&) {
+Feature
+Ex_inbound_sni::extract(Context &ctx, Spec const &)
+{
   return ctx.inbound_ssn().inbound_sni();
 }
 /* ------------------------------------------------------------------------------------ */
 /// Extract the client session remote address.
-class Ex_inbound_addr_remote : public Extractor {
+class Ex_inbound_addr_remote : public Extractor
+{
 public:
-  static constexpr TextView NAME { "inbound-addr-remote" };
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  static constexpr TextView NAME{"inbound-addr-remote"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Rv<ActiveType> Ex_inbound_addr_remote::validate(Config &, Extractor::Spec &, TextView const &) {
-  return ActiveType{ NIL, IP_ADDR };
+Rv<ActiveType>
+Ex_inbound_addr_remote::validate(Config &, Extractor::Spec &, TextView const &)
+{
+  return ActiveType{NIL, IP_ADDR};
 }
 
-Feature Ex_inbound_addr_remote::extract(Context & ctx, Spec const& ) {
+Feature
+Ex_inbound_addr_remote::extract(Context &ctx, Spec const &)
+{
   return swoc::IPAddr(ctx.inbound_ssn().addr_remote());
 }
 /* ------------------------------------------------------------------------------------ */
 /// Extract the client session local address.
-class Ex_inbound_addr_local : public Extractor {
+class Ex_inbound_addr_local : public Extractor
+{
 public:
-  static constexpr TextView NAME { "inbound-addr-local" };
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  Feature extract(Context & ctx, Spec const& spec) override;
+  static constexpr TextView NAME{"inbound-addr-local"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Rv<ActiveType> Ex_inbound_addr_local::validate(Config &, Extractor::Spec &, TextView const &) {
-  return ActiveType{ NIL, IP_ADDR };
+Rv<ActiveType>
+Ex_inbound_addr_local::validate(Config &, Extractor::Spec &, TextView const &)
+{
+  return ActiveType{NIL, IP_ADDR};
 }
 
-Feature Ex_inbound_addr_local::extract(Context & ctx, Spec const& ) {
+Feature
+Ex_inbound_addr_local::extract(Context &ctx, Spec const &)
+{
   return swoc::IPAddr(ctx.inbound_ssn().addr_local());
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_has_inbound_protocol_prefix : public Extractor {
+class Ex_has_inbound_protocol_prefix : public Extractor
+{
 public:
-  static constexpr TextView NAME {"has-inbound-protocol-prefix"};
+  static constexpr TextView NAME{"has-inbound-protocol-prefix"};
 
   /// Check argument and indicate possible feature types.
-  Rv<ActiveType> validate(Config &, Spec &, swoc::TextView const&) override;
+  Rv<ActiveType> validate(Config &, Spec &, swoc::TextView const &) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 
   /// Required text formatting access.
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context & ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_has_inbound_protocol_prefix::validate(Config& cfg, Extractor::Spec& spec, TextView const& arg) {
+Rv<ActiveType>
+Ex_has_inbound_protocol_prefix::validate(Config &cfg, Extractor::Spec &spec, TextView const &arg)
+{
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument to use as a protocol prefix.)", NAME);
   }
@@ -126,38 +147,47 @@ Rv<ActiveType> Ex_has_inbound_protocol_prefix::validate(Config& cfg, Extractor::
   return {BOOLEAN};
 }
 
-auto Ex_has_inbound_protocol_prefix::extract(Context &ctx, Spec const& spec) -> Feature {
-  return { ! ctx._txn.ssn().proto_contains(spec._data.text).empty() };
+auto
+Ex_has_inbound_protocol_prefix::extract(Context &ctx, Spec const &spec) -> Feature
+{
+  return {!ctx._txn.ssn().proto_contains(spec._data.text).empty()};
 }
 
-BufferWriter& Ex_has_inbound_protocol_prefix::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_has_inbound_protocol_prefix::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_inbound_protocol_stack : public Extractor {
+class Ex_inbound_protocol_stack : public Extractor
+{
 public:
-  static constexpr TextView NAME {"inbound-protocol-stack"};
+  static constexpr TextView NAME{"inbound-protocol-stack"};
 
   /// Check argument and indicate possible feature types.
-  Rv<ActiveType> validate(Config &, Spec &, swoc::TextView const&) override;
+  Rv<ActiveType> validate(Config &, Spec &, swoc::TextView const &) override;
 
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 
   /// Required text formatting access.
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context & ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_inbound_protocol_stack::validate(Config&, Extractor::Spec&, TextView const&) {
+Rv<ActiveType>
+Ex_inbound_protocol_stack::validate(Config &, Extractor::Spec &, TextView const &)
+{
   return {ActiveType::TupleOf(STRING)};
 }
 
-auto Ex_inbound_protocol_stack::extract(Context &ctx, Spec const&) -> Feature {
-  std::array<char const*, 10> tags;
+auto
+Ex_inbound_protocol_stack::extract(Context &ctx, Spec const &) -> Feature
+{
+  std::array<char const *, 10> tags;
   auto n = ctx._txn.ssn().protocol_stack(MemSpan{tags.data(), tags.size()});
   if (n > 0) {
     auto span = ctx.alloc_span<Feature>(n);
-    for ( decltype(n) idx = 0 ; idx < n ; ++idx ) {
+    for (decltype(n) idx = 0; idx < n; ++idx) {
       // Plugin API guarantees returned tags are process lifetime so can be marked literal.
       span[idx] = FeatureView::Literal(TextView{tags[idx], TextView::npos});
     }
@@ -166,66 +196,84 @@ auto Ex_inbound_protocol_stack::extract(Context &ctx, Spec const&) -> Feature {
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_inbound_protocol_stack::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_inbound_protocol_stack::format(BufferWriter &w, Extractor::Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 /* ------------------------------------------------------------------------------------ */
 /// Client Session protocol information.
-class Ex_inbound_protocol : public StringExtractor {
-  using self_type = Ex_inbound_protocol; ///< Self reference type.
-  using super_type = StringExtractor; ///< Parent type.
+class Ex_inbound_protocol : public StringExtractor
+{
+  using self_type  = Ex_inbound_protocol; ///< Self reference type.
+  using super_type = StringExtractor;     ///< Parent type.
 public:
-  static constexpr TextView NAME { "inbound-protocol" };
+  static constexpr TextView NAME{"inbound-protocol"};
 
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_inbound_protocol::validate(Config &cfg, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_inbound_protocol::validate(Config &cfg, Spec &spec, const TextView &arg)
+{
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument to use as a protocol prefix.)", NAME);
   }
   spec._data.text = cfg.localize(arg, Config::LOCAL_CSTR);
-  return { STRING };
+  return {STRING};
 }
 
-BufferWriter& Ex_inbound_protocol::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_inbound_protocol::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   auto tag = ctx._txn.ssn().proto_contains(spec._data.text);
   return bwformat(w, spec, tag);
 }
 /* ------------------------------------------------------------------------------------ */
-class Ex_inbound_cert_verify_result : public Extractor {
-  using self_type = Ex_inbound_cert_verify_result;
+class Ex_inbound_cert_verify_result : public Extractor
+{
+  using self_type  = Ex_inbound_cert_verify_result;
   using super_type = Extractor;
+
 public:
-  static constexpr TextView NAME { "inbound-cert-verify-result"};
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
+  static constexpr TextView NAME{"inbound-cert-verify-result"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
   /// Extract the feature from the @a ctx.
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 };
 
-Rv<ActiveType> Ex_inbound_cert_verify_result::validate(Config&, Extractor::Spec&, TextView const&) {
+Rv<ActiveType>
+Ex_inbound_cert_verify_result::validate(Config &, Extractor::Spec &, TextView const &)
+{
   return {INTEGER};
 }
 
-Feature Ex_inbound_cert_verify_result::extract(Context& ctx, const Spec&) {
+Feature
+Ex_inbound_cert_verify_result::extract(Context &ctx, const Spec &)
+{
   return ctx._txn.ssn().ssl_context().verify_result();
 }
 
 /// Value for an object in the issuer section of the server certificate of an inbound session.
 /// Extractor argument is the name of the field.
-class Ex_inbound_cert_local_issuer_value : public StringExtractor {
-  using self_type = Ex_inbound_cert_local_issuer_value;
+class Ex_inbound_cert_local_issuer_value : public StringExtractor
+{
+  using self_type  = Ex_inbound_cert_local_issuer_value;
   using super_type = StringExtractor;
+
 public:
-  static constexpr TextView NAME { "inbound-cert-local-issuer-field"};
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  static constexpr TextView NAME{"inbound-cert-local-issuer-field"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+
 protected:
 };
 
-Rv<ActiveType> Ex_inbound_cert_local_issuer_value::validate(Config &, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_inbound_cert_local_issuer_value::validate(Config &, Spec &spec, const TextView &arg)
+{
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument for the value name.)", NAME);
   }
@@ -234,28 +282,35 @@ Rv<ActiveType> Ex_inbound_cert_local_issuer_value::validate(Config &, Spec &spec
     return Error(R"("{}" is not a valid certificate issuer name in "{}" extractor.)", arg, NAME);
   }
   spec._data.u = nid;
-  return { STRING };
+  return {STRING};
 }
 
-BufferWriter& Ex_inbound_cert_local_issuer_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_inbound_cert_local_issuer_value::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.u;
+  auto nid     = spec._data.u;
   return bwformat(w, spec, ssl_ctx.local_issuer_value(nid));
 }
 
 /// Value for an object in the subject section of the server certificate of an inbound session.
 /// Extractor argument is the name of the field.
-class Ex_inbound_cert_local_subject_value : public StringExtractor {
-  using self_type = Ex_inbound_cert_local_subject_value;
+class Ex_inbound_cert_local_subject_value : public StringExtractor
+{
+  using self_type  = Ex_inbound_cert_local_subject_value;
   using super_type = StringExtractor;
+
 public:
-  static constexpr TextView NAME { "inbound-cert-local-subject-field"};
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  static constexpr TextView NAME{"inbound-cert-local-subject-field"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+
 protected:
 };
 
-Rv<ActiveType> Ex_inbound_cert_local_subject_value::validate(Config &, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_inbound_cert_local_subject_value::validate(Config &, Spec &spec, const TextView &arg)
+{
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument for the value name.)", NAME);
   }
@@ -264,28 +319,35 @@ Rv<ActiveType> Ex_inbound_cert_local_subject_value::validate(Config &, Spec &spe
     return Error(R"("{}" is not a valid certificate subject name in "{}" extractor.)", arg, NAME);
   }
   spec._data.u = nid;
-  return { STRING };
+  return {STRING};
 }
 
-BufferWriter& Ex_inbound_cert_local_subject_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_inbound_cert_local_subject_value::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.u;
+  auto nid     = spec._data.u;
   return bwformat(w, spec, ssl_ctx.local_subject_value(nid));
 }
 
 /// Value for an object in the issuer section of the client certificate of an inbound session.
 /// Extractor argument is the name of the field.
-class Ex_inbound_cert_remote_issuer_value : public StringExtractor {
-  using self_type = Ex_inbound_cert_remote_issuer_value;
+class Ex_inbound_cert_remote_issuer_value : public StringExtractor
+{
+  using self_type  = Ex_inbound_cert_remote_issuer_value;
   using super_type = StringExtractor;
+
 public:
-  static constexpr TextView NAME { "inbound-cert-remote-issuer-field"};
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  static constexpr TextView NAME{"inbound-cert-remote-issuer-field"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+
 protected:
 };
 
-Rv<ActiveType> Ex_inbound_cert_remote_issuer_value::validate(Config &, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_inbound_cert_remote_issuer_value::validate(Config &, Spec &spec, const TextView &arg)
+{
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument for the value name.)", NAME);
   }
@@ -295,28 +357,35 @@ Rv<ActiveType> Ex_inbound_cert_remote_issuer_value::validate(Config &, Spec &spe
   }
   // Sigh - abuse the memspan and use the size as the integer value.
   spec._data.u = nid;
-  return { STRING };
+  return {STRING};
 }
 
-BufferWriter& Ex_inbound_cert_remote_issuer_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_inbound_cert_remote_issuer_value::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.u;
+  auto nid     = spec._data.u;
   return bwformat(w, spec, ssl_ctx.remote_issuer_value(nid));
 }
 
 /// Value for an object in the subject section of the client certificate of an inbound session.
 /// Extractor argument is the name of the field.
-class Ex_inbound_cert_remote_subject_value : public StringExtractor {
-  using self_type = Ex_inbound_cert_remote_subject_value;
+class Ex_inbound_cert_remote_subject_value : public StringExtractor
+{
+  using self_type  = Ex_inbound_cert_remote_subject_value;
   using super_type = StringExtractor;
+
 public:
-  static constexpr TextView NAME { "inbound-cert-remote-subject-field"};
-  Rv<ActiveType> validate(Config & cfg, Spec & spec, TextView const& arg) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  static constexpr TextView NAME{"inbound-cert-remote-subject-field"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
+
 protected:
 };
 
-Rv<ActiveType> Ex_inbound_cert_remote_subject_value::validate(Config &, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_inbound_cert_remote_subject_value::validate(Config &, Spec &spec, const TextView &arg)
+{
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument for the value name.)", NAME);
   }
@@ -326,16 +395,19 @@ Rv<ActiveType> Ex_inbound_cert_remote_subject_value::validate(Config &, Spec &sp
   }
   // Sigh - abuse the memspan and use the size as the integer value.
   spec._data.u = nid;
-  return { STRING };
+  return {STRING};
 }
 
-BufferWriter& Ex_inbound_cert_remote_subject_value::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_inbound_cert_remote_subject_value::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   auto ssl_ctx = ctx._txn.ssn().ssl_context();
-  auto nid = spec._data.u;
+  auto nid     = spec._data.u;
   return bwformat(w, spec, ssl_ctx.remote_subject_value(nid));
 }
 /* ------------------------------------------------------------------------------------ */
-namespace {
+namespace
+{
 // Extractors aren't constructed, they are always named references to singletons.
 // These are the singletons.
 
@@ -352,7 +424,7 @@ Ex_inbound_cert_local_subject_value inbound_cert_local_subject_value;
 Ex_inbound_cert_remote_issuer_value inbound_cert_remote_issuer_value;
 Ex_inbound_cert_remote_subject_value inbound_cert_remote_subject_value;
 
-[[maybe_unused]] bool INITIALIZED = [] () -> bool {
+[[maybe_unused]] bool INITIALIZED = []() -> bool {
   Extractor::define(Ex_inbound_txn_count::NAME, &inbound_txn_count);
   Extractor::define(Ex_inbound_sni::NAME, &inbound_sni);
   Extractor::define(Ex_inbound_protocol::NAME, &inbound_protocol);
@@ -367,5 +439,5 @@ Ex_inbound_cert_remote_subject_value inbound_cert_remote_subject_value;
   Extractor::define(Ex_inbound_cert_remote_issuer_value::NAME, &inbound_cert_remote_issuer_value);
 
   return true;
-} ();
+}();
 } // namespace

--- a/plugin/src/Extractor.cc
+++ b/plugin/src/Extractor.cc
@@ -24,53 +24,77 @@ namespace bwf = swoc::bwf;
 using namespace swoc::literals;
 
 /* ------------------------------------------------------------------------------------ */
-swoc::Lexicon<BoolTag> const BoolNames { {{ BoolTag::True, { "true", "1", "on", "enable", "Y", "yes" }}
-                                             , { BoolTag::False, { "false", "0", "off", "disable", "N", "no" }}}
-                                         , { BoolTag::INVALID }
-};
+swoc::Lexicon<BoolTag> const BoolNames{
+  {{BoolTag::True, {"true", "1", "on", "enable", "Y", "yes"}}, {BoolTag::False, {"false", "0", "off", "disable", "N", "no"}}},
+  {BoolTag::INVALID}};
 /* ------------------------------------------------------------------------------------ */
-Errata Extractor::define(TextView name, self_type * ex) {
+Errata
+Extractor::define(TextView name, self_type *ex)
+{
   _ex_table[name] = ex;
   return {};
 }
 
-bool Extractor::has_ctx_ref() const { return false; }
-
-swoc::Rv<ActiveType> Extractor::validate(Config&, Extractor::Spec&, TextView const&) {
-  return ActiveType{ NIL, STRING };
+bool
+Extractor::has_ctx_ref() const
+{
+  return false;
 }
 
-Feature Extractor::extract(Config&, Extractor::Spec const&) { return NIL_FEATURE; }
+swoc::Rv<ActiveType>
+Extractor::validate(Config &, Extractor::Spec &, TextView const &)
+{
+  return ActiveType{NIL, STRING};
+}
 
-BufferWriter& Extractor::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+Feature
+Extractor::extract(Config &, Extractor::Spec const &)
+{
+  return NIL_FEATURE;
+}
+
+BufferWriter &
+Extractor::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
-Extractor::self_type *Extractor::find(TextView const& name) {
-  auto spot { _ex_table.find(name)};
+Extractor::self_type *
+Extractor::find(TextView const &name)
+{
+  auto spot{_ex_table.find(name)};
   return spot == _ex_table.end() ? nullptr : spot->second;
 }
 
 /* ---------------------------------------------------------------------------------------------- */
-auto FeatureGroup::Tracking::find(swoc::TextView const &name) const -> Tracking::Info * {
-  Info * spot  = std::find_if(_info.begin(), _info.end(), [&](auto & t) { return 0 == strcasecmp(t._name, name); });
+auto
+FeatureGroup::Tracking::find(swoc::TextView const &name) const -> Tracking::Info *
+{
+  Info *spot = std::find_if(_info.begin(), _info.end(), [&](auto &t) { return 0 == strcasecmp(t._name, name); });
   return spot == _info.end() ? nullptr : spot;
 }
-auto FeatureGroup::Tracking::obtain(swoc::TextView const &name) -> Tracking::Info * {
-  Info * spot  = this->find(name);
+auto
+FeatureGroup::Tracking::obtain(swoc::TextView const &name) -> Tracking::Info *
+{
+  Info *spot = this->find(name);
   if (nullptr == spot) {
-    spot = this->alloc();
+    spot        = this->alloc();
     spot->_name = name;
   }
   return spot;
 }
 
-FeatureGroup::index_type FeatureGroup::index_of(swoc::TextView const &name) {
-  auto spot = std::find_if(_expr_info.begin(), _expr_info.end(), [&name](ExprInfo const& info) { return 0 == strcasecmp(info._name, name); });
+FeatureGroup::index_type
+FeatureGroup::index_of(swoc::TextView const &name)
+{
+  auto spot =
+    std::find_if(_expr_info.begin(), _expr_info.end(), [&name](ExprInfo const &info) { return 0 == strcasecmp(info._name, name); });
   return spot == _expr_info.end() ? INVALID_IDX : spot - _expr_info.begin();
 }
 
-Errata FeatureGroup::load_expr(Config & cfg, Tracking& tracking, Tracking::Info * info, YAML::Node const &node) {
+Errata
+FeatureGroup::load_expr(Config &cfg, Tracking &tracking, Tracking::Info *info, YAML::Node const &node)
+{
   /* A bit tricky, but not unduly so. The goal is to traverse all of the specifiers in the
    * expression and convert generic "this" extractors to the "this" extractor for @a this
    * feature group instance. This struct is required by the visitation rules of @c std::variant.
@@ -78,16 +102,18 @@ Errata FeatureGroup::load_expr(Config & cfg, Tracking& tracking, Tracking::Info 
    * It's not possible to use lambda gathering because the @c List case is recursive.
    */
   struct V {
-    V(FeatureGroup & fg, Config & cfg, Tracking& tracking) : _fg(fg), _cfg(cfg), _tracking(tracking) {}
-    FeatureGroup & _fg;
-    Config & _cfg;
-    Tracking & _tracking;
+    V(FeatureGroup &fg, Config &cfg, Tracking &tracking) : _fg(fg), _cfg(cfg), _tracking(tracking) {}
+    FeatureGroup &_fg;
+    Config &_cfg;
+    Tracking &_tracking;
     bool _dependent_p = false;
 
     /// Update @a spec as needed to have the correct "this" extractor.
-    Errata load_spec(Extractor::Spec& spec) {
+    Errata
+    load_spec(Extractor::Spec &spec)
+    {
       if (spec._exf == &ex_this) {
-        auto && [ tinfo, errata ] = _fg.load_key(_cfg, _tracking, spec._ext);
+        auto &&[tinfo, errata] = _fg.load_key(_cfg, _tracking, spec._ext);
         if (errata.is_ok()) {
           spec._exf = &_fg._ex_this;
           // Don't track if the target is a literal - no runtime extraction needed.
@@ -109,13 +135,21 @@ Errata FeatureGroup::load_expr(Config & cfg, Tracking& tracking, Tracking::Info 
       return {};
     }
 
-    Errata operator() (std::monostate) { return {}; }
-    Errata operator() (Feature const&) { return {}; }
-    Errata operator() (Expr::Direct & d) {
+    Errata operator()(std::monostate) { return {}; }
+    Errata
+    operator()(Feature const &)
+    {
+      return {};
+    }
+    Errata
+    operator()(Expr::Direct &d)
+    {
       return this->load_spec(d._spec);
     }
-    Errata operator() (Expr::Composite & c) {
-      for (auto& spec : c._specs) {
+    Errata
+    operator()(Expr::Composite &c)
+    {
+      for (auto &spec : c._specs) {
         auto errata = this->load_spec(spec);
         if (!errata.is_ok()) {
           return errata;
@@ -124,10 +158,12 @@ Errata FeatureGroup::load_expr(Config & cfg, Tracking& tracking, Tracking::Info 
       return {};
     }
     // For list, it's a list of nested @c Expr instances, so visit those as this one was visited.
-    Errata operator() (Expr::List & l){
-      for ( auto & expr : l._exprs) {
+    Errata
+    operator()(Expr::List &l)
+    {
+      for (auto &expr : l._exprs) {
         auto errata = std::visit(*this, expr._raw);
-        if (! errata.is_ok()) {
+        if (!errata.is_ok()) {
           return errata;
         }
       }
@@ -135,23 +171,23 @@ Errata FeatureGroup::load_expr(Config & cfg, Tracking& tracking, Tracking::Info 
     }
   } v(*this, cfg, tracking);
 
-  auto && [ expr, errata ] { cfg.parse_expr(node) };
+  auto &&[expr, errata]{cfg.parse_expr(node)};
   info->_expr = std::move(expr);
   if (errata.is_ok()) {
-    errata = std::visit(v, info->_expr._raw); // update "this" extractor references.
+    errata             = std::visit(v, info->_expr._raw); // update "this" extractor references.
     info->_dependent_p = v._dependent_p;
   }
   return errata;
 }
 
-auto FeatureGroup::load_key(Config &cfg, FeatureGroup::Tracking &tracking, swoc::TextView name)
-     -> Rv<Tracking::Info*>
+auto
+FeatureGroup::load_key(Config &cfg, FeatureGroup::Tracking &tracking, swoc::TextView name) -> Rv<Tracking::Info *>
 {
-  YAML::Node n {tracking._node[name]};
+  YAML::Node n{tracking._node[name]};
 
   // Check if the key is present in the node. If not, it must be a referenced key because
   // the presence of explicit keys is checked before loading any keys.
-  if (! n) {
+  if (!n) {
     return Error(R"("{}" is referenced but no such key was found.)", name);
   }
 
@@ -166,8 +202,8 @@ auto FeatureGroup::load_key(Config &cfg, FeatureGroup::Tracking &tracking, swoc:
   }
   tinfo->_mark = IN_PLAY;
 
-  Errata errata { this->load_expr(cfg, tracking, tinfo, n) };
-  if (! errata.is_ok()) {
+  Errata errata{this->load_expr(cfg, tracking, tinfo, n)};
+  if (!errata.is_ok()) {
     errata.info(R"(While loading extraction format for key "{}" at {}.)", name, tracking._node.Mark());
     return errata;
   }
@@ -176,7 +212,9 @@ auto FeatureGroup::load_key(Config &cfg, FeatureGroup::Tracking &tracking, swoc:
   return tinfo;
 }
 
-Errata FeatureGroup::load(Config & cfg, YAML::Node const& node, std::initializer_list<FeatureGroup::Descriptor> const &ex_keys) {
+Errata
+FeatureGroup::load(Config &cfg, YAML::Node const &node, std::initializer_list<FeatureGroup::Descriptor> const &ex_keys)
+{
   unsigned n_keys = node.size(); // Number of keys in @a node.
 
   Tracking::Info tracking_info[n_keys];
@@ -185,13 +223,15 @@ Errata FeatureGroup::load(Config & cfg, YAML::Node const& node, std::initializer
   // Find the roots of extraction - these are the named keys actually in the node.
   // Need to do this explicitly to transfer the flags, and to check for duplicates in @a ex_keys.
   // It is not an error for a named key to be missing unless it's marked @c REQUIRED.
-  for ( auto & d : ex_keys ) {
+  for (auto &d : ex_keys) {
     auto tinfo = tracking.find(d._name);
     if (nullptr != tinfo) {
-      return Errata().error(R"("INTERNAL ERROR: "{}" is used more than once in the extractor key list of the feature group for the node {}.)", d._name, node.Mark());
+      return Errata().error(
+        R"("INTERNAL ERROR: "{}" is used more than once in the extractor key list of the feature group for the node {}.)", d._name,
+        node.Mark());
     }
     if (node[d._name]) {
-      tinfo = tracking.alloc();
+      tinfo        = tracking.alloc();
       tinfo->_name = d._name;
     } else if (d._flags[REQUIRED]) {
       return Errata().error(R"(The required key "{}" was not found in the node {}.)", d._name, node.Mark());
@@ -202,7 +242,7 @@ Errata FeatureGroup::load(Config & cfg, YAML::Node const& node, std::initializer
   // @c load_key as that can modify @a tracking_count. Also must avoid calling this on keys that
   // are explicit but not required - need to fail on missing keys iff they're referenced, which is
   // checked by @c load_key. The presence of required keys has already been verified.
-  for ( auto info = tracking_info, limit = info + tracking._count ; info < limit ; ++info ) {
+  for (auto info = tracking_info, limit = info + tracking._count; info < limit; ++info) {
     auto &&[dummy, errata]{this->load_key(cfg, tracking, info->_name)};
     if (!errata.is_ok()) {
       return errata;
@@ -211,54 +251,56 @@ Errata FeatureGroup::load(Config & cfg, YAML::Node const& node, std::initializer
 
   // Persist the tracking info, now that all the sizes are known.
   _expr_info = cfg.alloc_span<ExprInfo>(tracking._count);
-  _expr_info.apply([](ExprInfo & info) { new (&info) ExprInfo; });
+  _expr_info.apply([](ExprInfo &info) { new (&info) ExprInfo; });
 
   // If there are dependencies, allocate state to hold cached values.
   // If any key was marked dependent, then @a _ref_count > 0.
   if (_ref_count > 0) {
     _ctx_state_span = cfg.reserve_ctx_storage(sizeof(State));
-    _ordering = cfg.alloc_span<index_type>(_ref_count);
-    for ( index_type idx = 0 ; idx < _ref_count ; ++idx ) {
+    _ordering       = cfg.alloc_span<index_type>(_ref_count);
+    for (index_type idx = 0; idx < _ref_count; ++idx) {
       _ordering[idx] = tracking._info[idx]._order_idx;
     }
   }
 
   // Persist the keys by copying persistent data from the tracking data to config allocated space.
-  for ( unsigned short idx = 0 ; idx < tracking._count ; ++idx ) {
+  for (unsigned short idx = 0; idx < tracking._count; ++idx) {
     Tracking::Info &src = tracking._info[idx];
-    ExprInfo &dst = _expr_info[idx];
-    dst._name = src._name;
-    dst._expr = std::move(src._expr);
-    dst._exf_idx = src._exf_idx;
-    dst._dependent_p = src._dependent_p;
+    ExprInfo &dst       = _expr_info[idx];
+    dst._name           = src._name;
+    dst._expr           = std::move(src._expr);
+    dst._exf_idx        = src._exf_idx;
+    dst._dependent_p    = src._dependent_p;
   }
 
   return {};
 }
 
-Errata FeatureGroup::load_as_scalar(Config& cfg, const YAML::Node& value, swoc::TextView const& name) {
-  auto && [ expr, errata ] { cfg.parse_expr(value) };
-  if (! errata.is_ok()) {
+Errata
+FeatureGroup::load_as_scalar(Config &cfg, const YAML::Node &value, swoc::TextView const &name)
+{
+  auto &&[expr, errata]{cfg.parse_expr(value)};
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
   _expr_info = cfg.alloc_span<ExprInfo>(1);
-  auto info = _expr_info.data();
+  auto info  = _expr_info.data();
   new (info) ExprInfo;
   info->_expr = std::move(expr);
   info->_name = name;
   return {};
 }
 
-Errata FeatureGroup::load_as_tuple( Config &cfg, YAML::Node const &node
-                                  , std::initializer_list<FeatureGroup::Descriptor> const &ex_keys) {
-  unsigned idx = 0;
+Errata
+FeatureGroup::load_as_tuple(Config &cfg, YAML::Node const &node, std::initializer_list<FeatureGroup::Descriptor> const &ex_keys)
+{
+  unsigned idx    = 0;
   unsigned n_keys = ex_keys.size();
   unsigned n_elts = node.size();
   ExprInfo info[n_keys];
 
   // No dependency in tuples, can just walk the keys and load them.
-  for ( auto const& key : ex_keys ) {
-
+  for (auto const &key : ex_keys) {
     if (idx >= n_elts) {
       if (key._flags[REQUIRED]) {
         return Errata().error(R"(The list was {} elements long but {} are required.)", n_elts, n_keys);
@@ -266,8 +308,8 @@ Errata FeatureGroup::load_as_tuple( Config &cfg, YAML::Node const &node
       continue; // it was optional, skip it and keep checking for REQUIRED keys.
     }
 
-    auto && [ expr, errata ] = cfg.parse_expr(node[idx]);
-    if (! errata.is_ok()) {
+    auto &&[expr, errata] = cfg.parse_expr(node[idx]);
+    if (!errata.is_ok()) {
       return std::move(errata);
     }
     info[idx]._name = key._name;
@@ -275,10 +317,10 @@ Errata FeatureGroup::load_as_tuple( Config &cfg, YAML::Node const &node
     ++idx;
   }
   // Localize feature info, now that the size is determined.
-  _expr_info = cfg.alloc_span<ExprInfo>(idx);
+  _expr_info   = cfg.alloc_span<ExprInfo>(idx);
   index_type i = 0;
-  for ( auto & item : _expr_info ) {
-    new (&item) ExprInfo{std::move(info[i++]) };
+  for (auto &item : _expr_info) {
+    new (&item) ExprInfo{std::move(info[i++])};
   }
   // No dependencies for tuple loads.
   // No feature data because no dependencies.
@@ -286,93 +328,108 @@ Errata FeatureGroup::load_as_tuple( Config &cfg, YAML::Node const &node
   return {};
 }
 
-Feature FeatureGroup::extract(Context& ctx, swoc::TextView const& name) {
+Feature
+FeatureGroup::extract(Context &ctx, swoc::TextView const &name)
+{
   auto idx = this->index_of(name);
   return idx == INVALID_IDX ? NIL_FEATURE : this->extract(ctx, idx);
 }
 
-Feature FeatureGroup::extract(Context& ctx, index_type idx) {
-  auto& info = _expr_info[idx];
+Feature
+FeatureGroup::extract(Context &ctx, index_type idx)
+{
+  auto &info = _expr_info[idx];
   if (info._dependent_p || info._exf_idx != INVALID_IDX) {
     // State is always allocated if there are any dependents. Need to fill the cache if this is
     // a key that's either dependent or one of the dependency targets.
-    State& state = ctx.initialized_storage_for<State>(_ctx_state_span)[0];
-    if (state._features.empty()) {  // no target has yet been extracted, do it now.
+    State &state = ctx.initialized_storage_for<State>(_ctx_state_span)[0];
+    if (state._features.empty()) { // no target has yet been extracted, do it now.
       // Allocate target cache.
       state._features = ctx.alloc_span<Feature>(_ref_count);
       // Extract targets.
       for (index_type target_idx : _ordering) {
-        auto& target { _expr_info[target_idx] };
+        auto &target{_expr_info[target_idx]};
         state._features[target._exf_idx] = ctx.extract(target._expr);
       }
     }
   }
 
   if (info._exf_idx != INVALID_IDX) { // it's a target so it's in the cache - fetch it.
-    State& state = ctx.storage_for(_ctx_state_span).rebind<State>()[0];
+    State &state = ctx.storage_for(_ctx_state_span).rebind<State>()[0];
     return state._features[info._exf_idx];
   }
 
   return ctx.extract(info._expr);
 }
 
-FeatureGroup::~FeatureGroup() {
-  _expr_info.apply([](ExprInfo & info) { std::destroy_at(&info); });
+FeatureGroup::~FeatureGroup()
+{
+  _expr_info.apply([](ExprInfo &info) { std::destroy_at(&info); });
 }
 
 /* ---------------------------------------------------------------------------------------------- */
-Feature StringExtractor::extract(Context& ctx, Spec const& spec) {
-  return ctx.render_transient([&](BufferWriter & w) { this->format(w, spec, ctx); });
+Feature
+StringExtractor::extract(Context &ctx, Spec const &spec)
+{
+  return ctx.render_transient([&](BufferWriter &w) { this->format(w, spec, ctx); });
 }
 /* ------------------------------------------------------------------------------------ */
 // Utilities.
-bool Feature::is_list() const {
+bool
+Feature::is_list() const
+{
   auto idx = this->index();
   return IndexFor(TUPLE) == idx || IndexFor(CONS) == idx;
 }
 // ----
-ActiveType Feature::active_type() const {
-  auto vt = this->value_type();
+ActiveType
+Feature::active_type() const
+{
+  auto vt       = this->value_type();
   ActiveType at = vt;
   if (TUPLE == vt) {
-    auto & tp = std::get<IndexFor(TUPLE)>(*this);
+    auto &tp = std::get<IndexFor(TUPLE)>(*this);
     if (tp.size() == 0) { // empty tuple can be a tuple of any type.
       at = ActiveType::TupleOf(ActiveType::any_type().base_types());
-    } else if (auto tt = tp[0].value_type() ; std::all_of(tp.begin()+1, tp.end(), [=](Feature const& f){return f.value_type() == tt;})) {
+    } else if (auto tt = tp[0].value_type();
+               std::all_of(tp.begin() + 1, tp.end(), [=](Feature const &f) { return f.value_type() == tt; })) {
       at = ActiveType::TupleOf(tt);
     } // else leave it as just a tuple with no specific type.
   }
   return at;
 }
 // ----
-Feature car(Feature const& feature) {
+Feature
+car(Feature const &feature)
+{
   switch (feature.index()) {
-    case IndexFor(CONS):
-      return std::get<IndexFor(CONS)>(feature)->_car;
-    case IndexFor(TUPLE):
-      return std::get<IndexFor(TUPLE)>(feature)[0];
-    case IndexFor(GENERIC):{
-      auto gf = std::get<IndexFor(GENERIC)>(feature);
-      if (gf) {
-        return gf->extract();
-      }
+  case IndexFor(CONS):
+    return std::get<IndexFor(CONS)>(feature)->_car;
+  case IndexFor(TUPLE):
+    return std::get<IndexFor(TUPLE)>(feature)[0];
+  case IndexFor(GENERIC): {
+    auto gf = std::get<IndexFor(GENERIC)>(feature);
+    if (gf) {
+      return gf->extract();
     }
+  }
   }
   return feature;
 }
 // ----
-Feature & cdr(Feature & feature) {
+Feature &
+cdr(Feature &feature)
+{
   switch (feature.index()) {
-    case IndexFor(CONS):
-      feature = std::get<feature_type_for<CONS>>(feature)->_cdr;
-      break;
-    case IndexFor(TUPLE): {
-      Feature cdr { feature };
-      auto &span = std::get<feature_type_for<TUPLE>>(cdr);
-      span.remove_prefix(1);
-      feature = span.empty() ? NIL_FEATURE : cdr;
-    }
-      break;
+  case IndexFor(CONS):
+    feature = std::get<feature_type_for<CONS>>(feature)->_cdr;
+    break;
+  case IndexFor(TUPLE): {
+    Feature cdr{feature};
+    auto &span = std::get<feature_type_for<TUPLE>>(cdr);
+    span.remove_prefix(1);
+    feature = span.empty() ? NIL_FEATURE : cdr;
+  } break;
   }
   return feature;
 }

--- a/plugin/src/Machinery.cc
+++ b/plugin/src/Machinery.cc
@@ -5,14 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
 */
 
-#include "txn_box/common.h"
-
 #include <swoc/TextView.h>
 #include <swoc/Errata.h>
-#include <swoc/ArenaWriter.h>
 #include <swoc/BufferWriter.h>
 #include <swoc/bwf_base.h>
 
+#include "txn_box/common.h"
 #include "txn_box/Config.h"
 #include "txn_box/Context.h"
 #include "txn_box/Directive.h"
@@ -42,7 +40,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_ua_req_url_host(Expr && expr);
+  explicit Do_ua_req_url_host(Expr && expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -3330,7 +3328,7 @@ swoc::Rv<Directive::Handle> Do_with::load(Config& cfg, CfgStaticData const*, YAM
     return std::move(errata);
   }
 
-  self_type * self = new self_type;
+  auto * self = new self_type;
   Handle handle(self); // for return, and cleanup in case of error.
   self->_expr = std::move(expr);
   auto f_scope = cfg.feature_scope(self->_expr.result_type());

--- a/plugin/src/Machinery.cc
+++ b/plugin/src/Machinery.cc
@@ -164,7 +164,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_ua_req_url_port(Expr && expr);
+  explicit Do_ua_req_url_port(Expr && expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -226,7 +226,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_proxy_req_url_port(Expr && expr);
+  explicit Do_proxy_req_url_port(Expr && expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -386,7 +386,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_ua_req_url_loc(Expr && expr);
+  explicit Do_ua_req_url_loc(Expr && expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -444,7 +444,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_proxy_req_url_loc(Expr && expr);
+  explicit Do_proxy_req_url_loc(Expr && expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -504,7 +504,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_ua_req_host(Expr && expr);
+  explicit Do_ua_req_host(Expr && expr);
 
   /** Invoke directive.
    *
@@ -570,7 +570,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_ua_req_port(Expr && expr);
+  explicit Do_ua_req_port(Expr && expr);
 
   /** Invoke directive.
    *
@@ -638,7 +638,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_proxy_req_port(Expr && expr);
+  explicit Do_proxy_req_port(Expr && expr);
 
   /** Invoke directive.
    *
@@ -705,7 +705,7 @@ public:
    *
    * @param fmt Feature for host.
    */
-  Do_proxy_req_host(Expr && fmt);
+  explicit Do_proxy_req_host(Expr && fmt);
 
   /** Invoke directive.
    *
@@ -767,7 +767,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_ua_req_loc(Expr && expr);
+  explicit Do_ua_req_loc(Expr && expr);
 
   /** Invoke directive.
    *
@@ -830,7 +830,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  Do_proxy_req_loc(Expr && expr);
+  explicit Do_proxy_req_loc(Expr && expr);
 
   /** Invoke directive.
    *
@@ -892,7 +892,7 @@ public:
    *
    * @param fmt Feature for host.
    */
-  Do_ua_req_scheme(Expr && fmt);
+  explicit Do_ua_req_scheme(Expr && fmt);
 
   /** Invoke directive.
    *
@@ -956,7 +956,7 @@ public:
    *
    * @param fmt Feature for host.
    */
-  Do_ua_req_url(Expr && expr);
+  explicit Do_ua_req_url(Expr && expr);
 
   /** Invoke directive.
    *
@@ -1020,7 +1020,7 @@ public:
    *
    * @param fmt Feature for host.
    */
-  Do_proxy_req_scheme(Expr && fmt);
+  explicit Do_proxy_req_scheme(Expr && fmt);
 
   /** Invoke directive.
    *
@@ -1084,7 +1084,7 @@ public:
    *
    * @param expr Feature expression for the URL.
    */
-  Do_proxy_req_url(Expr && expr);
+  explicit Do_proxy_req_url(Expr && expr);
 
   /** Invoke directive.
    *
@@ -1145,7 +1145,7 @@ public:
    *
    * @param expr Feature expression for the URL.
    */
-  Do_did_remap(Expr && expr);
+  explicit Do_did_remap(Expr && expr);
 
   /** Invoke directive.
    *
@@ -1290,7 +1290,7 @@ public:
    *
    * @param expr Feature for host.
    */
-  Do_ua_req_path(Expr && expr);
+  explicit Do_ua_req_path(Expr && expr);
 
   /** Invoke directive.
    *
@@ -1356,7 +1356,7 @@ public:
    *
    * @param expr Feature for host.
    */
-  Do_ua_req_query(Expr && expr);
+  explicit Do_ua_req_query(Expr && expr);
 
   /** Invoke directive.
    *
@@ -1423,7 +1423,7 @@ public:
    *
    * @param expr Feature for host.
    */
-  Do_ua_req_fragment(Expr && expr);
+  explicit Do_ua_req_fragment(Expr && expr);
 
   /** Invoke directive.
    *
@@ -1489,7 +1489,7 @@ public:
    *
    * @param fmt Feature for host.
    */
-  Do_proxy_req_path(Expr && fmt);
+  explicit Do_proxy_req_path(Expr && fmt);
 
   /** Invoke directive.
    *
@@ -1553,7 +1553,7 @@ public:
    *
    * @param fmt Feature for host.
    */
-  Do_proxy_req_query(Expr && fmt);
+  explicit Do_proxy_req_query(Expr && fmt);
 
   /** Invoke directive.
    *
@@ -1617,7 +1617,7 @@ public:
    *
    * @param fmt Feature for host.
    */
-  Do_proxy_req_fragment(Expr && fmt);
+  explicit Do_proxy_req_fragment(Expr && fmt);
 
   /** Invoke directive.
    *
@@ -1692,16 +1692,13 @@ protected:
    */
   static Rv<Handle> load(Config& cfg, std::function<Handle (TextView const& name, Expr && fmt)> const& maker, TextView const& key, TextView const& name, YAML::Node key_value);
 
-  using super_type::invoke;
-  /** Invoke the directive.
+  /** Invoke the directive on an HTTP header.
    *
    * @param ctx Runtime context.
-   * @param hdr HTTP header containing the field.
+   * @param hdr HTTP header.
    * @return Errors, if any.
    */
-  Errata invoke(Context& ctx, ts::HttpHeader && hdr);
-
-  void apply(Context& ctx, ts::HttpHeader & hdr, TextView const& name);
+  Errata invoke_on_hdr(Context& ctx, ts::HttpHeader && hdr);
 
   /** Get the directive name (key).
    *
@@ -1779,7 +1776,7 @@ protected:
 
     // Other types, convert to string
     template<typename T> auto operator()(T&& t) -> EnableForFeatureTypes<T, void> {
-      this->assign(_ctx.template render_transient([&](BufferWriter & w) { bwformat(w, bwf::Spec::DEFAULT, t); }));
+      this->assign(_ctx.template render_transient([&t](BufferWriter & w) { bwformat(w, bwf::Spec::DEFAULT, t); }));
       this->clear_dups();
     }
   };
@@ -1788,15 +1785,10 @@ protected:
 
 FieldDirective::FieldDirective(TextView const &name, Expr &&expr) : _name(name), _expr(std::move(expr)) {}
 
-void FieldDirective::apply(Context & ctx, ts::HttpHeader & hdr, TextView const& name) {
-  auto value{ctx.extract(_expr)};
-  std::visit(Apply{ctx, hdr, name}, value);
-}
-
-Errata FieldDirective::invoke(Context & ctx, ts::HttpHeader && hdr) {
+Errata FieldDirective::invoke_on_hdr(Context& ctx, ts::HttpHeader&& hdr) {
   if (hdr.is_valid()) {
-    ts::HttpField field;
-    this->apply(ctx, hdr, _name);
+    auto value{ctx.extract(this->_expr)};
+    std::visit(Apply(ctx, hdr, _name), value);
     return {};
   }
   return Errata().error(R"(Failed to assign field value due to invalid HTTP header.)");
@@ -1830,6 +1822,7 @@ public:
   static const std::string KEY; ///< Directive key.
   static const HookMask HOOKS; ///< Valid hooks for directive.
 
+  using super_type::invoke;
   Errata invoke(Context & ctx) override;
 
   /** Load from YAML node.
@@ -1854,7 +1847,7 @@ const std::string Do_ua_req_field::KEY {"ua-req-field" };
 const HookMask Do_ua_req_field::HOOKS {MaskFor({ Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP }) };
 
 Errata Do_ua_req_field::invoke(Context &ctx) {
-  return this->super_type::invoke(ctx, ctx.ua_req_hdr());
+  return this->invoke_on_hdr(ctx, ctx.ua_req_hdr());
 }
 
 Rv<Directive::Handle> Do_ua_req_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
@@ -1893,7 +1886,7 @@ const std::string Do_proxy_req_field::KEY {"proxy-req-field" };
 const HookMask Do_proxy_req_field::HOOKS {MaskFor({ Hook::PREQ }) };
 
 Errata Do_proxy_req_field::invoke(Context &ctx) {
-  return this->super_type::invoke(ctx, ctx.proxy_req_hdr());
+  return this->invoke_on_hdr(ctx, ctx.proxy_req_hdr());
 }
 
 Rv<Directive::Handle> Do_proxy_req_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
@@ -1932,7 +1925,7 @@ const std::string Do_proxy_rsp_field::KEY {"proxy-rsp-field" };
 const HookMask Do_proxy_rsp_field::HOOKS {MaskFor(Hook::PRSP) };
 
 Errata Do_proxy_rsp_field::invoke(Context &ctx) {
-  return this->super_type::invoke(ctx, ctx.proxy_rsp_hdr());
+  return this->invoke_on_hdr(ctx, ctx.proxy_rsp_hdr());
 }
 
 Rv<Directive::Handle> Do_proxy_rsp_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
@@ -1971,7 +1964,7 @@ const std::string Do_upstream_rsp_field::KEY {"upstream-rsp-field" };
 const HookMask Do_upstream_rsp_field::HOOKS {MaskFor(Hook::URSP) };
 
 Errata Do_upstream_rsp_field::invoke(Context &ctx) {
-  return this->super_type::invoke(ctx, ctx.upstream_rsp_hdr());
+  return this->invoke_on_hdr(ctx, ctx.upstream_rsp_hdr());
 }
 
 Rv<Directive::Handle> Do_upstream_rsp_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
@@ -3119,7 +3112,7 @@ class Do_upstream_addr : public Directive {
   using self_type = Do_upstream_addr; ///< Self reference type.
   using super_type = Directive; ///< Parent type.
 public:
-  static const std::string KEY; ///< Directive name.
+  static inline const std::string KEY{"upstream-addr"}; ///< Directive name.
   static const HookMask HOOKS; ///< Valid hooks for directive.
 
   Errata invoke(Context & ctx) override; ///< Runtime activation.
@@ -3144,7 +3137,6 @@ protected:
   Do_upstream_addr(Expr && expr) : _expr(std::move(expr)) {}
 };
 
-const std::string Do_upstream_addr::KEY { "upstream-addr" };
 const HookMask Do_upstream_addr::HOOKS { MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP, Hook::PREQ}) };
 
 Errata Do_upstream_addr::invoke(Context &ctx) {

--- a/plugin/src/Machinery.cc
+++ b/plugin/src/Machinery.cc
@@ -27,11 +27,17 @@ namespace bwf = swoc::bwf;
 using namespace swoc::literals;
 
 /* ------------------------------------------------------------------------------------ */
-Feature Generic::extract() const { return NIL_FEATURE; }
+Feature
+Generic::extract() const
+{
+  return NIL_FEATURE;
+}
 /* ------------------------------------------------------------------------------------ */
-class Do_ua_req_url_host : public Directive {
+class Do_ua_req_url_host : public Directive
+{
   using super_type = Directive;
-  using self_type = Do_ua_req_url_host;
+  using self_type  = Do_ua_req_url_host;
+
 public:
   static const std::string KEY;
   static const HookMask HOOKS; ///< Valid hooks for directive.
@@ -40,7 +46,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  explicit Do_ua_req_url_host(Expr && expr);
+  explicit Do_ua_req_url_host(Expr &&expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -54,18 +60,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   Expr _expr; ///< Feature expression.
 };
 
-const std::string Do_ua_req_url_host::KEY {"ua-req-url-host" };
+const std::string Do_ua_req_url_host::KEY{"ua-req-url-host"};
 const HookMask Do_ua_req_url_host::HOOKS = MaskFor(Hook::PREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP);
 
-Do_ua_req_url_host::Do_ua_req_url_host(Expr && expr) : _expr(std::move(expr)) {}
+Do_ua_req_url_host::Do_ua_req_url_host(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_url_host::invoke(Context &ctx) {
+Errata
+Do_ua_req_url_host::invoke(Context &ctx)
+{
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       auto value = ctx.extract(_expr);
@@ -77,13 +86,16 @@ Errata Do_ua_req_url_host::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_url_host::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_url_host::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                         YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), STRING);
   }
   return Handle(new self_type{std::move(expr)});
@@ -91,9 +103,11 @@ swoc::Rv<Directive::Handle> Do_ua_req_url_host::load(Config& cfg, CfgStaticData 
 
 // ---
 
-class Do_proxy_req_url_host : public Directive {
+class Do_proxy_req_url_host : public Directive
+{
   using super_type = Directive;
-  using self_type = Do_proxy_req_url_host;
+  using self_type  = Do_proxy_req_url_host;
+
 public:
   static const std::string KEY;
   static const HookMask HOOKS; ///< Valid hooks for directive.
@@ -102,7 +116,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  explicit Do_proxy_req_url_host(Expr && expr);
+  explicit Do_proxy_req_url_host(Expr &&expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -116,18 +130,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   Expr _expr; ///< Host feature expression.
 };
 
-const std::string Do_proxy_req_url_host::KEY {"proxy-req-url-host" };
-const HookMask Do_proxy_req_url_host::HOOKS {MaskFor({ Hook::PREQ }) };
+const std::string Do_proxy_req_url_host::KEY{"proxy-req-url-host"};
+const HookMask Do_proxy_req_url_host::HOOKS{MaskFor({Hook::PREQ})};
 
-Do_proxy_req_url_host::Do_proxy_req_url_host(Expr && expr) : _expr(std::move(expr)) {}
+Do_proxy_req_url_host::Do_proxy_req_url_host(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_proxy_req_url_host::invoke(Context &ctx) {
+Errata
+Do_proxy_req_url_host::invoke(Context &ctx)
+{
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       auto value = ctx.extract(_expr);
@@ -139,13 +156,16 @@ Errata Do_proxy_req_url_host::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_url_host::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_url_host::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &,
+                            swoc::TextView const &, YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), STRING);
   }
   return Handle(new self_type{std::move(expr)});
@@ -153,9 +173,11 @@ swoc::Rv<Directive::Handle> Do_proxy_req_url_host::load(Config& cfg, CfgStaticDa
 
 /* ------------------------------------------------------------------------------------ */
 
-class Do_ua_req_url_port : public Directive {
+class Do_ua_req_url_port : public Directive
+{
   using super_type = Directive;
-  using self_type = Do_ua_req_url_port;
+  using self_type  = Do_ua_req_url_port;
+
 public:
   static const std::string KEY;
   static const HookMask HOOKS; ///< Valid hooks for directive.
@@ -164,7 +186,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  explicit Do_ua_req_url_port(Expr && expr);
+  explicit Do_ua_req_url_port(Expr &&expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -178,18 +200,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   Expr _expr; ///< Feature expression.
 };
 
-const std::string Do_ua_req_url_port::KEY {"ua-req-url-port" };
-const HookMask Do_ua_req_url_port::HOOKS {MaskFor({Hook::CREQ, Hook::PREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const std::string Do_ua_req_url_port::KEY{"ua-req-url-port"};
+const HookMask Do_ua_req_url_port::HOOKS{MaskFor({Hook::CREQ, Hook::PREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
-Do_ua_req_url_port::Do_ua_req_url_port(Expr && expr) : _expr(std::move(expr)) {}
+Do_ua_req_url_port::Do_ua_req_url_port(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_url_port::invoke(Context &ctx) {
+Errata
+Do_ua_req_url_port::invoke(Context &ctx)
+{
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       auto port = ctx.extract(_expr).as_integer(-1);
@@ -201,13 +226,16 @@ Errata Do_ua_req_url_port::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_url_port::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_url_port::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                         YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(INTEGER)) {
+  if (!expr.result_type().can_satisfy(INTEGER)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), INTEGER);
   }
   return Handle(new self_type{std::move(expr)});
@@ -215,9 +243,11 @@ swoc::Rv<Directive::Handle> Do_ua_req_url_port::load(Config& cfg, CfgStaticData 
 
 // ---
 
-class Do_proxy_req_url_port : public Directive {
+class Do_proxy_req_url_port : public Directive
+{
   using super_type = Directive;
-  using self_type = Do_proxy_req_url_port;
+  using self_type  = Do_proxy_req_url_port;
+
 public:
   static const std::string KEY;
   static const HookMask HOOKS; ///< Valid hooks for directive.
@@ -226,7 +256,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  explicit Do_proxy_req_url_port(Expr && expr);
+  explicit Do_proxy_req_url_port(Expr &&expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -240,18 +270,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   Expr _expr; ///< Feature expression.
 };
 
-const std::string Do_proxy_req_url_port::KEY {"proxy-req-url-port" };
-const HookMask Do_proxy_req_url_port::HOOKS {MaskFor(Hook::PREQ) };
+const std::string Do_proxy_req_url_port::KEY{"proxy-req-url-port"};
+const HookMask Do_proxy_req_url_port::HOOKS{MaskFor(Hook::PREQ)};
 
-Do_proxy_req_url_port::Do_proxy_req_url_port(Expr && expr) : _expr(std::move(expr)) {}
+Do_proxy_req_url_port::Do_proxy_req_url_port(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_proxy_req_url_port::invoke(Context &ctx) {
+Errata
+Do_proxy_req_url_port::invoke(Context &ctx)
+{
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       auto port = ctx.extract(_expr).as_integer(-1);
@@ -263,34 +296,37 @@ Errata Do_proxy_req_url_port::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_url_port::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_url_port::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &,
+                            swoc::TextView const &, YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(INTEGER)) {
+  if (!expr.result_type().can_satisfy(INTEGER)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), INTEGER);
   }
   return Handle(new self_type{std::move(expr)});
 }
 
 /* ------------------------------------------------------------------------------------ */
-namespace {
-
+namespace
+{
 // @return @c true if @a loc is syntactically a valid location and break out the pieces.
-bool Loc_String_Parse(TextView const& loc, TextView & host_token, int & port) {
+bool
+Loc_String_Parse(TextView const &loc, TextView &host_token, int &port)
+{
   TextView port_token, rest;
   if (swoc::IPEndpoint::tokenize(loc, &host_token, &port_token, &rest) && rest.size() == 0) {
-
     if (port_token.empty()) {
       port = 0;
       return true;
     }
 
-    if ( auto n = svtou(port_token, &rest) ; rest.size() == port_token.size() &&
-                                             0 < n && n <= std::numeric_limits<in_port_t>::max()
-    ) {
+    if (auto n = svtou(port_token, &rest);
+        rest.size() == port_token.size() && 0 < n && n <= std::numeric_limits<in_port_t>::max()) {
       port = n;
       return true;
     }
@@ -299,20 +335,22 @@ bool Loc_String_Parse(TextView const& loc, TextView & host_token, int & port) {
 }
 
 /// Set the location in a URL, accepting either a string or a tuple of <host, port>.
-void URL_Loc_Set(Context& ctx, Expr & expr, ts::URL & url) {
+void
+URL_Loc_Set(Context &ctx, Expr &expr, ts::URL &url)
+{
   auto value = ctx.extract(expr);
   TextView host_token;
   int port = -1; // if still -1 after parsing, the parsing failed.
   if (auto loc = std::get_if<IndexFor(STRING)>(&value); nullptr != loc) {
     // split the string to get the pieces.
     Loc_String_Parse(*loc, host_token, port);
-  } else if (auto t = std::get_if<IndexFor(TUPLE)>(&value) ; nullptr != t ) {
+  } else if (auto t = std::get_if<IndexFor(TUPLE)>(&value); nullptr != t) {
     // Must be host name, then port.
     if (t->size() > 0) {
-      if (auto & f0 = (*t)[0] ; f0.index() == IndexFor(STRING)) {
+      if (auto &f0 = (*t)[0]; f0.index() == IndexFor(STRING)) {
         host_token = std::get<IndexFor(STRING)>(f0);
         if (t->size() > 1) {
-          auto & f1 = (*t)[1];
+          auto &f1 = (*t)[1];
           if (is_empty(f1)) {
             port = 0; // clear port.
           } else {
@@ -329,20 +367,20 @@ void URL_Loc_Set(Context& ctx, Expr & expr, ts::URL & url) {
 }
 
 /// Set the location in the Host field and URL (if needed).
-void Req_Loc_Set(Context& ctx, Expr & expr, ts::HttpRequest & req) {
+void
+Req_Loc_Set(Context &ctx, Expr &expr, ts::HttpRequest &req)
+{
   auto value = ctx.extract(expr);
   TextView host_token;
   int port = -1; // if still -1 after parsing, the parsing failed.
-  if ( auto loc = std::get_if<IndexFor(STRING)>(&value)
-     ; nullptr != loc && Loc_String_Parse(*loc, host_token, port)
-     ) {
+  if (auto loc = std::get_if<IndexFor(STRING)>(&value); nullptr != loc && Loc_String_Parse(*loc, host_token, port)) {
     req.field_obtain(ts::HTTP_FIELD_HOST).assign(*loc);
-  } else if (auto t = std::get_if<IndexFor(TUPLE)>(&value) ; nullptr != t ) {
+  } else if (auto t = std::get_if<IndexFor(TUPLE)>(&value); nullptr != t) {
     if (t->size() > 0) { // host name, then port.
-      if (auto & f0 = (*t)[0] ; f0.index() == IndexFor(STRING)) {
+      if (auto &f0 = (*t)[0]; f0.index() == IndexFor(STRING)) {
         host_token = std::get<IndexFor(STRING)>(f0);
         if (t->size() > 1) {
-          auto & f1 = (*t)[1];
+          auto &f1 = (*t)[1];
           if (is_empty(f1)) {
             port = 0; // clear port.
           } else {
@@ -375,9 +413,11 @@ void Req_Loc_Set(Context& ctx, Expr & expr, ts::HttpRequest & req) {
 
 } // namespace
 
-class Do_ua_req_url_loc : public Directive {
+class Do_ua_req_url_loc : public Directive
+{
   using super_type = Directive;
-  using self_type = Do_ua_req_url_loc;
+  using self_type  = Do_ua_req_url_loc;
+
 public:
   static inline const std::string KEY = "ua-req-url-loc";
   static const HookMask HOOKS; ///< Valid hooks for directive.
@@ -386,7 +426,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  explicit Do_ua_req_url_loc(Expr && expr);
+  explicit Do_ua_req_url_loc(Expr &&expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -400,17 +440,20 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   Expr _expr; ///< Feature expression.
 };
 
 const HookMask Do_ua_req_url_loc::HOOKS = MaskFor(Hook::PREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP);
 
-Do_ua_req_url_loc::Do_ua_req_url_loc(Expr && expr) : _expr(std::move(expr)) {}
+Do_ua_req_url_loc::Do_ua_req_url_loc(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_url_loc::invoke(Context &ctx) {
+Errata
+Do_ua_req_url_loc::invoke(Context &ctx)
+{
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       URL_Loc_Set(ctx, _expr, url);
@@ -419,13 +462,16 @@ Errata Do_ua_req_url_loc::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_url_loc::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_url_loc::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                        YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy({ STRING, TUPLE } )) {
+  if (!expr.result_type().can_satisfy({STRING, TUPLE})) {
     return Error(R"(Value for "{}" directive at {} must be a {} or a {} of 2 elements.)", KEY, drtv_node.Mark(), STRING, TUPLE);
   }
   return Handle(new self_type{std::move(expr)});
@@ -433,9 +479,11 @@ swoc::Rv<Directive::Handle> Do_ua_req_url_loc::load(Config& cfg, CfgStaticData c
 
 // ---
 
-class Do_proxy_req_url_loc : public Directive {
+class Do_proxy_req_url_loc : public Directive
+{
   using super_type = Directive;
-  using self_type = Do_proxy_req_url_loc;
+  using self_type  = Do_proxy_req_url_loc;
+
 public:
   static inline const std::string KEY = "proxy-req-url-loc";
   static const HookMask HOOKS; ///< Valid hooks for directive.
@@ -444,7 +492,7 @@ public:
    *
    * @param expr Feature expression.
    */
-  explicit Do_proxy_req_url_loc(Expr && expr);
+  explicit Do_proxy_req_url_loc(Expr &&expr);
 
   Errata invoke(Context &ctx) override;
 
@@ -458,17 +506,20 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   Expr _expr; ///< Feature expression.
 };
 
 const HookMask Do_proxy_req_url_loc::HOOKS = MaskFor(Hook::PREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP);
 
-Do_proxy_req_url_loc::Do_proxy_req_url_loc(Expr && expr) : _expr(std::move(expr)) {}
+Do_proxy_req_url_loc::Do_proxy_req_url_loc(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_proxy_req_url_loc::invoke(Context &ctx) {
+Errata
+Do_proxy_req_url_loc::invoke(Context &ctx)
+{
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     if (auto url{hdr.url()}; url.is_valid()) {
       URL_Loc_Set(ctx, _expr, url);
@@ -477,13 +528,16 @@ Errata Do_proxy_req_url_loc::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_url_loc::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_url_loc::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                           YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy({ STRING, TUPLE } )) {
+  if (!expr.result_type().can_satisfy({STRING, TUPLE})) {
     return Error(R"(Value for "{}" directive at {} must be a {} or a {} of 2 elements.)", KEY, drtv_node.Mark(), STRING, TUPLE);
   }
   return Handle(new self_type{std::move(expr)});
@@ -493,18 +547,19 @@ swoc::Rv<Directive::Handle> Do_proxy_req_url_loc::load(Config& cfg, CfgStaticDat
 /** Set the host for the request.
  * This updates both the URL and the "Host" field, if appropriate.
  */
-class Do_ua_req_host : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_host; ///< Self reference type.
+class Do_ua_req_host : public Directive
+{
+  using super_type = Directive;      ///< Parent type.
+  using self_type  = Do_ua_req_host; ///< Self reference type.
 public:
-  static inline const std::string KEY { "ua-req-host" }; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const std::string KEY{"ua-req-host"}; ///< Directive name.
+  static const HookMask HOOKS;                        ///< Valid hooks for directive.
 
   /** Construct with feature expression..
    *
    * @param expr Feature expression.
    */
-  explicit Do_ua_req_host(Expr && expr);
+  explicit Do_ua_req_host(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -523,18 +578,20 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const HookMask Do_ua_req_host::HOOKS {MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const HookMask Do_ua_req_host::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_host::Do_ua_req_host(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_host::invoke(Context &ctx) {
+Errata
+Do_ua_req_host::invoke(Context &ctx)
+{
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     auto value = ctx.extract(_expr);
     if (auto host = std::get_if<IndexFor(STRING)>(&value); nullptr != host) {
@@ -544,13 +601,16 @@ Errata Do_ua_req_host::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_host::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_host::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                     YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), STRING);
   }
   return Handle(new self_type(std::move(expr)));
@@ -559,18 +619,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_host::load(Config& cfg, CfgStaticData cons
 /** Set the port for the user agent request.
  * This updates both the URL and the "Host" field, if appropriate.
  */
-class Do_ua_req_port : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_port; ///< Self reference type.
+class Do_ua_req_port : public Directive
+{
+  using super_type = Directive;      ///< Parent type.
+  using self_type  = Do_ua_req_port; ///< Self reference type.
 public:
-  static inline const std::string KEY { "ua-req-port" }; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const std::string KEY{"ua-req-port"}; ///< Directive name.
+  static const HookMask HOOKS;                        ///< Valid hooks for directive.
 
   /** Construct with feature expression..
    *
    * @param expr Feature expression.
    */
-  explicit Do_ua_req_port(Expr && expr);
+  explicit Do_ua_req_port(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -589,34 +650,39 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const HookMask Do_ua_req_port::HOOKS {MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const HookMask Do_ua_req_port::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_port::Do_ua_req_port(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_port::invoke(Context &ctx) {
+Errata
+Do_ua_req_port::invoke(Context &ctx)
+{
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     auto value = ctx.extract(_expr);
-    if (auto port = value.as_integer(-1) ; port >= 0) {
+    if (auto port = value.as_integer(-1); port >= 0) {
       hdr.port_set(port);
     }
   }
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_port::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_port::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                     YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(INTEGER)) {
+  if (!expr.result_type().can_satisfy(INTEGER)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), INTEGER);
   }
   return Handle(new self_type(std::move(expr)));
@@ -627,18 +693,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_port::load(Config& cfg, CfgStaticData cons
 /** Set the port for the proxy request.
  * This updates both the URL and the "Host" field, if appropriate.
  */
-class Do_proxy_req_port : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_port; ///< Self reference type.
+class Do_proxy_req_port : public Directive
+{
+  using super_type = Directive;         ///< Parent type.
+  using self_type  = Do_proxy_req_port; ///< Self reference type.
 public:
-  static inline const std::string KEY { "proxy-req-port" }; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const std::string KEY{"proxy-req-port"}; ///< Directive name.
+  static const HookMask HOOKS;                           ///< Valid hooks for directive.
 
   /** Construct with feature expression..
    *
    * @param expr Feature expression.
    */
-  explicit Do_proxy_req_port(Expr && expr);
+  explicit Do_proxy_req_port(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -657,34 +724,39 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const HookMask Do_proxy_req_port::HOOKS {MaskFor(Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP) };
+const HookMask Do_proxy_req_port::HOOKS{MaskFor(Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP)};
 
 Do_proxy_req_port::Do_proxy_req_port(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_proxy_req_port::invoke(Context &ctx) {
+Errata
+Do_proxy_req_port::invoke(Context &ctx)
+{
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     auto value = ctx.extract(_expr);
-    if (auto port = value.as_integer(-1) ; port >= 0) {
+    if (auto port = value.as_integer(-1); port >= 0) {
       hdr.port_set(port);
     }
   }
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_port::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_port::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                        YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(INTEGER)) {
+  if (!expr.result_type().can_satisfy(INTEGER)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), INTEGER);
   }
   return Handle(new self_type(std::move(expr)));
@@ -694,18 +766,19 @@ swoc::Rv<Directive::Handle> Do_proxy_req_port::load(Config& cfg, CfgStaticData c
 /** Set the host for the request.
  * This updates both the URL and the "Host" field, if appropriate.
  */
-class Do_proxy_req_host : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_host; ///< Self reference type.
+class Do_proxy_req_host : public Directive
+{
+  using super_type = Directive;         ///< Parent type.
+  using self_type  = Do_proxy_req_host; ///< Self reference type.
 public:
-  static inline const std::string KEY {"proxy-req-host"}; ///< Directive name.
-  static inline const HookMask HOOKS {MaskFor(Hook::PREQ)}; ///< Valid hooks for directive.
+  static inline const std::string KEY{"proxy-req-host"};   ///< Directive name.
+  static inline const HookMask HOOKS{MaskFor(Hook::PREQ)}; ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param fmt Feature for host.
    */
-  explicit Do_proxy_req_host(Expr && fmt);
+  explicit Do_proxy_req_host(Expr &&fmt);
 
   /** Invoke directive.
    *
@@ -724,8 +797,8 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _fmt; ///< Host feature.
@@ -733,7 +806,9 @@ protected:
 
 Do_proxy_req_host::Do_proxy_req_host(Expr &&fmt) : _fmt(std::move(fmt)) {}
 
-Errata Do_proxy_req_host::invoke(Context &ctx) {
+Errata
+Do_proxy_req_host::invoke(Context &ctx)
+{
   TextView host{std::get<IndexFor(STRING)>(ctx.extract(_fmt))};
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     hdr.host_set(host);
@@ -741,33 +816,37 @@ Errata Do_proxy_req_host::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_host::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_host::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                        YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a string.)", KEY, drtv_node.Mark());
   }
-  return  Handle(new self_type(std::move(expr)));
+  return Handle(new self_type(std::move(expr)));
 }
 /* ------------------------------------------------------------------------------------ */
 /** Set the location for the user agent request.
  * This updates both the URL and the "Host" field, if appropriate.
  */
-class Do_ua_req_loc : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_loc; ///< Self reference type.
+class Do_ua_req_loc : public Directive
+{
+  using super_type = Directive;     ///< Parent type.
+  using self_type  = Do_ua_req_loc; ///< Self reference type.
 public:
-  static inline const std::string KEY {"ua-req-loc"}; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const std::string KEY{"ua-req-loc"}; ///< Directive name.
+  static const HookMask HOOKS;                       ///< Valid hooks for directive.
 
   /** Construct with feature expression..
    *
    * @param expr Feature expression.
    */
-  explicit Do_ua_req_loc(Expr && expr);
+  explicit Do_ua_req_loc(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -786,31 +865,36 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const HookMask Do_ua_req_loc::HOOKS {MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const HookMask Do_ua_req_loc::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_loc::Do_ua_req_loc(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_loc::invoke(Context &ctx) {
+Errata
+Do_ua_req_loc::invoke(Context &ctx)
+{
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     Req_Loc_Set(ctx, _expr, hdr);
   }
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_loc::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_loc::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                    YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy({ STRING , TUPLE })) {
+  if (!expr.result_type().can_satisfy({STRING, TUPLE})) {
     return Error(R"(Value for "{}" directive at {} must be a {} or a {}.)", KEY, drtv_node.Mark(), STRING, TUPLE);
   }
   return Handle(new self_type(std::move(expr)));
@@ -819,18 +903,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_loc::load(Config& cfg, CfgStaticData const
 /** Set the location for the proxy request.
  * This updates both the URL and the "Host" field, if appropriate.
  */
-class Do_proxy_req_loc : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_loc; ///< Self reference type.
+class Do_proxy_req_loc : public Directive
+{
+  using super_type = Directive;        ///< Parent type.
+  using self_type  = Do_proxy_req_loc; ///< Self reference type.
 public:
-  static inline const std::string KEY {"proxy-req-loc"}; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const std::string KEY{"proxy-req-loc"}; ///< Directive name.
+  static const HookMask HOOKS;                          ///< Valid hooks for directive.
 
   /** Construct with feature expression..
    *
    * @param expr Feature expression.
    */
-  explicit Do_proxy_req_loc(Expr && expr);
+  explicit Do_proxy_req_loc(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -849,31 +934,36 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const HookMask Do_proxy_req_loc::HOOKS {MaskFor({Hook::PREQ}) };
+const HookMask Do_proxy_req_loc::HOOKS{MaskFor({Hook::PREQ})};
 
 Do_proxy_req_loc::Do_proxy_req_loc(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_proxy_req_loc::invoke(Context &ctx) {
+Errata
+Do_proxy_req_loc::invoke(Context &ctx)
+{
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     Req_Loc_Set(ctx, _expr, hdr);
   }
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_loc::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_loc::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                       YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy({ STRING , TUPLE })) {
+  if (!expr.result_type().can_satisfy({STRING, TUPLE})) {
     return Error(R"(Value for "{}" directive at {} must be a {} or a {}.)", KEY, drtv_node.Mark(), STRING, TUPLE);
   }
   return Handle(new self_type(std::move(expr)));
@@ -881,18 +971,19 @@ swoc::Rv<Directive::Handle> Do_proxy_req_loc::load(Config& cfg, CfgStaticData co
 /* ------------------------------------------------------------------------------------ */
 /** Set the scheme for the inbound request.
  */
-class Do_ua_req_scheme : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_scheme; ///< Self reference type.
+class Do_ua_req_scheme : public Directive
+{
+  using super_type = Directive;        ///< Parent type.
+  using self_type  = Do_ua_req_scheme; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param fmt Feature for host.
    */
-  explicit Do_ua_req_scheme(Expr && fmt);
+  explicit Do_ua_req_scheme(Expr &&fmt);
 
   /** Invoke directive.
    *
@@ -911,19 +1002,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Scheme expression.
 };
 
-const std::string Do_ua_req_scheme::KEY {"ua-req-scheme" };
-const HookMask Do_ua_req_scheme::HOOKS {MaskFor({ Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const std::string Do_ua_req_scheme::KEY{"ua-req-scheme"};
+const HookMask Do_ua_req_scheme::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_scheme::Do_ua_req_scheme(Expr &&fmt) : _expr(std::move(fmt)) {}
 
-Errata Do_ua_req_scheme::invoke(Context &ctx) {
+Errata
+Do_ua_req_scheme::invoke(Context &ctx)
+{
   TextView text{std::get<IndexFor(STRING)>(ctx.extract(_expr))};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     hdr.url().scheme_set(text);
@@ -931,13 +1024,16 @@ Errata Do_ua_req_scheme::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_scheme::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_scheme::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                       YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), STRING);
   }
   return Handle(new self_type(std::move(expr)));
@@ -945,18 +1041,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_scheme::load(Config& cfg, CfgStaticData co
 /* ------------------------------------------------------------------------------------ */
 /** Set the URL for the inbound request.
  */
-class Do_ua_req_url : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_url; ///< Self reference type.
+class Do_ua_req_url : public Directive
+{
+  using super_type = Directive;     ///< Parent type.
+  using self_type  = Do_ua_req_url; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param fmt Feature for host.
    */
-  explicit Do_ua_req_url(Expr && expr);
+  explicit Do_ua_req_url(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -975,19 +1072,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< URL expression.
 };
 
-const std::string Do_ua_req_url::KEY {"ua-req-url" };
-const HookMask Do_ua_req_url::HOOKS {MaskFor({ Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const std::string Do_ua_req_url::KEY{"ua-req-url"};
+const HookMask Do_ua_req_url::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_url::Do_ua_req_url(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_url::invoke(Context &ctx) {
+Errata
+Do_ua_req_url::invoke(Context &ctx)
+{
   TextView text{std::get<IndexFor(STRING)>(ctx.extract(_expr))};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     hdr.url_set(text);
@@ -995,13 +1094,16 @@ Errata Do_ua_req_url::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_url::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_url::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                    YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), STRING);
   }
   return Handle(new self_type(std::move(expr)));
@@ -1009,18 +1111,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_url::load(Config& cfg, CfgStaticData const
 /* ------------------------------------------------------------------------------------ */
 /** Set the scheme for the outbound request.
  */
-class Do_proxy_req_scheme : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_scheme; ///< Self reference type.
+class Do_proxy_req_scheme : public Directive
+{
+  using super_type = Directive;           ///< Parent type.
+  using self_type  = Do_proxy_req_scheme; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param fmt Feature for host.
    */
-  explicit Do_proxy_req_scheme(Expr && fmt);
+  explicit Do_proxy_req_scheme(Expr &&fmt);
 
   /** Invoke directive.
    *
@@ -1039,19 +1142,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _fmt; ///< Host feature.
 };
 
-const std::string Do_proxy_req_scheme::KEY {"proxy-req-scheme" };
-const HookMask Do_proxy_req_scheme::HOOKS {MaskFor({ Hook::PREQ}) };
+const std::string Do_proxy_req_scheme::KEY{"proxy-req-scheme"};
+const HookMask Do_proxy_req_scheme::HOOKS{MaskFor({Hook::PREQ})};
 
 Do_proxy_req_scheme::Do_proxy_req_scheme(Expr &&fmt) : _fmt(std::move(fmt)) {}
 
-Errata Do_proxy_req_scheme::invoke(Context &ctx) {
+Errata
+Do_proxy_req_scheme::invoke(Context &ctx)
+{
   TextView host{std::get<IndexFor(STRING)>(ctx.extract(_fmt))};
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     hdr.url().scheme_set(host);
@@ -1059,13 +1164,16 @@ Errata Do_proxy_req_scheme::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_scheme::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_scheme::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                          YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), STRING);
   }
   return Handle(new self_type(std::move(expr)));
@@ -1073,18 +1181,19 @@ swoc::Rv<Directive::Handle> Do_proxy_req_scheme::load(Config& cfg, CfgStaticData
 /* ------------------------------------------------------------------------------------ */
 /** Set the URL for the outbound request.
  */
-class Do_proxy_req_url : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_url; ///< Self reference type.
+class Do_proxy_req_url : public Directive
+{
+  using super_type = Directive;        ///< Parent type.
+  using self_type  = Do_proxy_req_url; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature expression..
    *
    * @param expr Feature expression for the URL.
    */
-  explicit Do_proxy_req_url(Expr && expr);
+  explicit Do_proxy_req_url(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -1103,19 +1212,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< URL expression.
 };
 
-const std::string Do_proxy_req_url::KEY {"proxy-req-url" };
-const HookMask Do_proxy_req_url::HOOKS {MaskFor({ Hook::PREQ }) };
+const std::string Do_proxy_req_url::KEY{"proxy-req-url"};
+const HookMask Do_proxy_req_url::HOOKS{MaskFor({Hook::PREQ})};
 
 Do_proxy_req_url::Do_proxy_req_url(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_proxy_req_url::invoke(Context &ctx) {
+Errata
+Do_proxy_req_url::invoke(Context &ctx)
+{
   TextView text{std::get<IndexFor(STRING)>(ctx.extract(_expr))};
   if (auto hdr{ctx.proxy_req_hdr()}; hdr.is_valid()) {
     hdr.url_set(text);
@@ -1123,29 +1234,34 @@ Errata Do_proxy_req_url::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_url::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_url::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                       YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a {}.)", KEY, drtv_node.Mark(), STRING);
   }
   return Handle(new self_type(std::move(expr)));
 }
 /* ------------------------------------------------------------------------------------ */
-class Do_did_remap : public Directive {
+class Do_did_remap : public Directive
+{
   using self_type = Do_did_remap;
+
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature expression..
    *
    * @param expr Feature expression for the URL.
    */
-  explicit Do_did_remap(Expr && expr);
+  explicit Do_did_remap(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -1164,34 +1280,40 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   Expr _expr; ///< Boolean to set whether remap was done.
 };
 
-const std::string Do_did_remap::KEY {"did-remap" };
-const HookMask Do_did_remap::HOOKS {MaskFor(Hook::REMAP) };
+const std::string Do_did_remap::KEY{"did-remap"};
+const HookMask Do_did_remap::HOOKS{MaskFor(Hook::REMAP)};
 
-Do_did_remap::Do_did_remap(Expr && expr) : _expr(std::move(expr)) {}
+Do_did_remap::Do_did_remap(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_did_remap::invoke(Context& ctx) {
-  auto f = ctx.extract(_expr);
+Errata
+Do_did_remap::invoke(Context &ctx)
+{
+  auto f            = ctx.extract(_expr);
   ctx._remap_status = f.as_bool() ? TSREMAP_DID_REMAP : TSREMAP_NO_REMAP;
   return {};
 }
 
-Rv<Directive::Handle> Do_did_remap::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_did_remap::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                   YAML::Node key_value)
+{
   // Default, with no value, is @c true.
   if (key_value.IsNull()) {
     return Handle{new self_type(Expr(true))};
   }
-  auto && [ expr, errata ] { cfg.parse_expr(key_value)};
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
   if (!errata.is_ok()) {
     errata.info(R"(While parsing value of "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(BOOLEAN)) {
+  if (!expr.result_type().can_satisfy(BOOLEAN)) {
     return Error(R"(Value for "{}" directive at {} must be convertible to a {}.)", KEY, drtv_node.Mark(), BOOLEAN);
   }
   return Handle{new self_type{std::move(expr)}};
@@ -1200,12 +1322,13 @@ Rv<Directive::Handle> Do_did_remap::load(Config& cfg, CfgStaticData const*, YAML
 /* ------------------------------------------------------------------------------------ */
 /** Do the remap.
  */
-class Do_apply_remap_rule : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_apply_remap_rule; ///< Self reference type.
+class Do_apply_remap_rule : public Directive
+{
+  using super_type = Directive;           ///< Parent type.
+  using self_type  = Do_apply_remap_rule; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Invoke directive.
    *
@@ -1224,22 +1347,24 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 };
 
-const std::string Do_apply_remap_rule::KEY { "apply-remap-rule" };
-const HookMask Do_apply_remap_rule::HOOKS { MaskFor(Hook::REMAP) };
+const std::string Do_apply_remap_rule::KEY{"apply-remap-rule"};
+const HookMask Do_apply_remap_rule::HOOKS{MaskFor(Hook::REMAP)};
 
-Errata Do_apply_remap_rule::invoke(Context &ctx) {
+Errata
+Do_apply_remap_rule::invoke(Context &ctx)
+{
   ctx._remap_status = TSREMAP_DID_REMAP;
   // This is complex because the internal logic is as well. A bit fragile, but this is
   // really only useful as a backwards compatibility fix for pre ATS 9 and should eventually
   // be removed.
   // Copy over the host and port.
-  ts::URL replacement_url { ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl };
-  ts::URL target_url { ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl };
-  ts::URL request_url { ctx._remap_info->requestBufp, ctx._remap_info->requestUrl };
+  ts::URL replacement_url{ctx._remap_info->requestBufp, ctx._remap_info->mapToUrl};
+  ts::URL target_url{ctx._remap_info->requestBufp, ctx._remap_info->mapFromUrl};
+  ts::URL request_url{ctx._remap_info->requestBufp, ctx._remap_info->requestUrl};
 
   in_port_t port = replacement_url.port();
   // decanonicalize the port - may need to dig in and see if it was explicitly set.
@@ -1252,16 +1377,16 @@ Errata Do_apply_remap_rule::invoke(Context &ctx) {
   if (ts::HttpRequest{ctx._remap_info->requestBufp, ctx._remap_info->requestHdrp}.method() != "CONNECT"_tv) {
     request_url.scheme_set(replacement_url.scheme());
     // Update the path as needed.
-    auto replacement_path { replacement_url.path() };
-    auto target_path { target_url.path() };
-    auto request_path { request_url.path() };
+    auto replacement_path{replacement_url.path()};
+    auto target_path{target_url.path()};
+    auto request_path{request_url.path()};
 
     // Need to do better - see if Context can provide an ArenaWriter?
-    swoc::LocalBufferWriter<(1<<16) - 1> url_w;
+    swoc::LocalBufferWriter<(1 << 16) - 1> url_w;
     url_w.write(replacement_path);
     if (request_path.size() > target_path.size()) {
       // Always slash separate the replacement from the remnant of the incoming request path.
-      if (url_w.size() && url_w.view()[url_w.size()-1] != '/') {
+      if (url_w.size() && url_w.view()[url_w.size() - 1] != '/') {
         url_w.write('/');
       }
       // Already have the separating slash, trim it from the target path.
@@ -1273,24 +1398,27 @@ Errata Do_apply_remap_rule::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_apply_remap_rule::load(Config&, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const&, YAML::Node) {
+swoc::Rv<Directive::Handle>
+Do_apply_remap_rule::load(Config &, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &, YAML::Node)
+{
   return Handle(new self_type);
 }
 /* ------------------------------------------------------------------------------------ */
 /** Set the path for the request.
  */
-class Do_ua_req_path : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_path; ///< Self reference type.
+class Do_ua_req_path : public Directive
+{
+  using super_type = Directive;      ///< Parent type.
+  using self_type  = Do_ua_req_path; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a expr.
    *
    * @param expr Feature for host.
    */
-  explicit Do_ua_req_path(Expr && expr);
+  explicit Do_ua_req_path(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -1309,21 +1437,23 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const std::string Do_ua_req_path::KEY {"ua-req-path" };
-const HookMask Do_ua_req_path::HOOKS {MaskFor({ Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const std::string Do_ua_req_path::KEY{"ua-req-path"};
+const HookMask Do_ua_req_path::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_path::Do_ua_req_path(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_path::invoke(Context &ctx) {
-  auto value { ctx.extract(_expr)};
-  if (auto text = std::get_if<IndexFor(STRING)>(&value) ; text ) {
+Errata
+Do_ua_req_path::invoke(Context &ctx)
+{
+  auto value{ctx.extract(_expr)};
+  if (auto text = std::get_if<IndexFor(STRING)>(&value); text) {
     if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
       hdr.url().path_set(*text);
     }
@@ -1331,9 +1461,12 @@ Errata Do_ua_req_path::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_path::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_path::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                     YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
@@ -1345,18 +1478,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_path::load(Config& cfg, CfgStaticData cons
 /* ------------------------------------------------------------------------------------ */
 /** Set the query for the request.
  */
-class Do_ua_req_query : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_query; ///< Self reference type.
+class Do_ua_req_query : public Directive
+{
+  using super_type = Directive;       ///< Parent type.
+  using self_type  = Do_ua_req_query; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param expr Feature for host.
    */
-  explicit Do_ua_req_query(Expr && expr);
+  explicit Do_ua_req_query(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -1375,19 +1509,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const std::string Do_ua_req_query::KEY {"ua-req-query" };
-const HookMask Do_ua_req_query::HOOKS {MaskFor({ Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const std::string Do_ua_req_query::KEY{"ua-req-query"};
+const HookMask Do_ua_req_query::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_query::Do_ua_req_query(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_query::invoke(Context &ctx) {
+Errata
+Do_ua_req_query::invoke(Context &ctx)
+{
   TextView text{std::get<IndexFor(STRING)>(ctx.extract(_expr))};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     hdr.url().query_set(text);
@@ -1395,14 +1531,17 @@ Errata Do_ua_req_query::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_query::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_query::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                      YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
   if (expr.is_null()) {
-    expr= Feature{FeatureView::Literal(""_tv)};
+    expr = Feature{FeatureView::Literal(""_tv)};
   }
   if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a string.)", KEY, drtv_node.Mark());
@@ -1412,18 +1551,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_query::load(Config& cfg, CfgStaticData con
 /* ------------------------------------------------------------------------------------ */
 /** Set the fragment for the request.
  */
-class Do_ua_req_fragment : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_ua_req_fragment; ///< Self reference type.
+class Do_ua_req_fragment : public Directive
+{
+  using super_type = Directive;          ///< Parent type.
+  using self_type  = Do_ua_req_fragment; ///< Self reference type.
 public:
-  static inline const std::string KEY { "ua-req-fragment" }; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const std::string KEY{"ua-req-fragment"}; ///< Directive name.
+  static const HookMask HOOKS;                            ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param expr Feature for host.
    */
-  explicit Do_ua_req_fragment(Expr && expr);
+  explicit Do_ua_req_fragment(Expr &&expr);
 
   /** Invoke directive.
    *
@@ -1442,18 +1582,20 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Host feature.
 };
 
-const HookMask Do_ua_req_fragment::HOOKS {MaskFor({ Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const HookMask Do_ua_req_fragment::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
 Do_ua_req_fragment::Do_ua_req_fragment(Expr &&expr) : _expr(std::move(expr)) {}
 
-Errata Do_ua_req_fragment::invoke(Context &ctx) {
+Errata
+Do_ua_req_fragment::invoke(Context &ctx)
+{
   TextView text{std::get<IndexFor(STRING)>(ctx.extract(_expr))};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     hdr.url().fragment_set(text);
@@ -1461,14 +1603,17 @@ Errata Do_ua_req_fragment::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_ua_req_fragment::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_ua_req_fragment::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                         YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
   if (expr.is_null()) {
-    expr= Feature{FeatureView::Literal(""_tv)};
+    expr = Feature{FeatureView::Literal(""_tv)};
   }
   if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(Value for "{}" directive at {} must be a string.)", KEY, drtv_node.Mark());
@@ -1478,18 +1623,19 @@ swoc::Rv<Directive::Handle> Do_ua_req_fragment::load(Config& cfg, CfgStaticData 
 /* ------------------------------------------------------------------------------------ */
 /** Set the path for the request.
  */
-class Do_proxy_req_path : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_path; ///< Self reference type.
+class Do_proxy_req_path : public Directive
+{
+  using super_type = Directive;         ///< Parent type.
+  using self_type  = Do_proxy_req_path; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param fmt Feature for host.
    */
-  explicit Do_proxy_req_path(Expr && fmt);
+  explicit Do_proxy_req_path(Expr &&fmt);
 
   /** Invoke directive.
    *
@@ -1508,19 +1654,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _fmt; ///< Host feature.
 };
 
-const std::string Do_proxy_req_path::KEY {"proxy-req-path" };
-const HookMask Do_proxy_req_path::HOOKS {MaskFor({ Hook::PREQ }) };
+const std::string Do_proxy_req_path::KEY{"proxy-req-path"};
+const HookMask Do_proxy_req_path::HOOKS{MaskFor({Hook::PREQ})};
 
 Do_proxy_req_path::Do_proxy_req_path(Expr &&fmt) : _fmt(std::move(fmt)) {}
 
-Errata Do_proxy_req_path::invoke(Context &ctx) {
+Errata
+Do_proxy_req_path::invoke(Context &ctx)
+{
   TextView host{std::get<IndexFor(STRING)>(ctx.extract(_fmt))};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     hdr.url().path_set(host);
@@ -1528,9 +1676,12 @@ Errata Do_proxy_req_path::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_path::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_path::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                        YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
@@ -1542,18 +1693,19 @@ swoc::Rv<Directive::Handle> Do_proxy_req_path::load(Config& cfg, CfgStaticData c
 /* ------------------------------------------------------------------------------------ */
 /** Set the query for the request.
  */
-class Do_proxy_req_query : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_query; ///< Self reference type.
+class Do_proxy_req_query : public Directive
+{
+  using super_type = Directive;          ///< Parent type.
+  using self_type  = Do_proxy_req_query; ///< Self reference type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param fmt Feature for host.
    */
-  explicit Do_proxy_req_query(Expr && fmt);
+  explicit Do_proxy_req_query(Expr &&fmt);
 
   /** Invoke directive.
    *
@@ -1572,19 +1724,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _fmt; ///< Host feature.
 };
 
-const std::string Do_proxy_req_query::KEY {"proxy-req-query" };
-const HookMask Do_proxy_req_query::HOOKS {MaskFor({ Hook::PREQ}) };
+const std::string Do_proxy_req_query::KEY{"proxy-req-query"};
+const HookMask Do_proxy_req_query::HOOKS{MaskFor({Hook::PREQ})};
 
 Do_proxy_req_query::Do_proxy_req_query(Expr &&fmt) : _fmt(std::move(fmt)) {}
 
-Errata Do_proxy_req_query::invoke(Context &ctx) {
+Errata
+Do_proxy_req_query::invoke(Context &ctx)
+{
   TextView text{std::get<IndexFor(STRING)>(ctx.extract(_fmt))};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     hdr.url().query_set(text);
@@ -1592,9 +1746,12 @@ Errata Do_proxy_req_query::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_query::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_query::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                         YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
@@ -1606,18 +1763,19 @@ swoc::Rv<Directive::Handle> Do_proxy_req_query::load(Config& cfg, CfgStaticData 
 /* ------------------------------------------------------------------------------------ */
 /** Set the fragment for the request.
  */
-class Do_proxy_req_fragment : public Directive {
-  using super_type = Directive; ///< Parent type.
-  using self_type = Do_proxy_req_fragment; ///< Self reference type.
+class Do_proxy_req_fragment : public Directive
+{
+  using super_type = Directive;             ///< Parent type.
+  using self_type  = Do_proxy_req_fragment; ///< Self reference type.
 public:
-  static inline const std::string KEY { "proxy-req-fragment" }; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const std::string KEY{"proxy-req-fragment"}; ///< Directive name.
+  static const HookMask HOOKS;                               ///< Valid hooks for directive.
 
   /** Construct with feature extractor @a fmt.
    *
    * @param fmt Feature for host.
    */
-  explicit Do_proxy_req_fragment(Expr && fmt);
+  explicit Do_proxy_req_fragment(Expr &&fmt);
 
   /** Invoke directive.
    *
@@ -1636,18 +1794,20 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _fmt; ///< Host feature.
 };
 
-const HookMask Do_proxy_req_fragment::HOOKS {MaskFor({ Hook::PREQ}) };
+const HookMask Do_proxy_req_fragment::HOOKS{MaskFor({Hook::PREQ})};
 
 Do_proxy_req_fragment::Do_proxy_req_fragment(Expr &&fmt) : _fmt(std::move(fmt)) {}
 
-Errata Do_proxy_req_fragment::invoke(Context &ctx) {
+Errata
+Do_proxy_req_fragment::invoke(Context &ctx)
+{
   TextView text{std::get<IndexFor(STRING)>(ctx.extract(_fmt))};
   if (auto hdr{ctx.ua_req_hdr()}; hdr.is_valid()) {
     hdr.url().fragment_set(text);
@@ -1655,9 +1815,12 @@ Errata Do_proxy_req_fragment::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_proxy_req_fragment::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+swoc::Rv<Directive::Handle>
+Do_proxy_req_fragment::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &,
+                            swoc::TextView const &, YAML::Node key_value)
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing "{}" directive at {}.)", KEY, drtv_node.Mark());
     return std::move(errata);
   }
@@ -1667,19 +1830,20 @@ swoc::Rv<Directive::Handle> Do_proxy_req_fragment::load(Config& cfg, CfgStaticDa
   return Handle(new self_type(std::move(expr)));
 }
 /* ------------------------------------------------------------------------------------ */
-class FieldDirective : public Directive {
-  using self_type = FieldDirective; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class FieldDirective : public Directive
+{
+  using self_type  = FieldDirective; ///< Self reference type.
+  using super_type = Directive;      ///< Parent type.
 protected:
   TextView _name; ///< Field name.
-  Expr _expr; ///< Value for field.
+  Expr _expr;     ///< Value for field.
 
   /** Base constructor.
    *
    * @param name Name of the field.
    * @param expr Value to assign to the field.
    */
-  FieldDirective(TextView const& name, Expr && expr);
+  FieldDirective(TextView const &name, Expr &&expr);
 
   /** Load from configuration.
    *
@@ -1690,7 +1854,8 @@ protected:
    * @param key_value  Value of the node for @a key.
    * @return An instance of the directive for @a key, or errors.
    */
-  static Rv<Handle> load(Config& cfg, std::function<Handle (TextView const& name, Expr && fmt)> const& maker, TextView const& key, TextView const& name, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, std::function<Handle(TextView const &name, Expr &&fmt)> const &maker, TextView const &key,
+                         TextView const &name, YAML::Node key_value);
 
   /** Invoke the directive on an HTTP header.
    *
@@ -1698,7 +1863,7 @@ protected:
    * @param hdr HTTP header.
    * @return Errors, if any.
    */
-  Errata invoke_on_hdr(Context& ctx, ts::HttpHeader && hdr);
+  Errata invoke_on_hdr(Context &ctx, ts::HttpHeader &&hdr);
 
   /** Get the directive name (key).
    *
@@ -1708,19 +1873,25 @@ protected:
    */
   virtual swoc::TextView key() const = 0;
 
-  template < typename T > void apply(Context&, ts::HttpHeader &&, T const&) {}
+  template <typename T>
+  void
+  apply(Context &, ts::HttpHeader &&, T const &)
+  {
+  }
 
   /// Visitor to perform the assignment.
   struct Apply {
-    Context & _ctx; ///< Runtime context.
-    ts::HttpHeader & _hdr; ///< HTTP Header to modify.
-    ts::HttpField _field; ///< Working field.
-    TextView const& _name; ///< Field name.
+    Context &_ctx;         ///< Runtime context.
+    ts::HttpHeader &_hdr;  ///< HTTP Header to modify.
+    ts::HttpField _field;  ///< Working field.
+    TextView const &_name; ///< Field name.
 
-    Apply(Context & ctx, ts::HttpHeader & hdr, TextView const& name) : _ctx(ctx), _hdr(hdr), _field(hdr.field(name)), _name(name) {}
+    Apply(Context &ctx, ts::HttpHeader &hdr, TextView const &name) : _ctx(ctx), _hdr(hdr), _field(hdr.field(name)), _name(name) {}
 
     /// Clear all duplicate fields past @a _field.
-    void clear_dups() {
+    void
+    clear_dups()
+    {
       if (_field.is_valid()) {
         for (auto nf = _field.next_dup(); nf.is_valid();) {
           nf.destroy();
@@ -1730,7 +1901,9 @@ protected:
 
     /// Assigned @a text to a single field, creating as needed.
     /// @return @c true if a field value was changed, @c false if the current value is @a text.
-    void assign(TextView const& text) {
+    void
+    assign(TextView const &text)
+    {
       if (_field.is_valid()) {
         if (_field.value() != text) {
           _field.assign(text);
@@ -1741,7 +1914,8 @@ protected:
     }
 
     /// Nil / NULL means destroy the field.
-    void operator()(feature_type_for<NIL>) {
+    void operator()(feature_type_for<NIL>)
+    {
       if (_field.is_valid()) {
         this->clear_dups();
         _field.destroy();
@@ -1749,15 +1923,19 @@ protected:
     }
 
     /// Assign the string, clear out any dups.
-    void operator()(feature_type_for<STRING>& text) {
+    void
+    operator()(feature_type_for<STRING> &text)
+    {
       this->assign(text);
       this->clear_dups();
     }
 
     /// Assign the tuple elements to duplicate fields.
-    void operator()(feature_type_for<TUPLE>& t) {
-      for (auto const& tf : t) {
-        auto text { std::get<STRING>(tf.join(_ctx, ", "_tv)) };
+    void
+    operator()(feature_type_for<TUPLE> &t)
+    {
+      for (auto const &tf : t) {
+        auto text{std::get<STRING>(tf.join(_ctx, ", "_tv))};
         // skip to next equal field, destroying mismatched fields.
         // once @a _field becomes invalid, it remains in that state.
         while (_field.is_valid() && _field.value() != text) {
@@ -1775,17 +1953,21 @@ protected:
     }
 
     // Other types, convert to string
-    template<typename T> auto operator()(T&& t) -> EnableForFeatureTypes<T, void> {
-      this->assign(_ctx.template render_transient([&t](BufferWriter & w) { bwformat(w, bwf::Spec::DEFAULT, t); }));
+    template <typename T>
+    auto
+    operator()(T &&t) -> EnableForFeatureTypes<T, void>
+    {
+      this->assign(_ctx.template render_transient([&t](BufferWriter &w) { bwformat(w, bwf::Spec::DEFAULT, t); }));
       this->clear_dups();
     }
   };
-
 };
 
 FieldDirective::FieldDirective(TextView const &name, Expr &&expr) : _name(name), _expr(std::move(expr)) {}
 
-Errata FieldDirective::invoke_on_hdr(Context& ctx, ts::HttpHeader&& hdr) {
+Errata
+FieldDirective::invoke_on_hdr(Context &ctx, ts::HttpHeader &&hdr)
+{
   if (hdr.is_valid()) {
     auto value{ctx.extract(this->_expr)};
     std::visit(Apply(ctx, hdr, _name), value);
@@ -1794,19 +1976,18 @@ Errata FieldDirective::invoke_on_hdr(Context& ctx, ts::HttpHeader&& hdr) {
   return Errata().error(R"(Failed to assign field value due to invalid HTTP header.)");
 }
 
-auto FieldDirective::load(Config &cfg
-                         , std::function<Handle(TextView const &, Expr &&)> const &maker
-                         , TextView const &key, TextView const &arg
-                         , YAML::Node key_value
-                         ) -> Rv<Handle> {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+auto
+FieldDirective::load(Config &cfg, std::function<Handle(TextView const &, Expr &&)> const &maker, TextView const &key,
+                     TextView const &arg, YAML::Node key_value) -> Rv<Handle>
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing value for "{}".)", key);
     return std::move(errata);
   }
 
   auto expr_type = expr.result_type();
-  if (! expr_type.has_value()) {
+  if (!expr_type.has_value()) {
     return Error(R"(Directive "{}" must have a value.)", key);
   }
   return maker(cfg.localize(arg), std::move(expr));
@@ -1815,15 +1996,17 @@ auto FieldDirective::load(Config &cfg
 // -- Implementations --
 
 // --
-class Do_ua_req_field : public FieldDirective {
-  using self_type = Do_ua_req_field;
+class Do_ua_req_field : public FieldDirective
+{
+  using self_type  = Do_ua_req_field;
   using super_type = FieldDirective;
+
 public:
   static const std::string KEY; ///< Directive key.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
   using super_type::invoke;
-  Errata invoke(Context & ctx) override;
+  Errata invoke(Context &ctx) override;
 
   /** Load from YAML node.
    *
@@ -1835,34 +2018,47 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   using super_type::super_type; // Inherit super_type constructors.
-  TextView key() const override { return KEY; }
+  TextView
+  key() const override
+  {
+    return KEY;
+  }
 };
 
-const std::string Do_ua_req_field::KEY {"ua-req-field" };
-const HookMask Do_ua_req_field::HOOKS {MaskFor({ Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP }) };
+const std::string Do_ua_req_field::KEY{"ua-req-field"};
+const HookMask Do_ua_req_field::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
-Errata Do_ua_req_field::invoke(Context &ctx) {
+Errata
+Do_ua_req_field::invoke(Context &ctx)
+{
   return this->invoke_on_hdr(ctx, ctx.ua_req_hdr());
 }
 
-Rv<Directive::Handle> Do_ua_req_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
-  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+Rv<Directive::Handle>
+Do_ua_req_field::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+                      YAML::Node key_value)
+{
+  return super_type::load(
+    cfg, [](TextView const &name, Expr &&fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg,
+    key_value);
 }
 
 // --
-class Do_proxy_req_field : public FieldDirective {
-  using self_type = Do_proxy_req_field;
+class Do_proxy_req_field : public FieldDirective
+{
+  using self_type  = Do_proxy_req_field;
   using super_type = FieldDirective;
+
 public:
   static const std::string KEY; ///< Directive key.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override;
+  Errata invoke(Context &ctx) override;
 
   /** Load from YAML node.
    *
@@ -1874,34 +2070,47 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   using super_type::super_type; // Inherit super_type constructors.
-  TextView key() const override { return KEY; }
+  TextView
+  key() const override
+  {
+    return KEY;
+  }
 };
 
-const std::string Do_proxy_req_field::KEY {"proxy-req-field" };
-const HookMask Do_proxy_req_field::HOOKS {MaskFor({ Hook::PREQ }) };
+const std::string Do_proxy_req_field::KEY{"proxy-req-field"};
+const HookMask Do_proxy_req_field::HOOKS{MaskFor({Hook::PREQ})};
 
-Errata Do_proxy_req_field::invoke(Context &ctx) {
+Errata
+Do_proxy_req_field::invoke(Context &ctx)
+{
   return this->invoke_on_hdr(ctx, ctx.proxy_req_hdr());
 }
 
-Rv<Directive::Handle> Do_proxy_req_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
-  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+Rv<Directive::Handle>
+Do_proxy_req_field::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+                         YAML::Node key_value)
+{
+  return super_type::load(
+    cfg, [](TextView const &name, Expr &&fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg,
+    key_value);
 }
 
 // --
-class Do_proxy_rsp_field : public FieldDirective {
-  using self_type = Do_proxy_rsp_field;
+class Do_proxy_rsp_field : public FieldDirective
+{
+  using self_type  = Do_proxy_rsp_field;
   using super_type = FieldDirective;
+
 public:
   static const std::string KEY; ///< Directive key.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override;
+  Errata invoke(Context &ctx) override;
 
   /** Load from YAML node.
    *
@@ -1913,34 +2122,47 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   using super_type::super_type; // Inherit super_type constructors.
-  TextView key() const override { return KEY; }
+  TextView
+  key() const override
+  {
+    return KEY;
+  }
 };
 
-const std::string Do_proxy_rsp_field::KEY {"proxy-rsp-field" };
-const HookMask Do_proxy_rsp_field::HOOKS {MaskFor(Hook::PRSP) };
+const std::string Do_proxy_rsp_field::KEY{"proxy-rsp-field"};
+const HookMask Do_proxy_rsp_field::HOOKS{MaskFor(Hook::PRSP)};
 
-Errata Do_proxy_rsp_field::invoke(Context &ctx) {
+Errata
+Do_proxy_rsp_field::invoke(Context &ctx)
+{
   return this->invoke_on_hdr(ctx, ctx.proxy_rsp_hdr());
 }
 
-Rv<Directive::Handle> Do_proxy_rsp_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
-  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+Rv<Directive::Handle>
+Do_proxy_rsp_field::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+                         YAML::Node key_value)
+{
+  return super_type::load(
+    cfg, [](TextView const &name, Expr &&fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg,
+    key_value);
 }
 
 // --
-class Do_upstream_rsp_field : public FieldDirective {
-  using self_type = Do_upstream_rsp_field;
+class Do_upstream_rsp_field : public FieldDirective
+{
+  using self_type  = Do_upstream_rsp_field;
   using super_type = FieldDirective;
+
 public:
   static const std::string KEY; ///< Directive key.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override;
+  Errata invoke(Context &ctx) override;
 
   /** Load from YAML node.
    *
@@ -1952,38 +2174,51 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   using super_type::super_type; // Inherit super_type constructors.
-  TextView key() const override { return KEY; }
+  TextView
+  key() const override
+  {
+    return KEY;
+  }
 };
 
-const std::string Do_upstream_rsp_field::KEY {"upstream-rsp-field" };
-const HookMask Do_upstream_rsp_field::HOOKS {MaskFor(Hook::URSP) };
+const std::string Do_upstream_rsp_field::KEY{"upstream-rsp-field"};
+const HookMask Do_upstream_rsp_field::HOOKS{MaskFor(Hook::URSP)};
 
-Errata Do_upstream_rsp_field::invoke(Context &ctx) {
+Errata
+Do_upstream_rsp_field::invoke(Context &ctx)
+{
   return this->invoke_on_hdr(ctx, ctx.upstream_rsp_hdr());
 }
 
-Rv<Directive::Handle> Do_upstream_rsp_field::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
-  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+Rv<Directive::Handle>
+Do_upstream_rsp_field::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+                            YAML::Node key_value)
+{
+  return super_type::load(
+    cfg, [](TextView const &name, Expr &&fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg,
+    key_value);
 }
 /* ------------------------------------------------------------------------------------ */
-class QueryValueDirective : public Directive {
-  using self_type = QueryValueDirective;
+class QueryValueDirective : public Directive
+{
+  using self_type  = QueryValueDirective;
   using super_type = Directive;
+
 public:
   TextView _name; ///< Query value key name.
-  Expr _expr; ///< Replacement value.
+  Expr _expr;     ///< Replacement value.
 
   /** Base constructor.
    *
    * @param name Name of the field.
    * @param expr Value to assign to the field.
    */
-  QueryValueDirective(TextView const& name, Expr && expr);
+  QueryValueDirective(TextView const &name, Expr &&expr);
 
   /** Load from configuration.
    *
@@ -1994,7 +2229,8 @@ public:
    * @param key_value  Value of the node for @a key.
    * @return An instance of the directive for @a key, or errors.
    */
-  static Rv<Handle> load(Config& cfg, std::function<Handle (TextView const& name, Expr && fmt)> const& maker, TextView const& key, TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, std::function<Handle(TextView const &name, Expr &&fmt)> const &maker, TextView const &key,
+                         TextView const &arg, YAML::Node key_value);
 
   /** Invoke the directive on a URL.
    *
@@ -2002,7 +2238,7 @@ public:
    * @param url URL.
    * @return Errors, if any.
    */
-  Errata invoke_on_url(Context& ctx, ts::URL && url);
+  Errata invoke_on_url(Context &ctx, ts::URL &&url);
 
 protected:
   /** Get the directive name (key).
@@ -2012,38 +2248,37 @@ protected:
    * Used by subclasses to provide the key for diagnostics.
    */
   virtual swoc::TextView key() const = 0;
-
 };
 
-QueryValueDirective::QueryValueDirective(TextView const& name, Expr && expr) : _name(name), _expr(std::move(expr)) {}
+QueryValueDirective::QueryValueDirective(TextView const &name, Expr &&expr) : _name(name), _expr(std::move(expr)) {}
 
-auto QueryValueDirective::load(Config& cfg
-                              , std::function<Handle(const TextView&, Expr&&)> const& maker
-                              , TextView const& key
-                              , TextView const& arg
-                              , YAML::Node key_value
-                              ) -> Rv<Handle> {
-  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
-  if (! errata.is_ok()) {
+auto
+QueryValueDirective::load(Config &cfg, std::function<Handle(const TextView &, Expr &&)> const &maker, TextView const &key,
+                          TextView const &arg, YAML::Node key_value) -> Rv<Handle>
+{
+  auto &&[expr, errata]{cfg.parse_expr(key_value)};
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing value for "{}".)", key);
     return std::move(errata);
   }
 
   auto expr_type = expr.result_type();
-  if (! expr_type.has_value()) {
+  if (!expr_type.has_value()) {
     return Error(R"(Directive "{}" must have a value.)", key);
   }
   return maker(cfg.localize(arg), std::move(expr));
 }
 
-Errata QueryValueDirective::invoke_on_url(Context& ctx, ts::URL && url) {
+Errata
+QueryValueDirective::invoke_on_url(Context &ctx, ts::URL &&url)
+{
   if (url.is_valid()) {
-    auto nv { ctx.extract(_expr)};
+    auto nv{ctx.extract(_expr)};
     bool nv_is_str_p = (nv.value_type() == STRING);
-    auto qs = url.query();
+    auto qs          = url.query();
     if (qs.empty()) {
       if (nv_is_str_p) {
-        qs = ctx.render_transient([&](BufferWriter&w){ w.print("{}={}", _name, std::get<STRING>(nv));});
+        qs = ctx.render_transient([&](BufferWriter &w) { w.print("{}={}", _name, std::get<STRING>(nv)); });
         url.query_set(qs);
         ctx.transient_discard();
       }
@@ -2051,25 +2286,23 @@ Errata QueryValueDirective::invoke_on_url(Context& ctx, ts::URL && url) {
       auto value = ts::query_value_for(qs, _name, true);
       if (value.data() == nullptr) { // not found at all.
         if (nv_is_str_p) {
-          auto str = ctx.render_transient([&](BufferWriter&w) {
-            w.print("{}&{}={}", qs, _name, std::get<STRING>(nv));
-          });
+          auto str = ctx.render_transient([&](BufferWriter &w) { w.print("{}&{}={}", qs, _name, std::get<STRING>(nv)); });
           url.query_set(str);
           ctx.transient_discard();
         }
       } else {
         // Prefix is the part before the value, less the name and if there is a value,
         // the '=' separator.
-        TextView prefix { qs.data(), value.data() - _name.size()};
-        if (value.size()) { prefix.remove_suffix(1); }
+        TextView prefix{qs.data(), value.data() - _name.size()};
+        if (value.size()) {
+          prefix.remove_suffix(1);
+        }
         // Suffix is the part after the value.
-        TextView suffix { value.end(), qs.end() };
+        TextView suffix{value.end(), qs.end()};
         TextView str;
         if (nv_is_str_p) {
           // If replacement, the separators on either side should be correct.
-          str = ctx.render_transient([&](BufferWriter&w) {
-            w.print("{}{}={}{}", prefix, _name, std::get<STRING>(nv), suffix);
-          });
+          str = ctx.render_transient([&](BufferWriter &w) { w.print("{}{}={}{}", prefix, _name, std::get<STRING>(nv), suffix); });
         } else {
           prefix.rtrim("&;"_tv);
           suffix.ltrim("&;"_tv);
@@ -2078,7 +2311,7 @@ Errata QueryValueDirective::invoke_on_url(Context& ctx, ts::URL && url) {
           } else if (prefix.empty()) {
             str = suffix;
           } else { // neither is empty.
-            str = ctx.render_transient([&](BufferWriter&w) {w.print("{}&{}", prefix, suffix);});
+            str = ctx.render_transient([&](BufferWriter &w) { w.print("{}&{}", prefix, suffix); });
           }
         }
         url.query_set(str);
@@ -2090,66 +2323,96 @@ Errata QueryValueDirective::invoke_on_url(Context& ctx, ts::URL && url) {
 }
 
 // --
-class Do_ua_req_query_value : public QueryValueDirective {
-  using self_type = Do_ua_req_query_value;
+class Do_ua_req_query_value : public QueryValueDirective
+{
+  using self_type  = Do_ua_req_query_value;
   using super_type = QueryValueDirective;
+
 public:
-  static inline const std::string KEY { "ua-req-query-value" }; ///< Directive key.
-  static inline const HookMask HOOKS { MaskFor(Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP)}; ///< Valid hooks for directive.
+  static inline const std::string KEY{"ua-req-query-value"}; ///< Directive key.
+  static inline const HookMask HOOKS{
+    MaskFor(Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP)}; ///< Valid hooks for directive.
 
   using super_type::invoke;
-  Errata invoke(Context & ctx) override;
+  Errata invoke(Context &ctx) override;
 
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   using super_type::super_type; // Inherit super_type constructors.
-  TextView key() const override { return KEY; }
+  TextView
+  key() const override
+  {
+    return KEY;
+  }
 };
 
-Errata Do_ua_req_query_value::invoke(Context &ctx) {
+Errata
+Do_ua_req_query_value::invoke(Context &ctx)
+{
   return this->invoke_on_url(ctx, ctx.ua_req_hdr().url());
 }
 
-Rv<Directive::Handle> Do_ua_req_query_value::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
-  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+Rv<Directive::Handle>
+Do_ua_req_query_value::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+                            YAML::Node key_value)
+{
+  return super_type::load(
+    cfg, [](TextView const &name, Expr &&fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg,
+    key_value);
 }
 
 // --
-class Do_proxy_req_query_value : public QueryValueDirective {
-  using self_type = Do_proxy_req_query_value;
+class Do_proxy_req_query_value : public QueryValueDirective
+{
+  using self_type  = Do_proxy_req_query_value;
   using super_type = QueryValueDirective;
+
 public:
-  static inline const std::string KEY { "proxy-req-query-value" }; ///< Directive key.
-  static inline const HookMask HOOKS { MaskFor(Hook::PREQ)}; ///< Valid hooks for directive.
+  static inline const std::string KEY{"proxy-req-query-value"}; ///< Directive key.
+  static inline const HookMask HOOKS{MaskFor(Hook::PREQ)};      ///< Valid hooks for directive.
 
   using super_type::invoke;
-  Errata invoke(Context & ctx) override;
+  Errata invoke(Context &ctx) override;
 
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
+
 protected:
   using super_type::super_type; // Inherit super_type constructors.
-  TextView key() const override { return KEY; }
+  TextView
+  key() const override
+  {
+    return KEY;
+  }
 };
 
-Errata Do_proxy_req_query_value::invoke(Context &ctx) {
+Errata
+Do_proxy_req_query_value::invoke(Context &ctx)
+{
   return this->invoke_on_url(ctx, ctx.proxy_req_hdr().url());
 }
 
-Rv<Directive::Handle> Do_proxy_req_query_value::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
-  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+Rv<Directive::Handle>
+Do_proxy_req_query_value::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+                               YAML::Node key_value)
+{
+  return super_type::load(
+    cfg, [](TextView const &name, Expr &&fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg,
+    key_value);
 }
 /* ------------------------------------------------------------------------------------ */
 /// Set upstream response status code.
-class Do_upstream_rsp_status : public Directive {
-  using self_type = Do_upstream_rsp_status; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_upstream_rsp_status : public Directive
+{
+  using self_type  = Do_upstream_rsp_status; ///< Self reference type.
+  using super_type = Directive;              ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -2161,8 +2424,8 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Return status.
@@ -2170,13 +2433,15 @@ protected:
   Do_upstream_rsp_status() = default;
 };
 
-const std::string Do_upstream_rsp_status::KEY {"upstream-rsp-status" };
-const HookMask Do_upstream_rsp_status::HOOKS {MaskFor({Hook::URSP}) };
+const std::string Do_upstream_rsp_status::KEY{"upstream-rsp-status"};
+const HookMask Do_upstream_rsp_status::HOOKS{MaskFor({Hook::URSP})};
 
-Errata Do_upstream_rsp_status::invoke(Context &ctx) {
-  int status = TS_HTTP_STATUS_NONE;
+Errata
+Do_upstream_rsp_status::invoke(Context &ctx)
+{
+  int status    = TS_HTTP_STATUS_NONE;
   Feature value = ctx.extract(_expr);
-  auto vtype = ValueTypeOf(value);
+  auto vtype    = ValueTypeOf(value);
   if (INTEGER == vtype) {
     status = std::get<IndexFor(INTEGER)>(value);
   } else if (TUPLE == vtype) {
@@ -2199,15 +2464,17 @@ Errata Do_upstream_rsp_status::invoke(Context &ctx) {
   if (100 <= status && status <= 599) {
     ctx._txn.ursp_hdr().status_set(static_cast<TSHttpStatus>(status));
   } else {
-    return Errata().error(R"(Status value {} out of range 100..599 for "{}".)", status
-                          , KEY);
+    return Errata().error(R"(Status value {} out of range 100..599 for "{}".)", status, KEY);
   }
   return {};
 }
 
-Rv<Directive::Handle> Do_upstream_rsp_status::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_upstream_rsp_status::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &,
+                             swoc::TextView const &, YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
   auto self = new self_type;
@@ -2222,14 +2489,15 @@ Rv<Directive::Handle> Do_upstream_rsp_status::load(Config& cfg, CfgStaticData co
 }
 /* ------------------------------------------------------------------------------------ */
 /// Set upstream response reason phrase.
-class Do_upstream_reason : public Directive {
-  using self_type = Do_upstream_reason; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_upstream_reason : public Directive
+{
+  using self_type  = Do_upstream_reason; ///< Self reference type.
+  using super_type = Directive;          ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML configuration.
    *
@@ -2238,19 +2506,22 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   TSHttpStatus _status = TS_HTTP_STATUS_NONE; ///< Return status is literal, 0 => extract at runtime.
-  Expr _fmt; ///< Reason phrase.
+  Expr _fmt;                                  ///< Reason phrase.
 
   Do_upstream_reason() = default;
 };
 
-const std::string Do_upstream_reason::KEY {"upstream-reason" };
-const HookMask Do_upstream_reason::HOOKS {MaskFor({Hook::URSP}) };
+const std::string Do_upstream_reason::KEY{"upstream-reason"};
+const HookMask Do_upstream_reason::HOOKS{MaskFor({Hook::URSP})};
 
-Errata Do_upstream_reason::invoke(Context &ctx) {
+Errata
+Do_upstream_reason::invoke(Context &ctx)
+{
   auto value = ctx.extract(_fmt);
   if (STRING != ValueTypeOf(value)) {
     return Error(R"(Value for "{}" is not a string.)", KEY);
@@ -2259,12 +2530,15 @@ Errata Do_upstream_reason::invoke(Context &ctx) {
   return {};
 }
 
-Rv<Directive::Handle> Do_upstream_reason::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_upstream_reason::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                         YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(The value for "{}" must be a string.)", KEY, drtv_node.Mark());
   }
   auto self = new self_type;
@@ -2276,14 +2550,15 @@ Rv<Directive::Handle> Do_upstream_reason::load(Config& cfg, CfgStaticData const*
 }
 /* ------------------------------------------------------------------------------------ */
 /// Set proxy response status code.
-class Do_proxy_rsp_status : public Directive {
-  using self_type = Do_proxy_rsp_status; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_proxy_rsp_status : public Directive
+{
+  using self_type  = Do_proxy_rsp_status; ///< Self reference type.
+  using super_type = Directive;           ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML configuration.
    *
@@ -2292,7 +2567,8 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Return status.
@@ -2300,13 +2576,15 @@ protected:
   Do_proxy_rsp_status() = default;
 };
 
-const std::string Do_proxy_rsp_status::KEY {"proxy-rsp-status" };
-const HookMask Do_proxy_rsp_status::HOOKS {MaskFor({Hook::PRSP}) };
+const std::string Do_proxy_rsp_status::KEY{"proxy-rsp-status"};
+const HookMask Do_proxy_rsp_status::HOOKS{MaskFor({Hook::PRSP})};
 
-Errata Do_proxy_rsp_status::invoke(Context &ctx) {
-  int status = TS_HTTP_STATUS_NONE;
+Errata
+Do_proxy_rsp_status::invoke(Context &ctx)
+{
+  int status    = TS_HTTP_STATUS_NONE;
   Feature value = ctx.extract(_expr);
-  auto vtype = ValueTypeOf(value);
+  auto vtype    = ValueTypeOf(value);
   if (INTEGER == vtype) {
     status = std::get<IndexFor(INTEGER)>(value);
   } else if (TUPLE == vtype) {
@@ -2334,9 +2612,12 @@ Errata Do_proxy_rsp_status::invoke(Context &ctx) {
   return {};
 }
 
-Rv<Directive::Handle> Do_proxy_rsp_status::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_proxy_rsp_status::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                          YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
   auto self = new self_type;
@@ -2351,14 +2632,15 @@ Rv<Directive::Handle> Do_proxy_rsp_status::load(Config& cfg, CfgStaticData const
 }
 /* ------------------------------------------------------------------------------------ */
 /// Set proxy response reason phrase.
-class Do_proxy_rsp_reason : public Directive {
-  using self_type = Do_proxy_rsp_reason; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_proxy_rsp_reason : public Directive
+{
+  using self_type  = Do_proxy_rsp_reason; ///< Self reference type.
+  using super_type = Directive;           ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML configuration.
    *
@@ -2367,19 +2649,22 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   TSHttpStatus _status = TS_HTTP_STATUS_NONE; ///< Return status is literal, 0 => extract at runtime.
-  Expr _expr; ///< Reason phrase.
+  Expr _expr;                                 ///< Reason phrase.
 
   Do_proxy_rsp_reason() = default;
 };
 
-const std::string Do_proxy_rsp_reason::KEY {"proxy-rsp-reason" };
-const HookMask Do_proxy_rsp_reason::HOOKS {MaskFor({Hook::PRSP}) };
+const std::string Do_proxy_rsp_reason::KEY{"proxy-rsp-reason"};
+const HookMask Do_proxy_rsp_reason::HOOKS{MaskFor({Hook::PRSP})};
 
-Errata Do_proxy_rsp_reason::invoke(Context &ctx) {
+Errata
+Do_proxy_rsp_reason::invoke(Context &ctx)
+{
   auto value = ctx.extract(_expr);
   if (STRING != ValueTypeOf(value)) {
     return Error(R"(Value for "{}" is not a string.)", KEY);
@@ -2388,12 +2673,15 @@ Errata Do_proxy_rsp_reason::invoke(Context &ctx) {
   return {};
 }
 
-Rv<Directive::Handle> Do_proxy_rsp_reason::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_proxy_rsp_reason::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                          YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(The value for "{}" must be a string.)", KEY, drtv_node.Mark());
   }
   auto self = new self_type;
@@ -2405,14 +2693,15 @@ Rv<Directive::Handle> Do_proxy_rsp_reason::load(Config& cfg, CfgStaticData const
 }
 /* ------------------------------------------------------------------------------------ */
 /// Set proxy response (error) body.
-class Do_proxy_rsp_body : public Directive {
-  using self_type = Do_proxy_rsp_body; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_proxy_rsp_body : public Directive
+{
+  using self_type  = Do_proxy_rsp_body; ///< Self reference type.
+  using super_type = Directive;         ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML configuration.
    *
@@ -2421,7 +2710,8 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Body content.
@@ -2429,20 +2719,22 @@ protected:
   Do_proxy_rsp_body() = default;
 };
 
-const std::string Do_proxy_rsp_body::KEY {"proxy-rsp-body" };
-const HookMask Do_proxy_rsp_body::HOOKS {MaskFor({Hook::PRSP}) };
+const std::string Do_proxy_rsp_body::KEY{"proxy-rsp-body"};
+const HookMask Do_proxy_rsp_body::HOOKS{MaskFor({Hook::PRSP})};
 
-Errata Do_proxy_rsp_body::invoke(Context &ctx) {
-  TextView body, mime { "text/html" };
+Errata
+Do_proxy_rsp_body::invoke(Context &ctx)
+{
+  TextView body, mime{"text/html"};
   auto value = ctx.extract(_expr);
   if (STRING == ValueTypeOf(value)) {
     body = std::get<IndexFor(STRING)>(value);
-  } else if (auto tp = std::get_if<IndexFor(TUPLE)>(&value) ; tp ) {
+  } else if (auto tp = std::get_if<IndexFor(TUPLE)>(&value); tp) {
     if (tp->count() == 2) {
-      if (auto ptr = std::get_if<IndexFor(STRING)>(&(*tp)[0]) ; ptr ){
+      if (auto ptr = std::get_if<IndexFor(STRING)>(&(*tp)[0]); ptr) {
         body = *ptr;
       }
-      if (auto ptr = std::get_if<IndexFor(STRING)>(&(*tp)[1]) ; ptr ){
+      if (auto ptr = std::get_if<IndexFor(STRING)>(&(*tp)[1]); ptr) {
         mime = *ptr;
       }
     } else {
@@ -2455,12 +2747,15 @@ Errata Do_proxy_rsp_body::invoke(Context &ctx) {
   return {};
 }
 
-Rv<Directive::Handle> Do_proxy_rsp_body::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_proxy_rsp_body::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                        YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy({ STRING, ActiveType::TupleOf(STRING) })) {
+  if (!expr.result_type().can_satisfy({STRING, ActiveType::TupleOf(STRING)})) {
     return Error(R"(The value for "{}" must be a string or a list of two strings.)", KEY, drtv_node.Mark());
   }
   auto self = new self_type;
@@ -2472,14 +2767,15 @@ Rv<Directive::Handle> Do_proxy_rsp_body::load(Config& cfg, CfgStaticData const*,
 }
 /* ------------------------------------------------------------------------------------ */
 /// Replace the upstream response body with a feature.
-class Do_upstream_rsp_body : public Directive {
-  using self_type = Do_upstream_rsp_body; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_upstream_rsp_body : public Directive
+{
+  using self_type  = Do_upstream_rsp_body; ///< Self reference type.
+  using super_type = Directive;            ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML configuration.
    *
@@ -2488,18 +2784,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Body content.
 
-  Do_upstream_rsp_body(Expr && expr) : _expr(std::move(expr)) {}
+  Do_upstream_rsp_body(Expr &&expr) : _expr(std::move(expr)) {}
 };
 
-const std::string Do_upstream_rsp_body::KEY {"upstream-rsp-body" };
-const HookMask Do_upstream_rsp_body::HOOKS {MaskFor({Hook::URSP}) };
+const std::string Do_upstream_rsp_body::KEY{"upstream-rsp-body"};
+const HookMask Do_upstream_rsp_body::HOOKS{MaskFor({Hook::URSP})};
 
-Errata Do_upstream_rsp_body::invoke(Context &ctx) {
+Errata
+Do_upstream_rsp_body::invoke(Context &ctx)
+{
   auto static transform = [](TSCont contp, TSEvent ev_code, void *) -> int {
     if (TSVConnClosedGet(contp)) {
       TSContDestroy(contp);
@@ -2508,46 +2807,45 @@ Errata Do_upstream_rsp_body::invoke(Context &ctx) {
 
     auto in_vio = TSVConnWriteVIOGet(contp);
     switch (ev_code) {
-      case TS_EVENT_ERROR:TSContCall(TSVIOContGet(in_vio), TS_EVENT_ERROR, in_vio);
-        break;
-      case TS_EVENT_VCONN_WRITE_COMPLETE:
-        TSVConnShutdown(TSTransformOutputVConnGet(contp), 0, 1);
-        break;
-      default:
-        // Consume all input data.
-        auto in_todo = TSVIONTodoGet(in_vio);
-        auto in_reader = TSVIOReaderGet(in_vio);
-        if (in_reader && in_todo) {
-          auto avail = TSIOBufferReaderAvail(in_reader);
-          in_todo = std::min(in_todo, avail);
-          if (in_todo > 0) {
-            TSIOBufferReaderConsume(in_reader, in_todo);
-            TSVIONDoneSet(in_vio, TSVIONDoneGet(in_vio) + in_todo);
-            TSContCall(TSVIOContGet(in_vio)
-                       , (TSVIONTodoGet(in_vio) <= 0) ? TS_EVENT_VCONN_WRITE_COMPLETE
-                                                      : TS_EVENT_VCONN_WRITE_READY
-                       , in_vio);
-          }
-          // If the full is there, create the output buffer and write it, then clear it.
-          auto view = static_cast<TextView *>(TSContDataGet(contp));
-          if (view) {
-            auto out_vconn = TSTransformOutputVConnGet(contp);
-            auto out_buff = TSIOBufferCreate();
-            auto out_vio = TSVConnWrite(out_vconn, contp, TSIOBufferReaderAlloc(out_buff), view->size());
-            TSIOBufferWrite(out_buff, view->data(), view->size());
-            TSContDataSet(contp, nullptr);
-            TSVIOReenable(out_vio);
-          }
+    case TS_EVENT_ERROR:
+      TSContCall(TSVIOContGet(in_vio), TS_EVENT_ERROR, in_vio);
+      break;
+    case TS_EVENT_VCONN_WRITE_COMPLETE:
+      TSVConnShutdown(TSTransformOutputVConnGet(contp), 0, 1);
+      break;
+    default:
+      // Consume all input data.
+      auto in_todo   = TSVIONTodoGet(in_vio);
+      auto in_reader = TSVIOReaderGet(in_vio);
+      if (in_reader && in_todo) {
+        auto avail = TSIOBufferReaderAvail(in_reader);
+        in_todo    = std::min(in_todo, avail);
+        if (in_todo > 0) {
+          TSIOBufferReaderConsume(in_reader, in_todo);
+          TSVIONDoneSet(in_vio, TSVIONDoneGet(in_vio) + in_todo);
+          TSContCall(TSVIOContGet(in_vio),
+                     (TSVIONTodoGet(in_vio) <= 0) ? TS_EVENT_VCONN_WRITE_COMPLETE : TS_EVENT_VCONN_WRITE_READY, in_vio);
         }
-        break;
+        // If the full is there, create the output buffer and write it, then clear it.
+        auto view = static_cast<TextView *>(TSContDataGet(contp));
+        if (view) {
+          auto out_vconn = TSTransformOutputVConnGet(contp);
+          auto out_buff  = TSIOBufferCreate();
+          auto out_vio   = TSVConnWrite(out_vconn, contp, TSIOBufferReaderAlloc(out_buff), view->size());
+          TSIOBufferWrite(out_buff, view->data(), view->size());
+          TSContDataSet(contp, nullptr);
+          TSVIOReenable(out_vio);
+        }
+      }
+      break;
     }
 
     return 0;
   };
 
-  auto value = ctx.extract(_expr);
-  auto vtype = ValueTypeOf(value);
-  TextView* content = nullptr;
+  auto value            = ctx.extract(_expr);
+  auto vtype            = ValueTypeOf(value);
+  TextView *content     = nullptr;
   TextView content_type = "text/html";
   if (STRING == vtype) {
     content = &std::get<IndexFor(STRING)>(value);
@@ -2567,8 +2865,8 @@ Errata Do_upstream_rsp_body::invoke(Context &ctx) {
     // The view contents are in the transaction data, but the full in the feature is not.
     // Make a copy there and pass its address to the continuation.
     auto ctx_view = ctx.alloc_span<TextView>(1);
-    auto cont = TSTransformCreate(transform, ctx._txn);
-    ctx_view[0] = *content;
+    auto cont     = TSTransformCreate(transform, ctx._txn);
+    ctx_view[0]   = *content;
     TSContDataSet(cont, ctx_view.data());
     TSHttpTxnHookAdd(ctx._txn, TS_HTTP_RESPONSE_TRANSFORM_HOOK, cont);
     ctx._txn.ursp_hdr().field_obtain("Content-Type"_tv).assign(content_type);
@@ -2577,12 +2875,15 @@ Errata Do_upstream_rsp_body::invoke(Context &ctx) {
   return {};
 }
 
-Rv<Directive::Handle> Do_upstream_rsp_body::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_upstream_rsp_body::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                           YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
-  if (! expr.result_type().can_satisfy(STRING)) {
+  if (!expr.result_type().can_satisfy(STRING)) {
     return Error(R"(The value for "{}" must be a string.)", KEY, drtv_node.Mark());
   }
 
@@ -2590,9 +2891,10 @@ Rv<Directive::Handle> Do_upstream_rsp_body::load(Config& cfg, CfgStaticData cons
 }
 // ---
 /// Immediate proxy reply.
-class Do_proxy_reply : public Directive {
-  using self_type = Do_proxy_reply; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_proxy_reply : public Directive
+{
+  using self_type  = Do_proxy_reply; ///< Self reference type.
+  using super_type = Directive;      ///< Parent type.
 
   /// Per configuration storage.
   struct CfgInfo {
@@ -2606,20 +2908,20 @@ class Do_proxy_reply : public Directive {
   };
 
 public:
-  inline static const std::string KEY = "proxy-reply"; ///< Directive name.
-  inline static const std::string STATUS_KEY = "status"; ///< Key for status value.
-  inline static const std::string REASON_KEY = "reason"; ///< Key for reason value.
-  inline static const std::string BODY_KEY ="body"; ///< Key for body.
+  inline static const std::string KEY        = "proxy-reply"; ///< Directive name.
+  inline static const std::string STATUS_KEY = "status";      ///< Key for status value.
+  inline static const std::string REASON_KEY = "reason";      ///< Key for reason value.
+  inline static const std::string BODY_KEY   = "body";        ///< Key for body.
 
   static const HookMask HOOKS; ///< Valid hooks for directive.
 
   /// Specify the required amount of reserved configuration storage.
-  static constexpr Options OPTIONS { sizeof(CfgInfo) };
+  static constexpr Options OPTIONS{sizeof(CfgInfo)};
 
   /// Need to do fixups on a later hook.
   static constexpr Hook FIXUP_HOOK = Hook::PRSP;
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -2630,22 +2932,23 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
   /// Configuration level initialization.
-  static Errata cfg_init(Config& cfg, CfgStaticData const * rtti);
+  static Errata cfg_init(Config &cfg, CfgStaticData const *rtti);
 
 protected:
   using index_type = FeatureGroup::index_type;
 
   FeatureGroup _fg; ///< Support cross references among the keys.
 
-  int _status = 0; ///< Return status is literal, 0 => extract at runtime.
+  int _status = 0;        ///< Return status is literal, 0 => extract at runtime.
   index_type _status_idx; ///< Return status.
   index_type _reason_idx; ///< Status reason text.
-  index_type _body_idx; ///< Body content of respons.
+  index_type _body_idx;   ///< Body content of respons.
   /// Bounce from fixup hook directive back to @a this.
-  Directive::Handle _fixup{new LambdaDirective([this] (Context& ctx) -> Errata { return this->fixup(ctx); })};
+  Directive::Handle _fixup{new LambdaDirective([this](Context &ctx) -> Errata { return this->fixup(ctx); })};
 
   Errata load_status();
 
@@ -2653,9 +2956,11 @@ protected:
   Errata fixup(Context &ctx);
 };
 
-const HookMask Do_proxy_reply::HOOKS { MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP} ) };
+const HookMask Do_proxy_reply::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP})};
 
-Errata Do_proxy_reply::cfg_init(Config& cfg, CfgStaticData const * rtti) {
+Errata
+Do_proxy_reply::cfg_init(Config &cfg, CfgStaticData const *rtti)
+{
   auto cfg_info = rtti->_cfg_store.rebind<CfgInfo>().data();
   new (cfg_info) CfgInfo; // Initialize the span.
   // Only one proxy_reply can be effective per transaction, therefore shared state per context is best.
@@ -2664,7 +2969,9 @@ Errata Do_proxy_reply::cfg_init(Config& cfg, CfgStaticData const * rtti) {
   return {};
 }
 
-Errata Do_proxy_reply::invoke(Context& ctx) {
+Errata
+Do_proxy_reply::invoke(Context &ctx)
+{
   auto cfg_info = _rtti->_cfg_store.rebind<CfgInfo>().data();
   auto ctx_info = ctx.initialized_storage_for<CtxInfo>(cfg_info->_ctx_span).data();
 
@@ -2677,7 +2984,7 @@ Errata Do_proxy_reply::invoke(Context& ctx) {
     Feature reason = _fg.extract(ctx, _reason_idx);
     if (reason.index() == IndexFor(STRING)) {
       ctx.commit(reason);
-      need_hook_p = ctx_info->_reason.empty(); // hook needed if this is first to set reason.
+      need_hook_p       = ctx_info->_reason.empty(); // hook needed if this is first to set reason.
       ctx_info->_reason = std::get<IndexFor(STRING)>(reason);
     }
   }
@@ -2686,7 +2993,7 @@ Errata Do_proxy_reply::invoke(Context& ctx) {
   if (_status) {
     ctx._txn.status_set(static_cast<TSHttpStatus>(_status));
   } else {
-    auto && [ status, errata ] { _fg.extract(ctx, _status_idx).as_integer(-1) };
+    auto &&[status, errata]{_fg.extract(ctx, _status_idx).as_integer(-1)};
     if (100 <= status && status <= 599) {
       ctx._txn.status_set(static_cast<TSHttpStatus>(status));
     }
@@ -2705,10 +3012,12 @@ Errata Do_proxy_reply::invoke(Context& ctx) {
   return {};
 }
 
-Errata Do_proxy_reply::fixup(Context &ctx) {
+Errata
+Do_proxy_reply::fixup(Context &ctx)
+{
   auto cfg_info = _rtti->_cfg_store.rebind<CfgInfo>().data();
   auto ctx_info = ctx.storage_for(cfg_info->_ctx_span).rebind<CtxInfo>().data();
-  auto hdr {ctx.proxy_rsp_hdr() };
+  auto hdr{ctx.proxy_rsp_hdr()};
   // Set the reason.
   if (!ctx_info->_reason.empty()) {
     hdr.reason_set(ctx_info->_reason);
@@ -2716,64 +3025,71 @@ Errata Do_proxy_reply::fixup(Context &ctx) {
   return {};
 }
 
-Errata Do_proxy_reply::load_status() {
+Errata
+Do_proxy_reply::load_status()
+{
   _status_idx = _fg.index_of(STATUS_KEY);
 
-  FeatureGroup::ExprInfo & info = _fg[_status_idx];
+  FeatureGroup::ExprInfo &info = _fg[_status_idx];
 
   if (info._expr.is_literal()) {
-    auto && [ status , errata ] { std::get<Feature>(info._expr._raw).as_integer(-1) };
-    if (! errata.is_ok()) {
+    auto &&[status, errata]{std::get<Feature>(info._expr._raw).as_integer(-1)};
+    if (!errata.is_ok()) {
       errata.info("While load key '{}' for directive '{}'", STATUS_KEY, KEY);
       return std::move(errata);
     }
     if (!(100 <= status && status <= 599)) {
-      return Errata().error(R"(Value for '{}' key in {} directive is not a positive integer 100..599 as required.)", STATUS_KEY, KEY);
+      return Errata().error(R"(Value for '{}' key in {} directive is not a positive integer 100..599 as required.)", STATUS_KEY,
+                            KEY);
     }
     _status = status;
-  } else if (! info._expr.result_type().can_satisfy(MaskFor(STRING, INTEGER))) {
+  } else if (!info._expr.result_type().can_satisfy(MaskFor(STRING, INTEGER))) {
     return Errata().error(R"({} is not an integer nor string as required.)", STATUS_KEY);
   }
   return {};
 }
 
-Rv<Directive::Handle> Do_proxy_reply::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_proxy_reply::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                     YAML::Node key_value)
+{
   Handle handle{new self_type};
   Errata errata;
   auto self = static_cast<self_type *>(handle.get());
   if (key_value.IsScalar()) {
     errata = self->_fg.load_as_scalar(cfg, key_value, STATUS_KEY);
   } else if (key_value.IsSequence()) {
-    errata = self->_fg.load_as_tuple(cfg, key_value, { { STATUS_KEY, FeatureGroup::REQUIRED } , { REASON_KEY } });
+    errata = self->_fg.load_as_tuple(cfg, key_value, {{STATUS_KEY, FeatureGroup::REQUIRED}, {REASON_KEY}});
   } else if (key_value.IsMap()) {
-    errata = self->_fg.load(cfg, key_value, { { STATUS_KEY, FeatureGroup::REQUIRED }, { REASON_KEY }, { BODY_KEY } });
+    errata = self->_fg.load(cfg, key_value, {{STATUS_KEY, FeatureGroup::REQUIRED}, {REASON_KEY}, {BODY_KEY}});
   } else {
     return Error(R"(Value for "{}" key at {} is must be a scalar, a list, or a map and is not.)", KEY, key_value.Mark());
   }
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing value at {} in "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
     return {{}, std::move(errata)};
   }
 
   self->_reason_idx = self->_fg.index_of(REASON_KEY);
-  self->_body_idx = self->_fg.index_of(BODY_KEY);
+  self->_body_idx   = self->_fg.index_of(BODY_KEY);
   errata.note(self->load_status());
 
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing value at {} in "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
-    return { {}, std::move(errata) };
+    return {{}, std::move(errata)};
   }
 
-  return { std::move(handle), {} };
+  return {std::move(handle), {}};
 }
 // ---
 /* ------------------------------------------------------------------------------------ */
 /// Redirect.
 /// Although this could technically be done "by hand", it's common enough to justify
 /// a specific directive.
-class Do_redirect : public Directive {
-  using self_type = Do_redirect; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_redirect : public Directive
+{
+  using self_type  = Do_redirect; ///< Self reference type.
+  using super_type = Directive;   ///< Parent type.
 
   /// Per configuration storage.
   struct CfgInfo {
@@ -2784,27 +3100,27 @@ class Do_redirect : public Directive {
   /// -- doc Do_redirect::CtxInfo
   struct CtxInfo {
     TextView _location; ///< Redirect target location.
-    TextView _reason; ///< Status text.
+    TextView _reason;   ///< Status text.
   };
 
 public:
-  inline static const std::string KEY = "redirect"; ///< Directive name.
-  inline static const std::string STATUS_KEY = "status"; ///< Key for status value.
-  inline static const std::string REASON_KEY = "reason"; ///< Key for reason value.
+  inline static const std::string KEY          = "redirect"; ///< Directive name.
+  inline static const std::string STATUS_KEY   = "status";   ///< Key for status value.
+  inline static const std::string REASON_KEY   = "reason";   ///< Key for reason value.
   inline static const std::string LOCATION_KEY = "location"; ///< Key for location value.
-  inline static const std::string BODY_KEY ="body" ; ///< Key for body.
+  inline static const std::string BODY_KEY     = "body";     ///< Key for body.
 
   static const HookMask HOOKS; ///< Valid hooks for directive.
 
   /// Specify the required amount of reserved configuration storage.
-  static constexpr Options OPTIONS { sizeof(CfgInfo) };
+  static constexpr Options OPTIONS{sizeof(CfgInfo)};
 
   /// Need to do fixups on a later hook.
   static constexpr Hook FIXUP_HOOK = Hook::PRSP;
   /// Status code to use if not specified.
   static const int DEFAULT_STATUS = TS_HTTP_STATUS_MOVED_PERMANENTLY;
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -2815,23 +3131,24 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
   /// Configuration level initialization.
-  static Errata cfg_init(Config& cfg, CfgStaticData const * rtti);
+  static Errata cfg_init(Config &cfg, CfgStaticData const *rtti);
 
 protected:
   using index_type = FeatureGroup::index_type;
 
   FeatureGroup _fg; ///< Support cross references among the keys.
 
-  int _status = 0; ///< Return status is literal, 0 => extract at runtime.
-  index_type _status_idx; ///< Return status.
-  index_type _reason_idx; ///< Status reason text.
+  int _status = 0;          ///< Return status is literal, 0 => extract at runtime.
+  index_type _status_idx;   ///< Return status.
+  index_type _reason_idx;   ///< Status reason text.
   index_type _location_idx; ///< Location field value.
-  index_type _body_idx; ///< Body content of respons.
+  index_type _body_idx;     ///< Body content of respons.
   /// Bounce from fixup hook directive back to @a this.
-  Directive::Handle _set_location{new LambdaDirective([this] (Context& ctx) -> Errata { return this->fixup(ctx); })};
+  Directive::Handle _set_location{new LambdaDirective([this](Context &ctx) -> Errata { return this->fixup(ctx); })};
 
   Errata load_status();
 
@@ -2839,9 +3156,11 @@ protected:
   Errata fixup(Context &ctx);
 };
 
-const HookMask Do_redirect::HOOKS { MaskFor(Hook::PRE_REMAP, Hook::REMAP) };
+const HookMask Do_redirect::HOOKS{MaskFor(Hook::PRE_REMAP, Hook::REMAP)};
 
-Errata Do_redirect::cfg_init(Config& cfg, CfgStaticData const * rtti) {
+Errata
+Do_redirect::cfg_init(Config &cfg, CfgStaticData const *rtti)
+{
   auto cfg_info = rtti->_cfg_store.rebind<CfgInfo>().data();
   new (cfg_info) CfgInfo; // Initialize the span.
   // Only one redirect can be effective per transaction, therefore shared state per context is best.
@@ -2851,7 +3170,9 @@ Errata Do_redirect::cfg_init(Config& cfg, CfgStaticData const * rtti) {
 }
 // -- doc Do_redirect::cfg_init
 
-Errata Do_redirect::invoke(Context& ctx) {
+Errata
+Do_redirect::invoke(Context &ctx)
+{
   auto cfg_info = _rtti->_cfg_store.rebind<CfgInfo>().data();
   auto ctx_info = ctx.initialized_storage_for<CtxInfo>(cfg_info->_ctx_span).data();
 
@@ -2873,7 +3194,7 @@ Errata Do_redirect::invoke(Context& ctx) {
     ctx._txn.status_set(static_cast<TSHttpStatus>(_status));
   } else {
     Feature value = _fg.extract(ctx, _status_idx);
-    auto && [ status, errata ] { value.as_integer(DEFAULT_STATUS) };
+    auto &&[status, errata]{value.as_integer(DEFAULT_STATUS)};
     if (!(100 <= status && status <= 599)) {
       status = DEFAULT_STATUS;
     }
@@ -2899,12 +3220,14 @@ Errata Do_redirect::invoke(Context& ctx) {
   return {};
 }
 
-Errata Do_redirect::fixup(Context &ctx) {
+Errata
+Do_redirect::fixup(Context &ctx)
+{
   auto cfg_info = _rtti->_cfg_store.rebind<CfgInfo>().data();
   auto ctx_info = ctx.storage_for(cfg_info->_ctx_span).rebind<CtxInfo>().data();
-  auto hdr {ctx.proxy_rsp_hdr() };
+  auto hdr{ctx.proxy_rsp_hdr()};
 
-  auto field { hdr.field_obtain(ts::HTTP_FIELD_LOCATION) };
+  auto field{hdr.field_obtain(ts::HTTP_FIELD_LOCATION)};
   field.assign(ctx_info->_location);
 
   if (!ctx_info->_reason.empty()) {
@@ -2913,7 +3236,9 @@ Errata Do_redirect::fixup(Context &ctx) {
   return {};
 }
 
-Errata Do_redirect::load_status() {
+Errata
+Do_redirect::load_status()
+{
   _status_idx = _fg.index_of(STATUS_KEY);
 
   if (_status_idx == FeatureGroup::INVALID_IDX) { // not present, use default value.
@@ -2921,17 +3246,18 @@ Errata Do_redirect::load_status() {
     return {};
   }
 
-  FeatureGroup::ExprInfo & info = _fg[_status_idx];
+  FeatureGroup::ExprInfo &info = _fg[_status_idx];
 
   if (info._expr.is_literal()) {
-    auto && [ status , errata ] { std::get<Feature>(info._expr._raw).as_integer(DEFAULT_STATUS) };
+    auto &&[status, errata]{std::get<Feature>(info._expr._raw).as_integer(DEFAULT_STATUS)};
     _status = status;
-    if (! errata.is_ok()) {
+    if (!errata.is_ok()) {
       errata.info("While load key '{}' for directive '{}'", STATUS_KEY, KEY);
       return std::move(errata);
     }
     if (!(100 <= status && status <= 599)) {
-      return Errata().error(R"(Value for '{}' key in {} directive is not a positive integer 100..599 as required.)", STATUS_KEY, KEY);
+      return Errata().error(R"(Value for '{}' key in {} directive is not a positive integer 100..599 as required.)", STATUS_KEY,
+                            KEY);
     }
   } else {
     auto rtype = info._expr.result_type();
@@ -2942,87 +3268,100 @@ Errata Do_redirect::load_status() {
   return {};
 }
 
-Rv<Directive::Handle> Do_redirect::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_redirect::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                  YAML::Node key_value)
+{
   Handle handle{new self_type};
   Errata errata;
   auto self = static_cast<self_type *>(handle.get());
   if (key_value.IsScalar()) {
     errata = self->_fg.load_as_scalar(cfg, key_value, LOCATION_KEY);
   } else if (key_value.IsSequence()) {
-    errata = self->_fg.load_as_tuple(cfg, key_value, { { STATUS_KEY, FeatureGroup::REQUIRED } , { LOCATION_KEY, FeatureGroup::REQUIRED } });
+    errata =
+      self->_fg.load_as_tuple(cfg, key_value, {{STATUS_KEY, FeatureGroup::REQUIRED}, {LOCATION_KEY, FeatureGroup::REQUIRED}});
   } else if (key_value.IsMap()) {
-    errata = self->_fg.load(cfg, key_value, { { LOCATION_KEY, FeatureGroup::REQUIRED }, { STATUS_KEY }, { REASON_KEY }, { BODY_KEY } });
+    errata = self->_fg.load(cfg, key_value, {{LOCATION_KEY, FeatureGroup::REQUIRED}, {STATUS_KEY}, {REASON_KEY}, {BODY_KEY}});
   } else {
     return Error(R"(Value for "{}" key at {} is must be a scalar, a list, or a map and is not.)", KEY, key_value.Mark());
   }
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing value at {} in "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
     return {{}, std::move(errata)};
   }
 
-  self->_reason_idx = self->_fg.index_of(REASON_KEY);
-  self->_body_idx = self->_fg.index_of(BODY_KEY);
+  self->_reason_idx   = self->_fg.index_of(REASON_KEY);
+  self->_body_idx     = self->_fg.index_of(BODY_KEY);
   self->_location_idx = self->_fg.index_of(LOCATION_KEY);
   errata.note(self->load_status());
 
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing value at {} in "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
-    return { {}, std::move(errata) };
+    return {{}, std::move(errata)};
   }
 
-  return { std::move(handle), {} };
+  return {std::move(handle), {}};
 }
 /* ------------------------------------------------------------------------------------ */
 /// Send a debug message.
-class Do_debug : public Directive {
-  using self_type = Do_debug;
+class Do_debug : public Directive
+{
+  using self_type  = Do_debug;
   using super_type = Directive;
+
 public:
   static const std::string KEY;
   static const HookMask HOOKS; ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override;
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  Errata invoke(Context &ctx) override;
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _tag;
   Expr _msg;
 
-  Do_debug(Expr && tag, Expr && msg);
+  Do_debug(Expr &&tag, Expr &&msg);
 };
 
-const std::string Do_debug::KEY {"debug" };
-const HookMask Do_debug::HOOKS {MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP, Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP }) };
+const std::string Do_debug::KEY{"debug"};
+const HookMask Do_debug::HOOKS{MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP,
+                                        Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP})};
 
 Do_debug::Do_debug(Expr &&tag, Expr &&msg) : _tag(std::move(tag)), _msg(std::move(msg)) {}
 
-Errata Do_debug::invoke(Context &ctx) {
-  TextView tag = ctx.extract_view(_tag, { Context::EX_COMMIT, Context::EX_C_STR});
+Errata
+Do_debug::invoke(Context &ctx)
+{
+  TextView tag = ctx.extract_view(_tag, {Context::EX_COMMIT, Context::EX_C_STR});
   TextView msg = ctx.extract_view(_msg);
   TSDebug(tag.data(), "%.*s", static_cast<int>(msg.size()), msg.data());
   return {};
 }
 
-Rv<Directive::Handle> Do_debug::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_debug::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+               YAML::Node key_value)
+{
   if (key_value.IsScalar()) {
-    auto && [ msg_fmt, msg_errata ] = cfg.parse_expr(key_value);
-    if (! msg_errata.is_ok()) {
+    auto &&[msg_fmt, msg_errata] = cfg.parse_expr(key_value);
+    if (!msg_errata.is_ok()) {
       msg_errata.info(R"(While parsing message at {} for "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
-      return { {}, std::move(msg_errata)};
+      return {{}, std::move(msg_errata)};
     }
-    return { Handle{new self_type{Expr{Config::PLUGIN_TAG}, std::move(msg_fmt)}}, {} };
+    return {Handle{new self_type{Expr{Config::PLUGIN_TAG}, std::move(msg_fmt)}}, {}};
   } else if (key_value.IsSequence()) {
     if (key_value.size() > 2) {
       return Error(R"(Value for "{}" key at {} is not a list of two strings as required.)", KEY, key_value.Mark());
     } else if (key_value.size() < 1) {
       return Error(R"(The list value for "{}" key at {} does not have at least one string as required.)", KEY, key_value.Mark());
     }
-    auto && [ tag_expr, tag_errata ] = cfg.parse_expr(key_value[0]);
+    auto &&[tag_expr, tag_errata] = cfg.parse_expr(key_value[0]);
     if (!tag_errata.is_ok()) {
       tag_errata.info(R"(While parsing tag at {} for "{}" directive at {}.)", key_value[0].Mark(), KEY, drtv_node.Mark());
       return std::move(tag_errata);
     }
-    auto && [ msg_expr, msg_errata ] = cfg.parse_expr(key_value[1]);
+    auto &&[msg_expr, msg_errata] = cfg.parse_expr(key_value[1]);
     if (!tag_errata.is_ok()) {
       tag_errata.info(R"(While parsing message at {} for "{}" directive at {}.)", key_value[1].Mark(), KEY, drtv_node.Mark());
       return std::move(tag_errata);
@@ -3034,59 +3373,67 @@ Rv<Directive::Handle> Do_debug::load(Config& cfg, CfgStaticData const*, YAML::No
 
 /* ------------------------------------------------------------------------------------ */
 /// Log an Error message.
-class Do_error : public Directive {
-  using self_type = Do_error;
+class Do_error : public Directive
+{
+  using self_type  = Do_error;
   using super_type = Directive;
+
 public:
   static inline const std::string KEY{"error"};
   static const HookMask HOOKS; ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override;
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  Errata invoke(Context &ctx) override;
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _msg;
 
-  Do_error(Expr && msg);
+  Do_error(Expr &&msg);
 };
 
-const HookMask Do_error::HOOKS {MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP, Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP }) };
+const HookMask Do_error::HOOKS{MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP,
+                                        Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP})};
 
 Do_error::Do_error(Expr &&msg) : _msg(std::move(msg)) {}
 
-Errata Do_error::invoke(Context &ctx) {
+Errata
+Do_error::invoke(Context &ctx)
+{
   TextView msg = ctx.extract_view(_msg);
   ts::Log_Error(msg);
   return {};
 }
 
-Rv<Directive::Handle> Do_error::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ msg_fmt, msg_errata ] = cfg.parse_expr(key_value);
-  if (! msg_errata.is_ok()) {
+Rv<Directive::Handle>
+Do_error::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+               YAML::Node key_value)
+{
+  auto &&[msg_fmt, msg_errata] = cfg.parse_expr(key_value);
+  if (!msg_errata.is_ok()) {
     msg_errata.info(R"(While parsing message at {} for "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
-    return { {}, std::move(msg_errata)};
+    return {{}, std::move(msg_errata)};
   }
-  return { Handle{new self_type{std::move(msg_fmt)}}};
+  return {Handle{new self_type{std::move(msg_fmt)}}};
 }
 
 /// Log an notify message.
-class Do_note : public Directive {
-  using self_type = Do_note; ///< Self reference type.
+class Do_note : public Directive
+{
+  using self_type  = Do_note;   ///< Self reference type.
   using super_type = Directive; ///< Super type.
 public:
   static inline const std::string KEY{"note"}; ///< Name of directive.
   /// Valid hooks for this directive.
-  static inline const HookMask HOOKS{MaskFor( Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ
-                                            , Hook::PREQ, Hook::URSP, Hook::PRSP, Hook::PRE_REMAP
-                                            , Hook::POST_REMAP, Hook::REMAP )};
+  static inline const HookMask HOOKS{MaskFor(Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP,
+                                             Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP)};
 
   /// Runtime invocation.
-  Errata invoke(Context & ctx) override;
+  Errata invoke(Context &ctx) override;
 
   /// Load from configuration.
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node
-                        , swoc::TextView const& name, swoc::TextView const& arg
-                        , YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _msg; ///< Message to log.
@@ -3095,14 +3442,16 @@ protected:
    *
    * @param msg Parsed feature expression for message.
    */
-  Do_note(Expr && msg);
+  Do_note(Expr &&msg);
 };
 // -- doc end Do_note
 
 Do_note::Do_note(Expr &&msg) : _msg(std::move(msg)) {}
 
 // -- doc note::invoke
-Errata Do_note::invoke(Context &ctx) {
+Errata
+Do_note::invoke(Context &ctx)
+{
   TextView msg = ctx.extract_view(_msg);
   ts::Log_Note(msg);
   return {};
@@ -3110,13 +3459,13 @@ Errata Do_note::invoke(Context &ctx) {
 // -- doc note::invoke
 
 // -- doc note::load
-Rv<Directive::Handle> Do_note::load( Config& cfg, CfgStaticData const*, YAML::Node drtv_node
-                                   , swoc::TextView const&, swoc::TextView const&
-                                   , YAML::Node key_value) {
-  auto && [ msg_fmt, msg_errata ] = cfg.parse_expr(key_value);
-  if (! msg_errata.is_ok()) {
-    msg_errata.info(R"(While parsing message at {} for "{}" directive at {}.)"
-                    , key_value.Mark(), KEY, drtv_node.Mark());
+Rv<Directive::Handle>
+Do_note::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+              YAML::Node key_value)
+{
+  auto &&[msg_fmt, msg_errata] = cfg.parse_expr(key_value);
+  if (!msg_errata.is_ok()) {
+    msg_errata.info(R"(While parsing message at {} for "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
     return std::move(msg_errata);
   }
   return Handle{new self_type{std::move(msg_fmt)}};
@@ -3124,51 +3473,61 @@ Rv<Directive::Handle> Do_note::load( Config& cfg, CfgStaticData const*, YAML::No
 // -- doc note::load
 
 /// Log an warning message.
-class Do_warning : public Directive {
-  using self_type = Do_warning;
+class Do_warning : public Directive
+{
+  using self_type  = Do_warning;
   using super_type = Directive;
+
 public:
   static inline const std::string KEY{"warning"};
   static const HookMask HOOKS; ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override;
-  static Rv<Handle> load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const& name, swoc::TextView const& arg, YAML::Node key_value);
+  Errata invoke(Context &ctx) override;
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _msg;
 
-  Do_warning(Expr && msg);
+  Do_warning(Expr &&msg);
 };
 
-const HookMask Do_warning::HOOKS {MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP, Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP }) };
+const HookMask Do_warning::HOOKS{MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP,
+                                          Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP})};
 
 Do_warning::Do_warning(Expr &&msg) : _msg(std::move(msg)) {}
 
-Errata Do_warning::invoke(Context &ctx) {
+Errata
+Do_warning::invoke(Context &ctx)
+{
   TextView msg = ctx.extract_view(_msg);
   ts::Log_Warning(msg);
   return {};
 }
 
-Rv<Directive::Handle> Do_warning::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
-  auto && [ msg_fmt, msg_errata ] = cfg.parse_expr(key_value);
-  if (! msg_errata.is_ok()) {
+Rv<Directive::Handle>
+Do_warning::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+                 YAML::Node key_value)
+{
+  auto &&[msg_fmt, msg_errata] = cfg.parse_expr(key_value);
+  if (!msg_errata.is_ok()) {
     msg_errata.info(R"(While parsing message at {} for "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
-    return { {}, std::move(msg_errata)};
+    return {{}, std::move(msg_errata)};
   }
-  return { Handle{new self_type{std::move(msg_fmt)}}};
+  return {Handle{new self_type{std::move(msg_fmt)}}};
 }
 
 /* ------------------------------------------------------------------------------------ */
 /// Set the cache key.
-class Do_cache_key : public Directive {
-  using self_type = Do_cache_key; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_cache_key : public Directive
+{
+  using self_type  = Do_cache_key; ///< Self reference type.
+  using super_type = Directive;    ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -3180,27 +3539,32 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _fmt; ///< Cache key.
 
-  Do_cache_key(Expr && fmt) : _fmt(std::move(fmt)) {}
+  Do_cache_key(Expr &&fmt) : _fmt(std::move(fmt)) {}
 };
 
-const std::string Do_cache_key::KEY { "cache-key" };
-const HookMask Do_cache_key::HOOKS { MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP}) };
+const std::string Do_cache_key::KEY{"cache-key"};
+const HookMask Do_cache_key::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
-Errata Do_cache_key::invoke(Context &ctx) {
+Errata
+Do_cache_key::invoke(Context &ctx)
+{
   auto value = ctx.extract(_fmt);
   ctx._txn.cache_key_assign(std::get<IndexFor(STRING)>(value));
   return {};
 }
 
-Rv<Directive::Handle> Do_cache_key::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_cache_key::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &,
+                   YAML::Node key_value)
+{
   auto &&[fmt, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
 
@@ -3208,14 +3572,15 @@ Rv<Directive::Handle> Do_cache_key::load(Config& cfg, CfgStaticData const*, YAML
 }
 /* ------------------------------------------------------------------------------------ */
 /// Set a transaction configuration variable override.
-class Do_txn_conf : public Directive {
-  using self_type = Do_txn_conf; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_txn_conf : public Directive
+{
+  using self_type  = Do_txn_conf; ///< Self reference type.
+  using super_type = Directive;   ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -3227,20 +3592,23 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Value for override.
   ts::TxnConfigVar *_var = nullptr;
 
-  Do_txn_conf(Expr && fmt, ts::TxnConfigVar * var) : _expr(std::move(fmt)), _var(var) {}
+  Do_txn_conf(Expr &&fmt, ts::TxnConfigVar *var) : _expr(std::move(fmt)), _var(var) {}
 };
 
-const std::string Do_txn_conf::KEY { "txn-conf" };
-const HookMask Do_txn_conf::HOOKS { MaskFor({Hook::TXN_START, Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP, Hook::PREQ}) };
+const std::string Do_txn_conf::KEY{"txn-conf"};
+const HookMask Do_txn_conf::HOOKS{
+  MaskFor({Hook::TXN_START, Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP, Hook::PREQ})};
 
-Errata Do_txn_conf::invoke(Context &ctx) {
+Errata
+Do_txn_conf::invoke(Context &ctx)
+{
   auto value = ctx.extract(_expr);
   if (value.index() == IndexFor(INTEGER)) {
     ctx._txn.override_assign(*_var, std::get<IndexFor(INTEGER)>(value));
@@ -3257,19 +3625,20 @@ Errata Do_txn_conf::invoke(Context &ctx) {
   return {};
 }
 
-Rv<Directive::Handle> Do_txn_conf::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_txn_conf::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+                  YAML::Node key_value)
+{
   auto txn_var = ts::HttpTxn::find_override(arg);
-  if (! txn_var) {
+  if (!txn_var) {
     return Error(R"("{}" is not recognized as an overridable transaction configuration variable.)", arg);
   }
-  if (txn_var->type() != TS_RECORDDATATYPE_INT &&
-    txn_var->type() != TS_RECORDDATATYPE_STRING &&
-    txn_var->type() != TS_RECORDDATATYPE_FLOAT
-  ) {
+  if (txn_var->type() != TS_RECORDDATATYPE_INT && txn_var->type() != TS_RECORDDATATYPE_STRING &&
+      txn_var->type() != TS_RECORDDATATYPE_FLOAT) {
     return Error(R"("{}" is of type "{}" which is not currently supported.)", arg, ts::TSRecordDataTypeNames[txn_var->type()]);
   }
   auto &&[fmt, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
 
@@ -3278,14 +3647,15 @@ Rv<Directive::Handle> Do_txn_conf::load(Config& cfg, CfgStaticData const*, YAML:
 
 /* ------------------------------------------------------------------------------------ */
 /// Set the address for the upstream.
-class Do_upstream_addr : public Directive {
-  using self_type = Do_upstream_addr; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_upstream_addr : public Directive
+{
+  using self_type  = Do_upstream_addr; ///< Self reference type.
+  using super_type = Directive;        ///< Parent type.
 public:
   static inline const std::string KEY{"upstream-addr"}; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;                          ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -3297,19 +3667,21 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   Expr _expr; ///< Address.
   ts::TxnConfigVar *_var = nullptr;
 
-  Do_upstream_addr(Expr && expr) : _expr(std::move(expr)) {}
+  Do_upstream_addr(Expr &&expr) : _expr(std::move(expr)) {}
 };
 
-const HookMask Do_upstream_addr::HOOKS { MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP, Hook::PREQ}) };
+const HookMask Do_upstream_addr::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP, Hook::PREQ})};
 
-Errata Do_upstream_addr::invoke(Context &ctx) {
+Errata
+Do_upstream_addr::invoke(Context &ctx)
+{
   auto value = ctx.extract(_expr);
   if (value.index() == IndexFor(IP_ADDR)) {
     ctx._txn.set_upstream_addr(std::get<IndexFor(IP_ADDR)>(value));
@@ -3317,13 +3689,16 @@ Errata Do_upstream_addr::invoke(Context &ctx) {
   return {};
 }
 
-Rv<Directive::Handle> Do_upstream_addr::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_upstream_addr::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &,
+                       YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
 
-  if (! expr.result_type().can_satisfy(IP_ADDR)) {
+  if (!expr.result_type().can_satisfy(IP_ADDR)) {
     return Error(R"(Value for "{}" must be an IP address.)");
   }
 
@@ -3331,14 +3706,15 @@ Rv<Directive::Handle> Do_upstream_addr::load(Config& cfg, CfgStaticData const*, 
 }
 /* ------------------------------------------------------------------------------------ */
 /// Set a transaction local variable.
-class Do_var : public Directive {
-  using self_type = Do_var; ///< Self reference type.
+class Do_var : public Directive
+{
+  using self_type  = Do_var;    ///< Self reference type.
   using super_type = Directive; ///< Parent type.
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -3350,27 +3726,33 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
   TextView _name; ///< Variable name.
-  Expr _value; ///< Value for variable.
+  Expr _value;    ///< Value for variable.
 
-  Do_var(TextView const& arg, Expr && value) : _name(arg), _value(std::move(value)) {}
+  Do_var(TextView const &arg, Expr &&value) : _name(arg), _value(std::move(value)) {}
 };
 
-const std::string Do_var::KEY { "var" };
-const HookMask Do_var::HOOKS { MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP, Hook::PREQ, Hook::URSP, Hook::PRSP}) };
+const std::string Do_var::KEY{"var"};
+const HookMask Do_var::HOOKS{
+  MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP, Hook::PREQ, Hook::URSP, Hook::PRSP})};
 
-Errata Do_var::invoke(Context &ctx) {
+Errata
+Do_var::invoke(Context &ctx)
+{
   ctx.store_txn_var(_name, ctx.extract(_value));
   return {};
 }
 
-Rv<Directive::Handle> Do_var::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_var::load(Config &cfg, CfgStaticData const *, YAML::Node, swoc::TextView const &, swoc::TextView const &arg,
+             YAML::Node key_value)
+{
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     return std::move(errata);
   }
 
@@ -3381,9 +3763,11 @@ Rv<Directive::Handle> Do_var::load(Config& cfg, CfgStaticData const*, YAML::Node
  *
  * This is a core directive that has lots of special properties.
  */
-class Do_with : public Directive {
+class Do_with : public Directive
+{
   using super_type = Directive;
-  using self_type = Do_with;
+  using self_type  = Do_with;
+
 public:
   static const std::string KEY;
   static const std::string SELECT_KEY;
@@ -3403,11 +3787,11 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
 protected:
-  Expr _expr; ///< Feature expression
+  Expr _expr;            ///< Feature expression
   Directive::Handle _do; ///< Explicit actions.
 
   union {
@@ -3421,33 +3805,36 @@ protected:
   /// A single case in the select.
   struct Case {
     Comparison::Handle _cmp; ///< Comparison to perform.
-    Directive::Handle _do; ///< Directives to execute.
+    Directive::Handle _do;   ///< Directives to execute.
   };
   using CaseGroup = std::vector<Case>;
   CaseGroup _cases; ///< List of cases for the select.
 
   Do_with() = default;
 
-  Errata load_case(Config & cfg, YAML::Node node);
+  Errata load_case(Config &cfg, YAML::Node node);
 };
 
-const std::string Do_with::KEY {"with" };
-const std::string Do_with::SELECT_KEY {"select" };
-const std::string Do_with::FOR_EACH_KEY {"for-each" };
-const std::string Do_with::CONTINUE_KEY {"continue" };
+const std::string Do_with::KEY{"with"};
+const std::string Do_with::SELECT_KEY{"select"};
+const std::string Do_with::FOR_EACH_KEY{"for-each"};
+const std::string Do_with::CONTINUE_KEY{"continue"};
 
-const HookMask Do_with::HOOKS  {MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP, Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP }) };
+const HookMask Do_with::HOOKS{MaskFor({Hook::POST_LOAD, Hook::TXN_START, Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP,
+                                       Hook::PRE_REMAP, Hook::POST_REMAP, Hook::REMAP})};
 
-Errata Do_with::invoke(Context &ctx) {
-  Feature feature { ctx.extract(_expr) };
+Errata
+Do_with::invoke(Context &ctx)
+{
+  Feature feature{ctx.extract(_expr)};
   ctx.commit(feature);
-  Feature save { ctx._active };
+  Feature save{ctx._active};
   ctx._active = feature;
 
   if (_do) {
     if (_opt.f.for_each_p) {
       ctx._active_ext = feature;
-      while (! is_nil(feature)) {
+      while (!is_nil(feature)) {
         ctx._active = car(feature);
         ctx.mark_terminal(false);
         _do->invoke(ctx);
@@ -3457,7 +3844,7 @@ Errata Do_with::invoke(Context &ctx) {
       ctx._active_ext = NIL_FEATURE;
       // Iteration can potentially modify the extracted feature value, so if there are comparisons
       // reset the feature.
-      if (! _cases.empty()) {
+      if (!_cases.empty()) {
         ctx._active = feature = ctx.extract(_expr);
       }
     } else {
@@ -3467,8 +3854,8 @@ Errata Do_with::invoke(Context &ctx) {
   }
 
   ctx.mark_terminal(false); // default is continue on.
-  for ( auto const& c : _cases ) {
-    if (! c._cmp || (*c._cmp)(ctx, feature)) {
+  for (auto const &c : _cases) {
+    if (!c._cmp || (*c._cmp)(ctx, feature)) {
       if (c._do) {
         c._do->invoke(ctx);
       }
@@ -3482,20 +3869,23 @@ Errata Do_with::invoke(Context &ctx) {
   return {};
 }
 
-swoc::Rv<Directive::Handle> Do_with::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+swoc::Rv<Directive::Handle>
+Do_with::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+              YAML::Node key_value)
+{
   // Need to parse this first, so the feature type can be determined.
-  auto && [ expr, errata ] = cfg.parse_expr(key_value);
+  auto &&[expr, errata] = cfg.parse_expr(key_value);
 
   if (!errata.is_ok()) {
     return std::move(errata);
   }
 
-  auto * self = new self_type;
+  auto *self = new self_type;
   Handle handle(self); // for return, and cleanup in case of error.
-  self->_expr = std::move(expr);
+  self->_expr  = std::move(expr);
   auto f_scope = cfg.feature_scope(self->_expr.result_type());
 
-  YAML::Node select_node { drtv_node[SELECT_KEY] };
+  YAML::Node select_node{drtv_node[SELECT_KEY]};
   if (select_node) {
     if (select_node.IsMap()) {
       errata = self->load_case(cfg, select_node);
@@ -3506,23 +3896,24 @@ swoc::Rv<Directive::Handle> Do_with::load(Config& cfg, CfgStaticData const*, YAM
       for (YAML::Node child : select_node) {
         errata = (self->load_case(cfg, child));
         if (!errata.is_ok()) {
-          errata.info(R"(While loading "{}" directive at {} in "{}" at {}.)", KEY, drtv_node.Mark()
-                       , SELECT_KEY, select_node.Mark());
+          errata.info(R"(While loading "{}" directive at {} in "{}" at {}.)", KEY, drtv_node.Mark(), SELECT_KEY,
+                      select_node.Mark());
           return std::move(errata);
         }
       }
     } else {
-      return Error(R"(The value for "{}" at {} in "{}" directive at {} is not a list or object.")", SELECT_KEY, select_node.Mark(), KEY, drtv_node.Mark());
+      return Error(R"(The value for "{}" at {} in "{}" directive at {} is not a list or object.")", SELECT_KEY, select_node.Mark(),
+                   KEY, drtv_node.Mark());
     }
   }
 
-  YAML::Node continue_node { drtv_node[CONTINUE_KEY]};
+  YAML::Node continue_node{drtv_node[CONTINUE_KEY]};
   if (continue_node) {
     self->_opt.f.continue_p = true;
   }
 
-  YAML::Node do_node { drtv_node[DO_KEY] };
-  YAML::Node for_each_node { drtv_node[FOR_EACH_KEY]};
+  YAML::Node do_node{drtv_node[DO_KEY]};
+  YAML::Node for_each_node{drtv_node[FOR_EACH_KEY]};
   if (do_node && for_each_node) {
     return Error(R"("{}" directive cannot have both "{}" and "{}" as keys - {}.)", DO_KEY, FOR_EACH_KEY, drtv_node.Mark());
   } else if (do_node) {
@@ -3536,7 +3927,7 @@ swoc::Rv<Directive::Handle> Do_with::load(Config& cfg, CfgStaticData const*, YAM
   } else if (for_each_node) {
     auto &&[fe_handle, errata]{cfg.parse_directive(for_each_node)};
     if (errata.is_ok()) {
-      self->_do = std::move(fe_handle);
+      self->_do               = std::move(fe_handle);
       self->_opt.f.for_each_p = true;
     } else {
       errata.info(R"(While parsing "{}" key at {} in selection case at {}.)", FOR_EACH_KEY, for_each_node.Mark(), drtv_node.Mark());
@@ -3546,15 +3937,17 @@ swoc::Rv<Directive::Handle> Do_with::load(Config& cfg, CfgStaticData const*, YAM
   return handle;
 }
 
-Errata Do_with::load_case(Config & cfg, YAML::Node node) {
+Errata
+Do_with::load_case(Config &cfg, YAML::Node node)
+{
   if (node.IsMap()) {
     Case c;
-    YAML::Node do_node { node[DO_KEY]};
+    YAML::Node do_node{node[DO_KEY]};
     // It's allowed to have no comparison, which is either an empty map or only a DO key.
     // In that case the comparison always matches.
     if (node.size() > 1 || (node.size() == 1 && !do_node)) {
       auto f_scope = cfg.feature_scope(_expr.result_type());
-      auto &&[cmp_handle, cmp_errata]{Comparison::load(cfg,  node)};
+      auto &&[cmp_handle, cmp_errata]{Comparison::load(cfg, node)};
       if (cmp_errata.is_ok()) {
         c._cmp = std::move(cmp_handle);
       } else {
@@ -3568,8 +3961,7 @@ Errata Do_with::load_case(Config & cfg, YAML::Node node) {
       if (errata.is_ok()) {
         c._do = std::move(handle);
       } else {
-        errata.info(R"(While parsing "{}" key at {} in selection case at {}.)", DO_KEY
-                     , do_node.Mark(), node.Mark());
+        errata.info(R"(While parsing "{}" key at {} in selection case at {}.)", DO_KEY, do_node.Mark(), node.Mark());
         return errata;
       }
     } else {
@@ -3583,20 +3975,25 @@ Errata Do_with::load_case(Config & cfg, YAML::Node node) {
 }
 
 /* ------------------------------------------------------------------------------------ */
-const std::string When::KEY { "when" };
-const HookMask When::HOOKS  { MaskFor({Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP }) };
+const std::string When::KEY{"when"};
+const HookMask When::HOOKS{
+  MaskFor({Hook::CREQ, Hook::PREQ, Hook::URSP, Hook::PRSP, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP})};
 
-When::When(Hook hook_idx, Directive::Handle &&directive) : _hook(hook_idx), _directive(std::move
-(directive)) {}
+When::When(Hook hook_idx, Directive::Handle &&directive) : _hook(hook_idx), _directive(std::move(directive)) {}
 
 // Put the internal directive in the directive array for the specified hook.
-Errata When::invoke(Context &ctx) {
+Errata
+When::invoke(Context &ctx)
+{
   return ctx.on_hook_do(_hook, _directive.get());
 }
 
-swoc::Rv<Directive::Handle> When::load(Config& cfg, CfgStaticData const*, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+swoc::Rv<Directive::Handle>
+When::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &, swoc::TextView const &,
+           YAML::Node key_value)
+{
   Errata zret;
-  if (Hook hook{HookName[key_value.Scalar()]} ; hook != Hook::INVALID) {
+  if (Hook hook{HookName[key_value.Scalar()]}; hook != Hook::INVALID) {
     if (YAML::Node do_node{drtv_node[DO_KEY]}; do_node) {
       auto save = cfg._hook;
       cfg._hook = hook;
@@ -3604,27 +4001,26 @@ swoc::Rv<Directive::Handle> When::load(Config& cfg, CfgStaticData const*, YAML::
       cfg._hook = save;
       if (do_errata.is_ok()) {
         cfg.reserve_slot(hook);
-        return { Handle{new self_type{hook, std::move(do_handle)}} , {}};
+        return {Handle{new self_type{hook, std::move(do_handle)}}, {}};
       } else {
         zret.note(do_errata);
-        zret.error(R"(Failed to load directive in "{}" at {} in "{}" directive at {}.)", DO_KEY
-                   , do_node.Mark(), KEY, key_value.Mark());
+        zret.error(R"(Failed to load directive in "{}" at {} in "{}" directive at {}.)", DO_KEY, do_node.Mark(), KEY,
+                   key_value.Mark());
       }
     } else {
-      zret.error(R"(The required "{}" key was not found in the "{}" directive at {}.")", DO_KEY, KEY
-                 , drtv_node.Mark());
+      zret.error(R"(The required "{}" key was not found in the "{}" directive at {}.")", DO_KEY, KEY, drtv_node.Mark());
     }
   } else {
-    zret.error(R"(Invalid hook name "{}" in "{}" directive at {}.)", key_value.Scalar(), When::KEY
-               , key_value.Mark());
+    zret.error(R"(Invalid hook name "{}" in "{}" directive at {}.)", key_value.Scalar(), When::KEY, key_value.Mark());
   }
   return {{}, std::move(zret)};
 }
 
 /* ------------------------------------------------------------------------------------ */
 
-namespace {
-[[maybe_unused]] bool INITIALIZED = [] () -> bool {
+namespace
+{
+[[maybe_unused]] bool INITIALIZED = []() -> bool {
   Config::define<When>();
   Config::define<Do_with>();
 
@@ -3685,5 +4081,5 @@ namespace {
   Config::define<Do_did_remap>();
 
   return true;
-} ();
+}();
 } // namespace

--- a/plugin/src/Machinery.cc
+++ b/plugin/src/Machinery.cc
@@ -1971,6 +1971,176 @@ Rv<Directive::Handle> Do_upstream_rsp_field::load(Config& cfg, CfgStaticData con
   return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
 }
 /* ------------------------------------------------------------------------------------ */
+class QueryValueDirective : public Directive {
+  using self_type = QueryValueDirective;
+  using super_type = Directive;
+public:
+  TextView _name; ///< Query value key name.
+  Expr _expr; ///< Replacement value.
+
+  /** Base constructor.
+   *
+   * @param name Name of the field.
+   * @param expr Value to assign to the field.
+   */
+  QueryValueDirective(TextView const& name, Expr && expr);
+
+  /** Load from configuration.
+   *
+   * @param cfg Configuration.
+   * @param maker Subclass maker.
+   * @param key Name of the key identifying the directive.
+   * @param name Field name (directive argumnet).
+   * @param key_value  Value of the node for @a key.
+   * @return An instance of the directive for @a key, or errors.
+   */
+  static Rv<Handle> load(Config& cfg, std::function<Handle (TextView const& name, Expr && fmt)> const& maker, TextView const& key, TextView const& arg, YAML::Node key_value);
+
+  /** Invoke the directive on a URL.
+   *
+   * @param ctx Runtime context.
+   * @param url URL.
+   * @return Errors, if any.
+   */
+  Errata invoke_on_url(Context& ctx, ts::URL && url);
+
+protected:
+  /** Get the directive name (key).
+   *
+   * @return The directive key.
+   *
+   * Used by subclasses to provide the key for diagnostics.
+   */
+  virtual swoc::TextView key() const = 0;
+
+};
+
+QueryValueDirective::QueryValueDirective(TextView const& name, Expr && expr) : _name(name), _expr(std::move(expr)) {}
+
+auto QueryValueDirective::load(Config& cfg
+                              , std::function<Handle(const TextView&, Expr&&)> const& maker
+                              , TextView const& key
+                              , TextView const& arg
+                              , YAML::Node key_value
+                              ) -> Rv<Handle> {
+  auto && [ expr, errata ] { cfg.parse_expr(key_value) };
+  if (! errata.is_ok()) {
+    errata.info(R"(While parsing value for "{}".)", key);
+    return std::move(errata);
+  }
+
+  auto expr_type = expr.result_type();
+  if (! expr_type.has_value()) {
+    return Error(R"(Directive "{}" must have a value.)", key);
+  }
+  return maker(cfg.localize(arg), std::move(expr));
+}
+
+Errata QueryValueDirective::invoke_on_url(Context& ctx, ts::URL && url) {
+  if (url.is_valid()) {
+    auto nv { ctx.extract(_expr)};
+    bool nv_is_str_p = (nv.value_type() == STRING);
+    auto qs = url.query();
+    if (qs.empty()) {
+      if (nv_is_str_p) {
+        qs = ctx.render_transient([&](BufferWriter&w){ w.print("{}={}", _name, std::get<STRING>(nv));});
+        url.query_set(qs);
+        ctx.transient_discard();
+      }
+    } else {
+      auto value = ts::query_value_for(qs, _name, true);
+      if (value.data() == nullptr) { // not found at all.
+        if (nv_is_str_p) {
+          auto str = ctx.render_transient([&](BufferWriter&w) {
+            w.print("{}&{}={}", qs, _name, std::get<STRING>(nv));
+          });
+          url.query_set(str);
+          ctx.transient_discard();
+        }
+      } else {
+        // Prefix is the part before the value, less the name and if there is a value,
+        // the '=' separator.
+        TextView prefix { qs.data(), value.data() - _name.size()};
+        if (value.size()) { prefix.remove_suffix(1); }
+        // Suffix is the part after the value.
+        TextView suffix { value.end(), qs.end() };
+        TextView str;
+        if (nv_is_str_p) {
+          // If replacement, the separators on either side should be correct.
+          str = ctx.render_transient([&](BufferWriter&w) {
+            w.print("{}{}={}{}", prefix, _name, std::get<STRING>(nv), suffix);
+          });
+        } else {
+          prefix.rtrim("&;"_tv);
+          suffix.ltrim("&;"_tv);
+          if (suffix.empty()) {
+            str = prefix;
+          } else if (prefix.empty()) {
+            str = suffix;
+          } else { // neither is empty.
+            str = ctx.render_transient([&](BufferWriter&w) {w.print("{}&{}", prefix, suffix);});
+          }
+        }
+        url.query_set(str);
+        ctx.transient_discard();
+      }
+    }
+  }
+  return Error("Failed to update query value {} because the URL could not be found.", _name);
+}
+
+// --
+class Do_ua_req_query_value : public QueryValueDirective {
+  using self_type = Do_ua_req_query_value;
+  using super_type = QueryValueDirective;
+public:
+  static inline const std::string KEY { "ua-req-query-value" }; ///< Directive key.
+  static inline const HookMask HOOKS { MaskFor(Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP, Hook::POST_REMAP)}; ///< Valid hooks for directive.
+
+  using super_type::invoke;
+  Errata invoke(Context & ctx) override;
+
+  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
+                          , swoc::TextView const& arg, YAML::Node key_value);
+protected:
+  using super_type::super_type; // Inherit super_type constructors.
+  TextView key() const override { return KEY; }
+};
+
+Errata Do_ua_req_query_value::invoke(Context &ctx) {
+  return this->invoke_on_url(ctx, ctx.ua_req_hdr().url());
+}
+
+Rv<Directive::Handle> Do_ua_req_query_value::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
+  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+}
+
+// --
+class Do_proxy_req_query_value : public QueryValueDirective {
+  using self_type = Do_proxy_req_query_value;
+  using super_type = QueryValueDirective;
+public:
+  static inline const std::string KEY { "proxy-req-query-value" }; ///< Directive key.
+  static inline const HookMask HOOKS { MaskFor(Hook::PREQ)}; ///< Valid hooks for directive.
+
+  using super_type::invoke;
+  Errata invoke(Context & ctx) override;
+
+  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
+                          , swoc::TextView const& arg, YAML::Node key_value);
+protected:
+  using super_type::super_type; // Inherit super_type constructors.
+  TextView key() const override { return KEY; }
+};
+
+Errata Do_proxy_req_query_value::invoke(Context &ctx) {
+  return this->invoke_on_url(ctx, ctx.proxy_req_hdr().url());
+}
+
+Rv<Directive::Handle> Do_proxy_req_query_value::load(Config& cfg, CfgStaticData const*, YAML::Node, swoc::TextView const&, swoc::TextView const& arg, YAML::Node key_value) {
+  return super_type::load(cfg, [](TextView const& name, Expr && fmt) -> Handle { return Handle(new self_type(name, std::move(fmt))); }, KEY, arg, key_value);
+}
+/* ------------------------------------------------------------------------------------ */
 /// Set upstream response status code.
 class Do_upstream_rsp_status : public Directive {
   using self_type = Do_upstream_rsp_status; ///< Self reference type.
@@ -3470,6 +3640,7 @@ namespace {
   Config::define<Do_ua_req_loc>();
   Config::define<Do_ua_req_path>();
   Config::define<Do_ua_req_query>();
+  Config::define<Do_ua_req_query_value>();
   Config::define<Do_ua_req_fragment>();
 
   Config::define<Do_proxy_req_field>();
@@ -3484,6 +3655,7 @@ namespace {
   Config::define<Do_proxy_req_scheme>();
   Config::define<Do_proxy_req_path>();
   Config::define<Do_proxy_req_query>();
+  Config::define<Do_proxy_req_query_value>();
   Config::define<Do_proxy_req_fragment>();
 
   Config::define<Do_upstream_rsp_field>();

--- a/plugin/src/Rxp.cc
+++ b/plugin/src/Rxp.cc
@@ -15,28 +15,35 @@ using namespace swoc::literals;
 using swoc::Errata;
 using swoc::Rv;
 
-Rv<Rxp> Rxp::parse(TextView const& str, Options const& options) {
-  int errc = 0;
-  size_t err_off = 0;
+Rv<Rxp>
+Rxp::parse(TextView const &str, Options const &options)
+{
+  int errc         = 0;
+  size_t err_off   = 0;
   uint32_t rxp_opt = 0;
   if (options.f.nc) {
     rxp_opt = PCRE2_CASELESS;
   }
-  auto result = pcre2_compile(reinterpret_cast<unsigned const char*>(str.data()), str.size(), rxp_opt, &errc, &err_off, nullptr);
+  auto result = pcre2_compile(reinterpret_cast<unsigned const char *>(str.data()), str.size(), rxp_opt, &errc, &err_off, nullptr);
   if (nullptr == result) {
     PCRE2_UCHAR err_buff[128];
     auto err_size = pcre2_get_error_message(errc, err_buff, sizeof(err_buff));
-    return Error(R"(Failed to parse regular expression - error "{}" [{}] at offset {} in "{}".)", TextView(reinterpret_cast<char const*>(err_buff), err_size), errc, err_off, str);
+    return Error(R"(Failed to parse regular expression - error "{}" [{}] at offset {} in "{}".)",
+                 TextView(reinterpret_cast<char const *>(err_buff), err_size), errc, err_off, str);
   }
-  return { result };
+  return {result};
 };
 
-int Rxp::operator()(swoc::TextView text, pcre2_match_data* match) const {
+int
+Rxp::operator()(swoc::TextView text, pcre2_match_data *match) const
+{
   return pcre2_match(_rxp.get(), reinterpret_cast<PCRE2_SPTR>(text.data()), text.size(), 0, 0, match, nullptr);
 }
 
-size_t Rxp::capture_count() const {
+size_t
+Rxp::capture_count() const
+{
   uint32_t count = 0;
-  auto result = pcre2_pattern_info(_rxp.get(), PCRE2_INFO_CAPTURECOUNT, &count);
+  auto result    = pcre2_pattern_info(_rxp.get(), PCRE2_INFO_CAPTURECOUNT, &count);
   return result == 0 ? count + 1 : 0; // output doesn't reflect capture group 0, apparently.
 }

--- a/plugin/src/ip_space.cc
+++ b/plugin/src/ip_space.cc
@@ -860,7 +860,7 @@ Rv<ActiveType> Ex_ip_col::validate(Config &cfg, Spec &spec, const TextView &arg)
   }
 
   auto span = cfg.allocate_cfg_storage(sizeof(Info)).rebind<Info>();
-  spec._data = span;
+  spec._data.span = span;
   Info & info = span[0];
   auto drtv = mod_info->_drtv;
   // Always do the column conversion if it's an integer - that won't change at runtime.
@@ -900,7 +900,7 @@ Rv<ActiveType> Ex_ip_col::validate(Config &cfg, Spec &spec, const TextView &arg)
 
 Feature Ex_ip_col::extract(Context &ctx, const Spec &spec) {
   // Get all the pieces needed.
-  auto info = spec._data.rebind<Info>().data(); // Extractor local storage.
+  auto info = spec._data.span.rebind<Info>().data(); // Extractor local storage.
   CtxActiveInfo * ctx_ai = Do_ip_space_define::ctx_active_info(ctx);
   auto drtv = ctx_ai->_drtv; // Needed for column information.
   auto idx = (info->_idx != INVALID_IDX ? info->_idx : drtv->col_idx(info->_arg));

--- a/plugin/src/ip_space.cc
+++ b/plugin/src/ip_space.cc
@@ -42,15 +42,16 @@ namespace bwf = swoc::bwf;
 /* ------------------------------------------------------------------------------------ */
 class Do_ip_space_define;
 
-namespace {
+namespace
+{
 /// Column data type.
 enum class ColumnData {
   INVALID, ///< Invalid marker.
   ADDRESS, ///< Special marker for range column (column 0)
-  STRING, ///< text.
+  STRING,  ///< text.
   INTEGER, ///< integral value.
-  ENUM, ///< enumeration.
-  FLAGS ///< Set of flags.
+  ENUM,    ///< enumeration.
+  FLAGS    ///< Set of flags.
 };
 
 /// A row in the space.
@@ -59,7 +60,7 @@ using Row = MemSpan<std::byte>;
 using Space = IPSpace<Row>;
 /// Space information that must be reloaded on file change.
 struct SpaceInfo {
-  Space space; ///< IPSpace.
+  Space space;          ///< IPSpace.
   swoc::MemArena arena; ///< Row storage.
 };
 
@@ -68,9 +69,9 @@ using SpaceHandle = std::shared_ptr<SpaceInfo>;
 /// This is set up by the @c ip-space modifier and is only valid in the expression scope.
 struct CtxActiveInfo {
   Do_ip_space_define *_drtv = nullptr; ///< Active definition.
-  SpaceHandle _space; ///< Active space.
-  IPAddr _addr; ///< Search address.
-  Row *_row = nullptr; ///< Active row.
+  SpaceHandle _space;                  ///< Active space.
+  IPAddr _addr;                        ///< Search address.
+  Row *_row = nullptr;                 ///< Active row.
 };
 
 } // namespace
@@ -82,8 +83,9 @@ struct CtxActiveInfo {
  * memory as a bit set. This enables fitting it in to a @c Row in the @c IPSpace payload where
  * the @c Row data is allocated in a single chunk.
  */
-class BitSpan {
-  using self_type = BitSpan; ///< Self reference type.
+class BitSpan
+{
+  using self_type                = BitSpan;                              ///< Self reference type.
   static constexpr unsigned BITS = std::numeric_limits<uint8_t>::digits; ///< # of bits per unit.
 
   /// Reference class to make the index operator work.
@@ -96,7 +98,15 @@ class BitSpan {
      *
      * The bit is set if @a b is @c true, and reset if @a b is @c false.
      */
-    bit_ref & operator = (bool b) { if (b) bits.set(idx); else bits.reset(idx); return *this; }
+    bit_ref &
+    operator=(bool b)
+    {
+      if (b)
+        bits.set(idx);
+      else
+        bits.reset(idx);
+      return *this;
+    }
 
     /** Assign an @c int to the bit.
      *
@@ -105,109 +115,129 @@ class BitSpan {
      *
      * The bit is set to zero if @a v is zero, otherwise it is set to 1.
      */
-    bit_ref & operator = (int v) { return (*this) = (v != 0);}
+    bit_ref &
+    operator=(int v)
+    {
+      return (*this) = (v != 0);
+    }
 
     /** Allow bit to be used as a boolean.
      *
      * @return @c true if the bit is set, @c false if not.
      */
-    explicit operator bool () { return (bits._span[idx/BITS] & (1 << (idx % BITS))) != 0;}
+    explicit operator bool() { return (bits._span[idx / BITS] & (1 << (idx % BITS))) != 0; }
 
-    BitSpan& bits; ///< Containing span.
-    unsigned idx; ///< Bit index.
+    BitSpan &bits; ///< Containing span.
+    unsigned idx;  ///< Bit index.
   };
+
 public:
   /// Construct from chunk of memory.
-  BitSpan(MemSpan<void> const& span) : _span(span.rebind<uint8_t>()) {}
+  BitSpan(MemSpan<void> const &span) : _span(span.rebind<uint8_t>()) {}
   /// Construct from chunk of bytes.
-  BitSpan(MemSpan<uint8_t> const& span) : _span(span) {}
+  BitSpan(MemSpan<uint8_t> const &span) : _span(span) {}
 
   /** Set a bit
    *
    * @param idx Bit index.
    * @return @a this.
    */
-  self_type & set(unsigned idx);
+  self_type &set(unsigned idx);
 
   /** Reset a bit.
    *
    * @param idx Bit index.
    * @return @a this.
    */
-  self_type & reset(unsigned idx);
+  self_type &reset(unsigned idx);
 
   /** Reset all bits.
    *
    * @return @a this.
    */
-  self_type & reset();
+  self_type &reset();
 
   /** Access a single bit.
    *
    * @param idx Index of bit.
    * @return @c true if the bit is set, @c false if not.
    */
-  bit_ref operator [](unsigned idx) { return { *this, idx }; }
+  bit_ref
+  operator[](unsigned idx)
+  {
+    return {*this, idx};
+  }
 
-  unsigned count() const {
+  unsigned
+  count() const
+  {
     unsigned zret = 0;
-    for ( unsigned idx = 0, N = _span.count() ; idx < N ; ++idx ) {
+    for (unsigned idx = 0, N = _span.count(); idx < N; ++idx) {
       zret += std::bitset<BITS>(_span[idx]).count();
     }
     return zret;
   }
+
 protected:
   MemSpan<uint8_t> _span;
 };
 
-inline auto BitSpan::set(unsigned int idx) -> self_type & {
-  _span[idx/BITS] |= (1 << (idx % BITS));
+inline auto
+BitSpan::set(unsigned int idx) -> self_type &
+{
+  _span[idx / BITS] |= (1 << (idx % BITS));
   return *this;
 }
 
-inline auto BitSpan::reset(unsigned int idx) -> self_type & {
-  _span[idx/BITS] &= ~(1 << (idx % BITS));
+inline auto
+BitSpan::reset(unsigned int idx) -> self_type &
+{
+  _span[idx / BITS] &= ~(1 << (idx % BITS));
   return *this;
 }
 
-inline auto BitSpan::reset() -> self_type & {
+inline auto
+BitSpan::reset() -> self_type &
+{
   memset(_span, 0);
   return *this;
 }
 /* ------------------------------------------------------------------------------------ */
 /// Define an IP Space
-class Do_ip_space_define : public Directive {
-  using self_type = Do_ip_space_define; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_ip_space_define : public Directive
+{
+  using self_type  = Do_ip_space_define; ///< Self reference type.
+  using super_type = Directive;          ///< Parent type.
 protected:
   /// Configuration level map of defined spaces.
-  using Map = std::unordered_map<TextView, self_type*, std::hash<std::string_view>>;
+  using Map = std::unordered_map<TextView, self_type *, std::hash<std::string_view>>;
 
   /// Per configuration data.
   /// An instance of this is stored in the configuration arena.
   struct CfgInfo {
     ReservedSpan _ctx_reserved_span; ///< Per context reserved storage.
     /// The active directive during configuration loading.
-    mutable self_type * _active = nullptr;
+    mutable self_type *_active = nullptr;
     Map _map; ///< Map of defined spaces.
   };
+
 public:
   static const std::string KEY; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;  ///< Valid hooks for directive.
   /// Specify the required amount of reserved configuration storage.
-  static constexpr Options OPTIONS { sizeof(CfgInfo) };
+  static constexpr Options OPTIONS{sizeof(CfgInfo)};
 
   /// Functor to do file content updating as needed.
   struct Updater {
     std::weak_ptr<Config> _cfg; ///< Configuration.
-    Do_ip_space_define * _block; ///< Space instance.
+    Do_ip_space_define *_block; ///< Space instance.
 
     void operator()(); ///< Do the update check.
   };
 
   ~Do_ip_space_define() noexcept override; ///< Destructor.
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -219,8 +249,8 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static swoc::Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                                , swoc::TextView const& arg, YAML::Node key_value);
+  static swoc::Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                               swoc::TextView const &arg, YAML::Node key_value);
 
   /** Per config initialization.
    *
@@ -228,54 +258,56 @@ public:
    * @param rtti Defined directive data.
    * @return Errors, if any.
    */
-  static Errata cfg_init(Config& cfg, CfgStaticData const* rtti);
+  static Errata cfg_init(Config &cfg, CfgStaticData const *rtti);
 
   static constexpr unsigned INVALID_IDX = std::numeric_limits<unsigned>::max();
 
-  unsigned col_idx(swoc::TextView const& name);
+  unsigned col_idx(swoc::TextView const &name);
 
 protected:
-
   /// Information about a column in the IPSpace table.
   struct Column {
-    TextView _name; ///< Name.
-    unsigned _idx; ///< Index.
-    ColumnData _type; ///< Column data type.
+    TextView _name;           ///< Name.
+    unsigned _idx;            ///< Index.
+    ColumnData _type;         ///< Column data type.
     swoc::Lexicon<int> _tags; ///< Tags for enumerations or flags.
-    size_t _row_offset; ///< Offset in to @c Row for column data.
-    size_t _row_size; ///< # of bytes of row storage.
+    size_t _row_offset;       ///< Offset in to @c Row for column data.
+    size_t _row_size;         ///< # of bytes of row storage.
 
-    Column() = default; ///< Default constructor.
-    Column(Column && that) = default; ///< Move constructor.
+    Column()              = default; ///< Default constructor.
+    Column(Column &&that) = default; ///< Move constructor.
 
     /** Extra data for this column from a @a row
      *
      * @param row IPSpace row.
      * @return Data for @a this column in that @a row.
      */
-    MemSpan<std::byte> data_in_row(Row* row) {
-      return { row->data() + _row_offset, _row_size};
+    MemSpan<std::byte>
+    data_in_row(Row *row)
+    {
+      return {row->data() + _row_offset, _row_size};
     }
 
     /// Mapping between strings and @c ColumnData enumeration values.
     static const swoc::Lexicon<ColumnData> TypeNames;
   };
 
-  TextView _name; ///< Block name.
-  swoc::file::path _path; ///< Path to file (optional)
-  SpaceHandle _space; ///< The IP Space
+  TextView _name;                 ///< Block name.
+  swoc::file::path _path;         ///< Path to file (optional)
+  SpaceHandle _space;             ///< The IP Space
   std::shared_mutex _space_mutex; ///< Reader / writer for @a _space.
 
-  std::vector<Column> _cols; ///< Defined columns.
-  swoc::Lexicon<unsigned> _col_names; ///< Mapping of names <-> indices.
+  std::vector<Column> _cols;             ///< Defined columns.
+  swoc::Lexicon<unsigned> _col_names;    ///< Mapping of names <-> indices.
   static constexpr int INVALID_TAG = -1; ///< Lexicon default value for invalid tag.
-  static constexpr int AUTO_TAG = -2; ///< Lexicon default value for auto adding tags (enum).
-  size_t _row_size = 0; ///< Current row size.
+  static constexpr int AUTO_TAG    = -2; ///< Lexicon default value for auto adding tags (enum).
+  size_t _row_size                 = 0;  ///< Current row size.
 
   feature_type_for<DURATION> _duration; ///< Time between update checks.
-  std::atomic<std::chrono::system_clock::duration> _last_check = std::chrono::system_clock::now().time_since_epoch(); ///< Absolute time of the last alert.
-  std::chrono::system_clock::time_point _last_modified; ///< Last modified time of the file.
-  ts::TaskHandle _task; ///< Handle for periodic checking task.
+  std::atomic<std::chrono::system_clock::duration> _last_check =
+    std::chrono::system_clock::now().time_since_epoch(); ///< Absolute time of the last alert.
+  std::chrono::system_clock::time_point _last_modified;  ///< Last modified time of the file.
+  ts::TaskHandle _task;                                  ///< Handle for periodic checking task.
 
   int _line_no = 0; ///< For debugging name conflicts.
 
@@ -289,7 +321,9 @@ protected:
   static const std::string VALUES_TAG;
   ///@}
 
-  SpaceHandle acquire_space() {
+  SpaceHandle
+  acquire_space()
+  {
     std::shared_lock lock(_space_mutex);
     return _space;
   }
@@ -301,18 +335,18 @@ protected:
    *
    * This is used by associated elements that do not have access to an instance of this class.
    */
-  static CfgInfo * cfg_info(Config& cfg);
+  static CfgInfo *cfg_info(Config &cfg);
 
   /// Find the space for the directive instance.
-  Map* map();
+  Map *map();
 
   /// Get the map of IP Space directives from the @a cfg.
-//  static Map* map(Config& cfg);
+  //  static Map* map(Config& cfg);
 
   /// Per context storage for the active space.
   /// This is reserved during config load.
   /// Reservation is in @c CfgInfo::_ctx_reserved_span
-  static CtxActiveInfo * ctx_active_info(Context& ctx);
+  static CtxActiveInfo *ctx_active_info(Context &ctx);
 
   Do_ip_space_define() = default; ///< Default constructor.
 
@@ -322,7 +356,7 @@ protected:
    * @param node Roto node of the column definition.
    * @return Errors, if any.
    */
-  Errata define_column(Config & cfg, YAML::Node node);
+  Errata define_column(Config &cfg, YAML::Node node);
 
   /** Parse the input file.
    *
@@ -330,7 +364,7 @@ protected:
    * @param content File content.
    * @return The parsed space, or errors.
    */
-  Rv<SpaceHandle> parse_space(Config & cfg, TextView content);
+  Rv<SpaceHandle> parse_space(Config &cfg, TextView content);
 
   /// Check if it is time to do a modified check on the file content.
   bool should_check();
@@ -340,45 +374,52 @@ protected:
   friend Updater;
 };
 
-const std::string Do_ip_space_define::KEY{"ip-space-define" };
-const std::string Do_ip_space_define::NAME_TAG{"name" };
-const std::string Do_ip_space_define::PATH_TAG{"path" };
-const std::string Do_ip_space_define::COLUMNS_TAG{ "columns" };
-const std::string Do_ip_space_define::DURATION_TAG{"duration" };
+const std::string Do_ip_space_define::KEY{"ip-space-define"};
+const std::string Do_ip_space_define::NAME_TAG{"name"};
+const std::string Do_ip_space_define::PATH_TAG{"path"};
+const std::string Do_ip_space_define::COLUMNS_TAG{"columns"};
+const std::string Do_ip_space_define::DURATION_TAG{"duration"};
 const std::string Do_ip_space_define::TYPE_TAG{"type"};
 const std::string Do_ip_space_define::VALUES_TAG{"values"};
 
 const HookMask Do_ip_space_define::HOOKS{MaskFor(Hook::POST_LOAD)};
 
-const swoc::Lexicon<ColumnData> Do_ip_space_define::Column::TypeNames {
-  {{ColumnData::STRING, "string" }
-        ,{ColumnData::ENUM, "enum" }
-        ,{ColumnData::INTEGER, "integer"}
-        ,{ColumnData::FLAGS, "flags" }
-        }
-        , ColumnData::INVALID };
+const swoc::Lexicon<ColumnData> Do_ip_space_define::Column::TypeNames{
+  {{ColumnData::STRING, "string"}, {ColumnData::ENUM, "enum"}, {ColumnData::INTEGER, "integer"}, {ColumnData::FLAGS, "flags"}},
+  ColumnData::INVALID};
 
-Do_ip_space_define::~Do_ip_space_define() noexcept {
+Do_ip_space_define::~Do_ip_space_define() noexcept
+{
   _task.cancel();
 }
 
-auto Do_ip_space_define::map() -> Map* { return &_rtti->_cfg_store.rebind<CfgInfo>()[0]._map; }
+auto
+Do_ip_space_define::map() -> Map *
+{
+  return &_rtti->_cfg_store.rebind<CfgInfo>()[0]._map;
+}
 
-auto Do_ip_space_define::cfg_info(Config& cfg) -> CfgInfo * {
+auto
+Do_ip_space_define::cfg_info(Config &cfg) -> CfgInfo *
+{
   return cfg.drtv_info(KEY)->_cfg_store.rebind<CfgInfo>().data();
 }
 
-auto Do_ip_space_define::ctx_active_info(Context &ctx) -> CtxActiveInfo * {
+auto
+Do_ip_space_define::ctx_active_info(Context &ctx) -> CtxActiveInfo *
+{
   return ctx.storage_for(cfg_info(ctx.cfg())->_ctx_reserved_span).rebind<CtxActiveInfo>().data();
 }
 
-bool Do_ip_space_define::should_check() {
+bool
+Do_ip_space_define::should_check()
+{
   using Clock = std::chrono::system_clock;
-  bool zret = false;
+  bool zret   = false;
 
   if (_duration.count() > 0) {
-    Clock::duration last = _last_check; // required because CAS needs lvalue reference.
-    auto now = Clock::now();                   // Current time_point.
+    Clock::duration last = _last_check;  // required because CAS needs lvalue reference.
+    auto now             = Clock::now(); // Current time_point.
     if (Clock::time_point(last) + _duration <= now) {
       // it's been long enough, swap out our time for the last time. The winner of this swap
       // does the actual alert, leaving its current time as the last alert time.
@@ -388,21 +429,24 @@ bool Do_ip_space_define::should_check() {
   return zret;
 }
 
-Errata Do_ip_space_define::invoke(Context &ctx) {
+Errata
+Do_ip_space_define::invoke(Context &ctx)
+{
   // Start update checking.
   if (_duration.count()) {
-    _task = ts::PerformAsTaskEvery(Updater{ctx.acquire_cfg(), this}
-                                   , std::chrono::duration_cast<std::chrono::milliseconds>(_duration)
-    );
+    _task =
+      ts::PerformAsTaskEvery(Updater{ctx.acquire_cfg(), this}, std::chrono::duration_cast<std::chrono::milliseconds>(_duration));
   }
   return {};
 }
 
-auto Do_ip_space_define::parse_space(Config& cfg, TextView content) -> Rv<SpaceHandle> {
+auto
+Do_ip_space_define::parse_space(Config &cfg, TextView content) -> Rv<SpaceHandle>
+{
   TextView line;
   unsigned line_no = 0;
-  auto space = std::make_shared<SpaceInfo>();
-  while (! (line = content.take_prefix_at('\n')).empty()) {
+  auto space       = std::make_shared<SpaceInfo>();
+  while (!(line = content.take_prefix_at('\n')).empty()) {
     ++line_no;
     line.trim_if(&isspace);
     if (line.empty() || '#' == line.front()) {
@@ -419,49 +463,51 @@ auto Do_ip_space_define::parse_space(Config& cfg, TextView content) -> Rv<SpaceH
     // Iterate over the columns. If the input data runs out, then @a token becomes the empty
     // full, which the various cases deal with (in most an empty token isn't a problem).
     // This guarantees that every column in every row is initialized.
-    for (unsigned col_idx = 1 ; col_idx < _cols.size() ; ++col_idx ) {
-      Column& c = _cols[col_idx];
+    for (unsigned col_idx = 1; col_idx < _cols.size(); ++col_idx) {
+      Column &c = _cols[col_idx];
       MemSpan<void> data{row.data() + c._row_offset, c._row_size};
       token = line.take_prefix_at(',').ltrim_if(&isspace);
       switch (c._type) {
-        default: break; // Shouldn't ever happen.
-        case ColumnData::STRING:
-          data.rebind<TextView>()[0] = cfg.localize(token);
-          break;
-        case ColumnData::INTEGER: {
-          if (token) {
-            auto n = swoc::svtoi(token, &parsed);
-            if (parsed.size() == token.size()) {
-              data.rebind<feature_type_for<INTEGER>>()[0] = n;
-            }
+      default:
+        break; // Shouldn't ever happen.
+      case ColumnData::STRING:
+        data.rebind<TextView>()[0] = cfg.localize(token);
+        break;
+      case ColumnData::INTEGER: {
+        if (token) {
+          auto n = swoc::svtoi(token, &parsed);
+          if (parsed.size() == token.size()) {
+            data.rebind<feature_type_for<INTEGER>>()[0] = n;
+          }
+        } else {
+          data.rebind<feature_type_for<INTEGER>>()[0] = 0;
+        }
+      } break;
+      case ColumnData::ENUM:
+        if (auto idx = c._tags[token]; INVALID_TAG == idx) {
+          return Error(R"("{}" is not a valid tag for column {}{} at line {}.)", token, c._idx, bwf::Optional(R"( "{}")", c._name),
+                       line_no);
+        } else {
+          if (AUTO_TAG == idx) {
+            idx = c._tags.count();
+            c._tags.define(idx, token);
+          }
+          data.rebind<feature_type_for<INTEGER>>()[0] = idx;
+        }
+        break;
+      case ColumnData::FLAGS: {
+        TextView key;
+        BitSpan bits{data};
+        bits.reset(); // start with no bits set.
+        while (!(key = token.take_prefix_if([](char c) -> bool { return !('-' == c || '_' == c || isalnum(c)); })).empty()) {
+          if (auto idx = c._tags[key]; idx >= 0) {
+            bits[idx] = true;
           } else {
-            data.rebind<feature_type_for<INTEGER>>()[0] = 0;
+            return Error(R"("{}" is not a valid tag for column {}{} at line {}".)", key, c._idx, bwf::Optional(R"( "{}")", c._name),
+                         line_no);
           }
         }
-          break;
-        case ColumnData::ENUM:
-          if (auto idx = c._tags[token] ; INVALID_TAG == idx) {
-            return Error(R"("{}" is not a valid tag for column {}{} at line {}.)", token, c._idx, bwf::Optional(R"( "{}")", c._name), line_no);
-          } else {
-            if (AUTO_TAG == idx) {
-              idx = c._tags.count();
-              c._tags.define(idx, token);
-            }
-            data.rebind<feature_type_for<INTEGER>>()[0] = idx;
-          }
-          break;
-        case ColumnData::FLAGS: {
-          TextView key;
-          BitSpan bits { data };
-          bits.reset(); // start with no bits set.
-          while (! (key = token.take_prefix_if([](char c)->bool{return !('-' == c || '_' == c || isalnum(c));})).empty()) {
-            if (auto idx = c._tags[key] ; idx >= 0) {
-              bits[idx] = true;
-            } else {
-              return Error(R"("{}" is not a valid tag for column {}{} at line {}".)", key, c._idx, bwf::Optional(R"( "{}")", c._name), line_no);
-            }
-          }
-        }
+      }
       }
     }
     space->space.fill(range, row);
@@ -469,7 +515,9 @@ auto Do_ip_space_define::parse_space(Config& cfg, TextView content) -> Rv<SpaceH
   return space;
 }
 
-Errata Do_ip_space_define::define_column(Config & cfg, YAML::Node node) {
+Errata
+Do_ip_space_define::define_column(Config &cfg, YAML::Node node)
+{
   Column col;
   auto name_node = node[NAME_TAG];
   if (name_node) {
@@ -479,13 +527,14 @@ Errata Do_ip_space_define::define_column(Config & cfg, YAML::Node node) {
       return std::move(name_errata);
     }
     if (!name_expr.is_literal() || !name_expr.result_type().can_satisfy(STRING)) {
-      return Error("{} value at {} for {} define at {} must be a literal string.", NAME_TAG, name_node.Mark(), COLUMNS_TAG, node.Mark());
+      return Error("{} value at {} for {} define at {} must be a literal string.", NAME_TAG, name_node.Mark(), COLUMNS_TAG,
+                   node.Mark());
     }
     col._name = std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(name_expr._raw));
   }
 
   auto type_node = node[TYPE_TAG];
-  if (! type_node){
+  if (!type_node) {
     return Error("{} at {} must have a {} key.", COLUMNS_TAG, node.Mark(), TYPE_TAG);
   }
   auto &&[type_expr, type_errata]{cfg.parse_expr(type_node)};
@@ -494,10 +543,11 @@ Errata Do_ip_space_define::define_column(Config & cfg, YAML::Node node) {
     return std::move(type_errata);
   }
   if (!type_expr.is_literal() || !type_expr.result_type().can_satisfy(STRING)) {
-    return Error("{} value at {} for {} define at {} must be a literal string.", NAME_TAG, name_node.Mark(), COLUMNS_TAG, node.Mark());
+    return Error("{} value at {} for {} define at {} must be a literal string.", NAME_TAG, name_node.Mark(), COLUMNS_TAG,
+                 node.Mark());
   }
   auto text = std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(type_expr._raw));
-  col._type= Column::TypeNames[text];
+  col._type = Column::TypeNames[text];
   if (col._type == ColumnData::INVALID) {
     return Error(R"(Type "{}" at {] is not valid - must be one of {:s}.)", text, type_node.Mark(), Column::TypeNames);
   }
@@ -505,9 +555,10 @@ Errata Do_ip_space_define::define_column(Config & cfg, YAML::Node node) {
   // Need names if it's FLAGS. Names for ENUM are optional.
   if (ColumnData::ENUM == col._type || ColumnData::FLAGS == col._type) {
     auto tags_node = node[VALUES_TAG];
-    if (! tags_node){
+    if (!tags_node) {
       if (ColumnData::FLAGS == col._type) {
-        return Error("{} at {} must have a {} key because it is of type {}.", COLUMNS_TAG, node.Mark(), VALUES_TAG, Column::TypeNames[ColumnData::FLAGS]);
+        return Error("{} at {} must have a {} key because it is of type {}.", COLUMNS_TAG, node.Mark(), VALUES_TAG,
+                     Column::TypeNames[ColumnData::FLAGS]);
       }
       col._tags.set_default(AUTO_TAG);
     } else {
@@ -517,33 +568,41 @@ Errata Do_ip_space_define::define_column(Config & cfg, YAML::Node node) {
         tags_errata.info("While parsing {} key at {} in {} at {}.", VALUES_TAG, tags_node.Mark(), COLUMNS_TAG, node.Mark());
         return std::move(type_errata);
       }
-      if (! tags_expr.is_literal()) {
-        return Error("{} value at {} for {} define at {} must be a literal string or list of strings.", NAME_TAG, tags_node.Mark(), COLUMNS_TAG, node.Mark());
+      if (!tags_expr.is_literal()) {
+        return Error("{} value at {} for {} define at {} must be a literal string or list of strings.", NAME_TAG, tags_node.Mark(),
+                     COLUMNS_TAG, node.Mark());
       }
       col._tags.set_default(INVALID_TAG);
       Feature lit = std::get<Expr::LITERAL>(tags_expr._raw);
       if (ValueTypeOf(lit) == TUPLE) {
-        for ( auto f : std::get<IndexFor(TUPLE)>(lit)) {
+        for (auto f : std::get<IndexFor(TUPLE)>(lit)) {
           if (ValueTypeOf(f) != STRING) {
-            return Error("{} value at {} for {} define at {} must be a literal string or list of strings.", NAME_TAG, name_node.Mark(), COLUMNS_TAG, node.Mark());
+            return Error("{} value at {} for {} define at {} must be a literal string or list of strings.", NAME_TAG,
+                         name_node.Mark(), COLUMNS_TAG, node.Mark());
           }
           col._tags.define(col._tags.count(), std::get<IndexFor(STRING)>(f));
         }
-      } else if (ValueTypeOf(lit) == STRING ) {
+      } else if (ValueTypeOf(lit) == STRING) {
         col._tags.define(col._tags.count(), std::get<IndexFor(STRING)>(lit));
       } else {
-        return Error("{} value at {} for {} define at {} must be a literal string or list of strings.", NAME_TAG, name_node.Mark(), COLUMNS_TAG, node.Mark());
+        return Error("{} value at {} for {} define at {} must be a literal string or list of strings.", NAME_TAG, name_node.Mark(),
+                     COLUMNS_TAG, node.Mark());
       }
     }
   }
-  col._idx = _cols.size();
+  col._idx        = _cols.size();
   col._row_offset = _row_size;
   switch (col._type) {
-    default: break; // shouldn't happen.
-    case ColumnData::ENUM:
-    case ColumnData::FLAGS:
-    case ColumnData::INTEGER: col._row_size = sizeof(feature_type_for<INTEGER>); break;
-    case ColumnData::STRING: col._row_size = sizeof(TextView); break;
+  default:
+    break; // shouldn't happen.
+  case ColumnData::ENUM:
+  case ColumnData::FLAGS:
+  case ColumnData::INTEGER:
+    col._row_size = sizeof(feature_type_for<INTEGER>);
+    break;
+  case ColumnData::STRING:
+    col._row_size = sizeof(TextView);
+    break;
   }
   _row_size += col._row_size;
   _cols.emplace_back(std::move(col));
@@ -551,7 +610,10 @@ Errata Do_ip_space_define::define_column(Config & cfg, YAML::Node node) {
   return {};
 }
 
-Rv<Directive::Handle> Do_ip_space_define::load(Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_ip_space_define::load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &,
+                         swoc::TextView const &, YAML::Node key_value)
+{
   auto self = new self_type();
   Handle handle(self);
   self->_line_no = drtv_node.Mark().line;
@@ -560,19 +622,20 @@ Rv<Directive::Handle> Do_ip_space_define::load(Config& cfg, CfgStaticData const*
   if (!name_node) {
     return Error("{} directive at {} must have a {} key.", KEY, drtv_node.Mark(), NAME_TAG);
   }
-  auto &&[name_expr, name_errata] { cfg.parse_expr(name_node) };
-  if (! name_errata.is_ok()) {
+  auto &&[name_expr, name_errata]{cfg.parse_expr(name_node)};
+  if (!name_errata.is_ok()) {
     name_errata.info("While parsing {} directive at {}.", KEY, drtv_node.Mark());
     return std::move(name_errata);
   }
-  if (! name_expr.is_literal() || ! name_expr.result_type().can_satisfy(STRING)) {
-    return Error("{} value at {} for {} directive at {} must be a literal string.", NAME_TAG, name_node.Mark(), KEY, drtv_node.Mark());
+  if (!name_expr.is_literal() || !name_expr.result_type().can_satisfy(STRING)) {
+    return Error("{} value at {} for {} directive at {} must be a literal string.", NAME_TAG, name_node.Mark(), KEY,
+                 drtv_node.Mark());
   }
   drtv_node.remove(name_node);
   self->_name = cfg.localize(TextView{std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(name_expr._raw))});
 
   auto path_node = key_value[PATH_TAG];
-  if (! path_node) {
+  if (!path_node) {
     return Error("{} directive at {} must have a {} key.", KEY, drtv_node.Mark(), PATH_TAG);
   }
 
@@ -582,7 +645,8 @@ Rv<Directive::Handle> Do_ip_space_define::load(Config& cfg, CfgStaticData const*
     return std::move(path_errata);
   }
   if (!path_expr.is_literal()) {
-    return Error("{} value at {} for {} directive at {} must be a literal string.", PATH_TAG, path_node.Mark(), KEY, drtv_node.Mark());
+    return Error("{} value at {} for {} directive at {} must be a literal string.", PATH_TAG, path_node.Mark(), KEY,
+                 drtv_node.Mark());
   }
   drtv_node.remove(path_node);
   self->_path = std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(path_expr._raw));
@@ -591,17 +655,18 @@ Rv<Directive::Handle> Do_ip_space_define::load(Config& cfg, CfgStaticData const*
   auto dur_node = key_value[DURATION_TAG];
   if (dur_node) {
     auto &&[dur_expr, dur_errata] = cfg.parse_expr(dur_node);
-    if (! dur_errata.is_ok()) {
+    if (!dur_errata.is_ok()) {
       dur_errata.info("While parsing {} directive at {}.", KEY, drtv_node.Mark());
       return std::move(dur_errata);
     }
-    if (! dur_expr.is_literal()) {
-      return Error("{} value at {} for {} directive at {} must be a literal duration.", DURATION_TAG, dur_node.Mark(), KEY, drtv_node.Mark());
+    if (!dur_expr.is_literal()) {
+      return Error("{} value at {} for {} directive at {} must be a literal duration.", DURATION_TAG, dur_node.Mark(), KEY,
+                   drtv_node.Mark());
     }
-    auto && [ dur_value, dur_value_errata ] { std::get<Expr::LITERAL>(dur_expr._raw).as_duration()};
-    if (! dur_value_errata.is_ok()) {
-      return Error("{} value at {} for {} directive at {} is not a valid duration."
-                   , DURATION_TAG, dur_node.Mark(), KEY, drtv_node.Mark());
+    auto &&[dur_value, dur_value_errata]{std::get<Expr::LITERAL>(dur_expr._raw).as_duration()};
+    if (!dur_value_errata.is_ok()) {
+      return Error("{} value at {} for {} directive at {} is not a valid duration.", DURATION_TAG, dur_node.Mark(), KEY,
+                   drtv_node.Mark());
     }
     self->_duration = dur_value;
     drtv_node.remove(dur_node);
@@ -612,7 +677,7 @@ Rv<Directive::Handle> Do_ip_space_define::load(Config& cfg, CfgStaticData const*
   // indices match up.
   self->_cols.emplace_back(Column{});
   self->_cols[0]._name = "range";
-  self->_cols[0]._idx = 0;
+  self->_cols[0]._idx  = 0;
   self->_cols[0]._type = ColumnData::ADDRESS;
   self->_col_names.define(self->_cols[0]._idx, self->_cols[0]._name);
 
@@ -624,7 +689,7 @@ Rv<Directive::Handle> Do_ip_space_define::load(Config& cfg, CfgStaticData const*
         return errata;
       }
     } else if (cols_node.IsSequence()) {
-      for ( auto child : cols_node ) {
+      for (auto child : cols_node) {
         auto errata = self->define_column(cfg, child);
         if (!errata.is_ok()) {
           errata.info(R"(While parsing "{}" key at {}.)", COLUMNS_TAG, cols_node.Mark());
@@ -641,28 +706,30 @@ Rv<Directive::Handle> Do_ip_space_define::load(Config& cfg, CfgStaticData const*
   if (ec) {
     return Error("Unable to read input file {} for space {} - {}", self->_path, self->_name, ec);
   }
-  self->_last_modified = swoc::file::modify_time(swoc::file::status(self->_path, ec));
-  auto && [ space_info, space_errata ] = self->parse_space(cfg, content);
-  if (! space_errata.is_ok()) {
+  self->_last_modified              = swoc::file::modify_time(swoc::file::status(self->_path, ec));
+  auto &&[space_info, space_errata] = self->parse_space(cfg, content);
+  if (!space_errata.is_ok()) {
     space_errata.info(R"(While parsing IPSpace file "{}" in space "{}".)", self->_path, self->_name);
     return std::move(space_errata);
   }
   self->_space = space_info;
 
   // Put the directive in the map.
-  Map* map = &rtti->_cfg_store.rebind<CfgInfo>()[0]._map;
-  if (auto spot = map->find(self->_name) ; spot != map->end()) {
-    return Error(R"("{}" directive at {} has the same name "{}" as another instance at line {}.)"
-    , KEY, drtv_node.Mark(), self->_name, spot->second->_line_no);
+  Map *map = &rtti->_cfg_store.rebind<CfgInfo>()[0]._map;
+  if (auto spot = map->find(self->_name); spot != map->end()) {
+    return Error(R"("{}" directive at {} has the same name "{}" as another instance at line {}.)", KEY, drtv_node.Mark(),
+                 self->_name, spot->second->_line_no);
   }
   (*map)[self->_name] = self;
 
   return handle;
 }
 
-Errata Do_ip_space_define::cfg_init(Config &cfg, CfgStaticData const * rtti) {
+Errata
+Do_ip_space_define::cfg_init(Config &cfg, CfgStaticData const *rtti)
+{
   // Note - @a h gets a pointer to the Handle.
-  auto h = & rtti->_cfg_store.rebind<CfgInfo>()[0];
+  auto h = &rtti->_cfg_store.rebind<CfgInfo>()[0];
   new (h) CfgInfo();
   cfg.mark_for_cleanup(h); // takes a pointer to the object to clean up.
   // Scoped access to defined space in a @c Context.
@@ -672,13 +739,15 @@ Errata Do_ip_space_define::cfg_init(Config &cfg, CfgStaticData const * rtti) {
   return {};
 }
 
-void Do_ip_space_define::Updater::operator()() {
+void
+Do_ip_space_define::Updater::operator()()
+{
   auto cfg = _cfg.lock(); // Make sure the config is still around while work is done.
   if (!cfg) {
     return;
   }
 
-  if (! _block->should_check()) {
+  if (!_block->should_check()) {
     return; // not time yet.
   }
 
@@ -691,7 +760,7 @@ void Do_ip_space_define::Updater::operator()() {
     }
     std::string content = swoc::file::load(_block->_path, ec);
     if (!ec) { // swap in updated content.
-      auto && [ space, errata ] { _block->parse_space(*cfg, content) };
+      auto &&[space, errata]{_block->parse_space(*cfg, content)};
       if (errata.is_ok()) {
         std::unique_lock lock(_block->_space_mutex);
         _block->_space = space;
@@ -702,9 +771,12 @@ void Do_ip_space_define::Updater::operator()() {
   }
 }
 
-unsigned Do_ip_space_define::col_idx(TextView const& name) {
-  if (auto spot = std::find_if(_cols.begin(), _cols.end(), [&](
-        Do_ip_space_define::Column& c) { return 0 == strcasecmp(c._name, name); }); spot != _cols.end()) {
+unsigned
+Do_ip_space_define::col_idx(TextView const &name)
+{
+  if (auto spot =
+        std::find_if(_cols.begin(), _cols.end(), [&](Do_ip_space_define::Column &c) { return 0 == strcasecmp(c._name, name); });
+      spot != _cols.end()) {
     return spot - _cols.begin();
   }
   // Not found.
@@ -713,17 +785,18 @@ unsigned Do_ip_space_define::col_idx(TextView const& name) {
 /* ------------------------------------------------------------------------------------ */
 /// IPSpace modifier
 /// Convert an IP address feature in to an IPSpace row.
-class Mod_ip_space : public Modifier {
-  using self_type = Mod_ip_space; ///< Self reference type.
-  using super_type = Modifier; ///< Parent type.
+class Mod_ip_space : public Modifier
+{
+  using self_type  = Mod_ip_space; ///< Self reference type.
+  using super_type = Modifier;     ///< Parent type.
 
 public:
-  Mod_ip_space(Expr && expr, TextView const& view, Do_ip_space_define *drtv);
+  Mod_ip_space(Expr &&expr, TextView const &view, Do_ip_space_define *drtv);
 
-  inline static const std::string KEY { "ip-space" };
+  inline static const std::string KEY{"ip-space"};
 
   struct CfgActiveInfo {
-    Do_ip_space_define * _drtv = nullptr;
+    Do_ip_space_define *_drtv = nullptr;
   };
 
   /** Modify the feature.
@@ -732,17 +805,17 @@ public:
    * @param feature Feature to modify [in,out]
    * @return Errors, if any.
    */
-  Rv<Feature> operator()(Context& ctx, feature_type_for<IP_ADDR> feature) override;
+  Rv<Feature> operator()(Context &ctx, feature_type_for<IP_ADDR> feature) override;
 
   /** Check if @a ftype is a valid type to be modified.
    *
    * @param ex_type Type of feature to modify.
    * @return @c true if this modifier can modity that feature type, @c false if not.
    */
-  bool is_valid_for(ActiveType const& ex_type) const override;
+  bool is_valid_for(ActiveType const &ex_type) const override;
 
   /// Resulting type of feature after modifying.
-  ActiveType result_type(ActiveType const&) const override;
+  ActiveType result_type(ActiveType const &) const override;
 
   /** Create an instance from YAML config.
    *
@@ -754,28 +827,36 @@ public:
   static Rv<Handle> load(Config &cfg, YAML::Node node, TextView key, TextView arg, YAML::Node key_value);
 
 protected:
-  Expr _expr; ///< Value expression.
-  TextView _name; ///< Argument - IPSpace name.
-  Do_ip_space_define* _drtv = nullptr; ///< The IPSpace define for @a _name
+  Expr _expr;                          ///< Value expression.
+  TextView _name;                      ///< Argument - IPSpace name.
+  Do_ip_space_define *_drtv = nullptr; ///< The IPSpace define for @a _name
 };
 
-Mod_ip_space::Mod_ip_space(Expr && expr, TextView const& name, Do_ip_space_define *drtv)
-  : _expr(std::move(expr)), _name(name), _drtv(drtv) {}
+Mod_ip_space::Mod_ip_space(Expr &&expr, TextView const &name, Do_ip_space_define *drtv)
+  : _expr(std::move(expr)), _name(name), _drtv(drtv)
+{
+}
 
-bool Mod_ip_space::is_valid_for(ActiveType const& ex_type) const {
+bool
+Mod_ip_space::is_valid_for(ActiveType const &ex_type) const
+{
   return ex_type.can_satisfy(IP_ADDR);
 }
 
-ActiveType Mod_ip_space::result_type(const ActiveType &) const {
-  return { NIL, STRING, INTEGER, ActiveType::TupleOf(STRING) };
+ActiveType
+Mod_ip_space::result_type(const ActiveType &) const
+{
+  return {NIL, STRING, INTEGER, ActiveType::TupleOf(STRING)};
 }
 
-Rv<Modifier::Handle> Mod_ip_space::load(Config &cfg, YAML::Node node, TextView, TextView arg, YAML::Node key_value) {
-  auto * csi = Do_ip_space_define::cfg_info(cfg);
+Rv<Modifier::Handle>
+Mod_ip_space::load(Config &cfg, YAML::Node node, TextView, TextView arg, YAML::Node key_value)
+{
+  auto *csi = Do_ip_space_define::cfg_info(cfg);
   CfgActiveInfo info;
   // Unfortunately supporting remap requires dynamic access.
   if (csi) { // global, resolve to the specific ipspace directive.
-    auto& map = csi->_map;
+    auto &map = csi->_map;
     auto spot = map.find(arg);
     if (spot == map.end()) {
       return Error(R"("{}" at {} is not the name of a defined IP space.)", arg, node.Mark());
@@ -784,7 +865,7 @@ Rv<Modifier::Handle> Mod_ip_space::load(Config &cfg, YAML::Node node, TextView, 
   } // else leave @a _drtv null as a signal to find it dynamically.
 
   // Make info about active space available to expression parsing.
-  auto scope { cfg.active_value_let(KEY, &info) };
+  auto scope{cfg.active_value_let(KEY, &info)};
   auto &&[expr, errata]{cfg.parse_expr(key_value)};
 
   if (!errata.is_ok()) {
@@ -794,30 +875,32 @@ Rv<Modifier::Handle> Mod_ip_space::load(Config &cfg, YAML::Node node, TextView, 
   return Handle(new self_type{std::move(expr), arg, info._drtv});
 }
 
-Rv<Feature> Mod_ip_space::operator()(Context& ctx, feature_type_for<IP_ADDR> addr) {
+Rv<Feature>
+Mod_ip_space::operator()(Context &ctx, feature_type_for<IP_ADDR> addr)
+{
   // Set up local active state.
   CtxActiveInfo active;
   auto drtv = _drtv;
   if (drtv) {
     active._space = drtv->acquire_space();
   } else {
-    if (auto * csi = Do_ip_space_define::cfg_info(ctx.cfg()) ; nullptr != csi) {
-      auto& map = csi->_map;
-      if ( auto spot = map.find(_name) ;  spot != map.end()) {
-        drtv = spot->second;
+    if (auto *csi = Do_ip_space_define::cfg_info(ctx.cfg()); nullptr != csi) {
+      auto &map = csi->_map;
+      if (auto spot = map.find(_name); spot != map.end()) {
+        drtv          = spot->second;
         active._space = drtv->acquire_space();
       }
     }
   }
-  Feature value { FeatureView::Literal("") };
+  Feature value{FeatureView::Literal("")};
   if (active._space) {
     auto &&[range, payload] = *active._space->space.find(addr);
-    active._row = range.empty() ? nullptr : &payload;
-    active._addr = addr;
-    active._drtv = drtv;
+    active._row             = range.empty() ? nullptr : &payload;
+    active._addr            = addr;
+    active._drtv            = drtv;
 
     // Current active data.
-    auto& store = ctx.storage_for(_drtv->cfg_info(ctx.cfg())->_ctx_reserved_span).rebind<CtxActiveInfo>()[0];
+    auto &store = ctx.storage_for(_drtv->cfg_info(ctx.cfg())->_ctx_reserved_span).rebind<CtxActiveInfo>()[0];
     // Temporarily update it to local conditions.
     let scope(store, active);
     value = ctx.extract(_expr);
@@ -827,42 +910,45 @@ Rv<Feature> Mod_ip_space::operator()(Context& ctx, feature_type_for<IP_ADDR> add
 
 /* ------------------------------------------------------------------------------------ */
 /// IP Space extractor.
-class Ex_ip_col : public Extractor {
-  using self_type = Ex_ip_col; ///< Self reference type.
+class Ex_ip_col : public Extractor
+{
+  using self_type  = Ex_ip_col; ///< Self reference type.
   using super_type = Extractor; ///< Parent type.
 
 public:
   static constexpr TextView NAME{"ip-col"};
 
-  Rv<ActiveType> validate(Config& cfg, Spec& spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
-  Feature extract(Context& ctx, Spec const& spec) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
 
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 
 protected:
   static constexpr auto INVALID_IDX = Do_ip_space_define::INVALID_IDX;
   struct Info {
     unsigned _idx = INVALID_IDX; ///< Column index.
-    TextView _arg; ///< Argument name for use in remap / lazy lookup.
+    TextView _arg;               ///< Argument name for use in remap / lazy lookup.
   };
 };
 
-Rv<ActiveType> Ex_ip_col::validate(Config &cfg, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_ip_col::validate(Config &cfg, Spec &spec, const TextView &arg)
+{
   TextView parsed;
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument to specify the column.)", NAME);
   }
 
-  auto * mod_info = cfg.active_value<Mod_ip_space::CfgActiveInfo>(Mod_ip_space::KEY);
-  if (! mod_info) {
+  auto *mod_info = cfg.active_value<Mod_ip_space::CfgActiveInfo>(Mod_ip_space::KEY);
+  if (!mod_info) {
     return Error(R"("{}" extractor can only be used with an active IP Space from the {} modifier.)", NAME, Mod_ip_space::KEY);
   }
 
-  auto span = cfg.allocate_cfg_storage(sizeof(Info)).rebind<Info>();
+  auto span       = cfg.allocate_cfg_storage(sizeof(Info)).rebind<Info>();
   spec._data.span = span;
-  Info & info = span[0];
-  auto drtv = mod_info->_drtv;
+  Info &info      = span[0];
+  auto drtv       = mod_info->_drtv;
   // Always do the column conversion if it's an integer - that won't change at runtime.
   if (auto n = svtou(arg, &parsed); arg.size() == parsed.size()) {
     if (drtv && n >= drtv->_cols.size()) {
@@ -883,66 +969,82 @@ Rv<ActiveType> Ex_ip_col::validate(Config &cfg, Spec &spec, const TextView &arg)
 
   ActiveType result_type = NIL;
   switch (drtv->_cols[info._idx]._type) {
-    default: break; // shouldn't happen.
-    case ColumnData::ADDRESS: result_type = IP_ADDR;
-      break;
-    case ColumnData::STRING: result_type = STRING;
-      break;
-    case ColumnData::INTEGER: result_type = INTEGER;
-      break;
-    case ColumnData::ENUM: result_type = STRING;
-      break;
-    case ColumnData::FLAGS: result_type = TUPLE;
-      break;
+  default:
+    break; // shouldn't happen.
+  case ColumnData::ADDRESS:
+    result_type = IP_ADDR;
+    break;
+  case ColumnData::STRING:
+    result_type = STRING;
+    break;
+  case ColumnData::INTEGER:
+    result_type = INTEGER;
+    break;
+  case ColumnData::ENUM:
+    result_type = STRING;
+    break;
+  case ColumnData::FLAGS:
+    result_type = TUPLE;
+    break;
   }
   return result_type;
 }
 
-Feature Ex_ip_col::extract(Context &ctx, const Spec &spec) {
+Feature
+Ex_ip_col::extract(Context &ctx, const Spec &spec)
+{
   // Get all the pieces needed.
-  auto info = spec._data.span.rebind<Info>().data(); // Extractor local storage.
-  CtxActiveInfo * ctx_ai = Do_ip_space_define::ctx_active_info(ctx);
-  auto drtv = ctx_ai->_drtv; // Needed for column information.
-  auto idx = (info->_idx != INVALID_IDX ? info->_idx : drtv->col_idx(info->_arg));
+  auto info             = spec._data.span.rebind<Info>().data(); // Extractor local storage.
+  CtxActiveInfo *ctx_ai = Do_ip_space_define::ctx_active_info(ctx);
+  auto drtv             = ctx_ai->_drtv; // Needed for column information.
+  auto idx              = (info->_idx != INVALID_IDX ? info->_idx : drtv->col_idx(info->_arg));
   if (idx != INVALID_IDX) { // Column is valid.
-    auto& col = drtv->_cols[idx];
+    auto &col = drtv->_cols[idx];
     if (ctx_ai->_row) {
       auto data = col.data_in_row(ctx_ai->_row);
       switch (col._type) {
-        default: break; // Shouldn't happen.
-        case ColumnData::ADDRESS: return {ctx_ai->_addr };
-        case ColumnData::STRING:return FeatureView::Literal(data.rebind<TextView>()[0]);
-        case ColumnData::INTEGER:return {data.rebind<feature_type_for<INTEGER>>()[0]};
-        case ColumnData::ENUM:return FeatureView::Literal(col._tags[data.rebind<unsigned>()[0]]);
-        case ColumnData::FLAGS: {
-          auto bits = BitSpan(data);
-          auto n_bits = bits.count();
-          auto t = ctx.alloc_span<Feature>(n_bits);
-          for (unsigned k = 0, t_idx = 0; k < col._tags.count(); ++k) {
-            if (bits[k]) {
-              t[t_idx++] = FeatureView::Literal(col._tags[k]);
-            }
+      default:
+        break; // Shouldn't happen.
+      case ColumnData::ADDRESS:
+        return {ctx_ai->_addr};
+      case ColumnData::STRING:
+        return FeatureView::Literal(data.rebind<TextView>()[0]);
+      case ColumnData::INTEGER:
+        return {data.rebind<feature_type_for<INTEGER>>()[0]};
+      case ColumnData::ENUM:
+        return FeatureView::Literal(col._tags[data.rebind<unsigned>()[0]]);
+      case ColumnData::FLAGS: {
+        auto bits   = BitSpan(data);
+        auto n_bits = bits.count();
+        auto t      = ctx.alloc_span<Feature>(n_bits);
+        for (unsigned k = 0, t_idx = 0; k < col._tags.count(); ++k) {
+          if (bits[k]) {
+            t[t_idx++] = FeatureView::Literal(col._tags[k]);
           }
-          return {t};
         }
+        return {t};
+      }
       }
     }
   }
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_ip_col::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_ip_col::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
 /* ------------------------------------------------------------------------------------ */
 
-namespace {
+namespace
+{
 Ex_ip_col ex_ip_col;
-[[maybe_unused]] bool INITIALIZED = [] () -> bool {
+[[maybe_unused]] bool INITIALIZED = []() -> bool {
   Config::define<Do_ip_space_define>();
   Modifier::define(Mod_ip_space::KEY, Mod_ip_space::load);
   Extractor::define(ex_ip_col.NAME, &ex_ip_col);
   return true;
-} ();
+}();
 } // namespace

--- a/plugin/src/stats.cc
+++ b/plugin/src/stats.cc
@@ -319,13 +319,13 @@ Rv<ActiveType> Ex_stat::validate(Config &cfg, Spec &spec, const TextView &arg) {
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument to specify the statistic.)", NAME);
   }
-  spec._data = cfg.alloc_span<Stat>(1); // allocate and stash.
-  spec._data.rebind<Stat>()[0].assign(cfg, arg);
+  spec._data.span = cfg.alloc_span<Stat>(1); // allocate and stash.
+  spec._data.span.rebind<Stat>()[0].assign(cfg, arg);
   return { INTEGER };
 }
 
 Feature Ex_stat::extract(Context &, const Spec &spec) {
-  return spec._data.rebind<Stat>()[0].value();
+  return spec._data.span.rebind<Stat>()[0].value();
 }
 
 BufferWriter& Ex_stat::format(BufferWriter &w, Spec const &spec, Context &ctx) {

--- a/plugin/src/text_block.cc
+++ b/plugin/src/text_block.cc
@@ -301,12 +301,12 @@ Rv<ActiveType> Ex_text_block::validate(Config &cfg, Spec &spec, const TextView &
   }
   auto view = cfg.alloc_span<TextView>(1);
   view[0] = cfg.localize(TextView{arg});
-  spec._data = view.rebind<void>();
+  spec._data.span = view.rebind<void>();
   return { STRING };
 }
 
 Feature Ex_text_block::extract(Context &ctx, const Spec &spec) {
-  auto arg = spec._data.rebind<TextView>()[0];
+  auto arg = spec._data.span.rebind<TextView>()[0];
   if ( auto rtti = ctx.cfg().drtv_info(Do_text_block_define::KEY) ; nullptr != rtti ) {
     // If there's file content, get a shared pointer to it to preserve the full until
     // the end of the transaction.

--- a/plugin/src/text_block.cc
+++ b/plugin/src/text_block.cc
@@ -36,28 +36,30 @@ using Clock = std::chrono::system_clock;
 
 /* ------------------------------------------------------------------------------------ */
 /// Define a static text block.
-class Do_text_block_define : public Directive {
-  using self_type = Do_text_block_define; ///< Self reference type.
-  using super_type = Directive; ///< Parent type.
+class Do_text_block_define : public Directive
+{
+  using self_type  = Do_text_block_define; ///< Self reference type.
+  using super_type = Directive;            ///< Parent type.
 protected:
   struct CfgInfo;
+
 public:
   static inline const std::string KEY{"text-block-define"}; ///< Directive name.
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static const HookMask HOOKS;                              ///< Valid hooks for directive.
 
-  static constexpr Options OPTIONS { sizeof(CfgInfo*) };
+  static constexpr Options OPTIONS{sizeof(CfgInfo *)};
 
   /// Functor to do file content updating as needed.
   struct Updater {
-    std::weak_ptr<Config> _cfg; ///< Configuration.
-    Do_text_block_define * _block; ///< Text block holder.
+    std::weak_ptr<Config> _cfg;   ///< Configuration.
+    Do_text_block_define *_block; ///< Text block holder.
 
     void operator()(); ///< Do the update check.
   };
 
   ~Do_text_block_define() noexcept;
 
-  Errata invoke(Context & ctx) override; ///< Runtime activation.
+  Errata invoke(Context &ctx) override; ///< Runtime activation.
 
   /** Load from YAML node.
    *
@@ -69,8 +71,8 @@ public:
    * @param key_value Value for directive @a KEY
    * @return A directive, or errors on failure.
    */
-  static Rv<Handle> load( Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const& name
-                          , swoc::TextView const& arg, YAML::Node key_value);
+  static Rv<Handle> load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &name,
+                         swoc::TextView const &arg, YAML::Node key_value);
 
   /** Create config level shared data.
    *
@@ -78,10 +80,10 @@ public:
    * @param rtti Static configuration data
    * @return
    */
-  static Errata cfg_init(Config& cfg, CfgStaticData const* rtti);
+  static Errata cfg_init(Config &cfg, CfgStaticData const *rtti);
 
 protected:
-  using Map = std::unordered_map<TextView, self_type *, std::hash<std::string_view>>;
+  using Map       = std::unordered_map<TextView, self_type *, std::hash<std::string_view>>;
   using MapHandle = std::unique_ptr<Map>;
 
   /// Config level data for all text blocks.
@@ -89,19 +91,19 @@ protected:
     MapHandle _map; ///< Map of names to specific text block definitions.
   };
 
-  TextView _name; ///< Block name.
-  swoc::file::path _path; ///< Path to file (optional)
-  std::optional<TextView> _text; ///< Default literal text (optional)
-  feature_type_for<DURATION> _duration; ///< Time between update checks.
+  TextView _name;                                                             ///< Block name.
+  swoc::file::path _path;                                                     ///< Path to file (optional)
+  std::optional<TextView> _text;                                              ///< Default literal text (optional)
+  feature_type_for<DURATION> _duration;                                       ///< Time between update checks.
   std::atomic<Clock::duration> _last_check = Clock::now().time_since_epoch(); ///< Absolute time of the last alert.
-  Clock::time_point _last_modified; ///< Last modified time of the file.
-  std::shared_ptr<std::string> _content; ///< Content of the file.
-  int _line_no = 0; ///< For debugging name conflicts.
-  std::shared_mutex _content_mutex; ///< Lock for access @a content.
-  ts::TaskHandle _task; ///< Handle for periodic checking task.
+  Clock::time_point _last_modified;                                           ///< Last modified time of the file.
+  std::shared_ptr<std::string> _content;                                      ///< Content of the file.
+  int _line_no = 0;                                                           ///< For debugging name conflicts.
+  std::shared_mutex _content_mutex;                                           ///< Lock for access @a content.
+  ts::TaskHandle _task;                                                       ///< Handle for periodic checking task.
 
   FeatureGroup _fg;
-  using index_type = FeatureGroup::index_type;
+  using index_type                  = FeatureGroup::index_type;
   static auto constexpr INVALID_IDX = FeatureGroup::INVALID_IDX;
   index_type _notify_idx;
 
@@ -112,7 +114,7 @@ protected:
   static inline const std::string NOTIFY_TAG{"notify"};
 
   /// Map of names to text blocks.
-  static Map* map(Directive::CfgStaticData const * rtti);
+  static Map *map(Directive::CfgStaticData const *rtti);
 
   Do_text_block_define() = default;
 
@@ -122,79 +124,81 @@ protected:
 
 const HookMask Do_text_block_define::HOOKS{MaskFor(Hook::POST_LOAD)};
 
-Do_text_block_define::~Do_text_block_define() noexcept {
+Do_text_block_define::~Do_text_block_define() noexcept
+{
   _task.cancel();
 }
 
-auto Do_text_block_define::map(Directive::CfgStaticData const * rtti) -> Map* {
-  return rtti->_cfg_store.rebind<CfgInfo*>()[0]->_map.get();
+auto
+Do_text_block_define::map(Directive::CfgStaticData const *rtti) -> Map *
+{
+  return rtti->_cfg_store.rebind<CfgInfo *>()[0]->_map.get();
 }
 
-Errata Do_text_block_define::invoke(Context &ctx) {
+Errata
+Do_text_block_define::invoke(Context &ctx)
+{
   // Set up the update checking.
   if (_duration.count()) {
-    _task = ts::PerformAsTaskEvery(Updater{ctx.acquire_cfg(), this}
-                                   , std::chrono::duration_cast<std::chrono::milliseconds>(_duration)
-    );
+    _task =
+      ts::PerformAsTaskEvery(Updater{ctx.acquire_cfg(), this}, std::chrono::duration_cast<std::chrono::milliseconds>(_duration));
   }
   return {};
 }
 
-Rv<Directive::Handle> Do_text_block_define::load(Config& cfg, CfgStaticData const* rtti, YAML::Node drtv_node, swoc::TextView const&, swoc::TextView const&, YAML::Node key_value) {
+Rv<Directive::Handle>
+Do_text_block_define::load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &,
+                           swoc::TextView const &, YAML::Node key_value)
+{
   auto self = new self_type();
   Handle handle(self);
-  auto & fg = self->_fg;
+  auto &fg       = self->_fg;
   self->_line_no = drtv_node.Mark().line;
 
-  auto errata = self->_fg.load(cfg, key_value,
-                               {
-    { NAME_TAG, FeatureGroup::REQUIRED },
-    { PATH_TAG },
-    { TEXT_TAG },
-    { DURATION_TAG},
-    { NOTIFY_TAG }
-                               });
+  auto errata =
+    self->_fg.load(cfg, key_value, {{NAME_TAG, FeatureGroup::REQUIRED}, {PATH_TAG}, {TEXT_TAG}, {DURATION_TAG}, {NOTIFY_TAG}});
 
-  if (! errata.is_ok()) {
+  if (!errata.is_ok()) {
     errata.info(R"(While parsing value at {} in "{}" directive at {}.)", key_value.Mark(), KEY, drtv_node.Mark());
     return errata;
   }
   auto idx = fg.index_of(NAME_TAG);
 
   // Must have a NAME, and either TEXT or PATH. DURATION is optional, but must be a duration if present.
-  auto & name_expr { fg[idx]._expr };
-  if (! name_expr.is_literal() || ! name_expr.result_type().can_satisfy(STRING)) {
+  auto &name_expr{fg[idx]._expr};
+  if (!name_expr.is_literal() || !name_expr.result_type().can_satisfy(STRING)) {
     return Error("{} value for {} directive at {} must be a literal string.", NAME_TAG, KEY, drtv_node.Mark());
   }
   self->_name = std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(name_expr._raw));
 
-  if ( auto path_idx = fg.index_of(PATH_TAG) ; path_idx != INVALID_IDX) {
-    auto & path_expr = fg[path_idx]._expr;
-    if (! path_expr.is_literal() || ! path_expr.result_type().can_satisfy(STRING)) {
+  if (auto path_idx = fg.index_of(PATH_TAG); path_idx != INVALID_IDX) {
+    auto &path_expr = fg[path_idx]._expr;
+    if (!path_expr.is_literal() || !path_expr.result_type().can_satisfy(STRING)) {
       return Error("{} value for {} directive at {} must be a literal string.", PATH_TAG, KEY, drtv_node.Mark());
     }
-    self->_path = cfg.localize(ts::make_absolute(std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(path_expr._raw))).view().data(), Config::LOCAL_CSTR);
+    self->_path = cfg.localize(ts::make_absolute(std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(path_expr._raw))).view().data(),
+                               Config::LOCAL_CSTR);
   }
 
-  if ( auto text_idx = fg.index_of(TEXT_TAG) ; text_idx != INVALID_IDX) {
-    auto & text_expr = fg[text_idx]._expr;
-    if (! text_expr.is_literal() || ! text_expr.result_type().can_satisfy(STRING)) {
+  if (auto text_idx = fg.index_of(TEXT_TAG); text_idx != INVALID_IDX) {
+    auto &text_expr = fg[text_idx]._expr;
+    if (!text_expr.is_literal() || !text_expr.result_type().can_satisfy(STRING)) {
       return Error("{} value for {} directive at {} must be a literal string.", TEXT_TAG, KEY, drtv_node.Mark());
     }
     self->_text = std::get<IndexFor(STRING)>(std::get<Expr::LITERAL>(text_expr._raw));
   }
 
-  if (! self->_text.has_value() && self->_path.empty()) {
+  if (!self->_text.has_value() && self->_path.empty()) {
     return Error("{} directive at {} must have a {} or a {} key.", KEY, drtv_node.Mark(), PATH_TAG, TEXT_TAG);
   }
 
-  if (auto dur_idx = fg.index_of(DURATION_TAG) ; dur_idx != INVALID_IDX) {
-    auto & dur_expr = fg[dur_idx]._expr;
-    if (! dur_expr.is_literal()) {
+  if (auto dur_idx = fg.index_of(DURATION_TAG); dur_idx != INVALID_IDX) {
+    auto &dur_expr = fg[dur_idx]._expr;
+    if (!dur_expr.is_literal()) {
       return Error("{} value for {} directive at {} must be a literal duration.", DURATION_TAG, KEY, drtv_node.Mark());
     }
-    auto && [ dur_value, dur_value_errata ] { std::get<Expr::LITERAL>(dur_expr._raw).as_duration()};
-    if (! dur_value_errata.is_ok()) {
+    auto &&[dur_value, dur_value_errata]{std::get<Expr::LITERAL>(dur_expr._raw).as_duration()};
+    if (!dur_value_errata.is_ok()) {
       return Error("{} value for {} directive at {} is not a valid duration.", DURATION_TAG, KEY, drtv_node.Mark());
     }
     self->_duration = dur_value;
@@ -202,7 +206,7 @@ Rv<Directive::Handle> Do_text_block_define::load(Config& cfg, CfgStaticData cons
 
   self->_notify_idx = fg.index_of(NOTIFY_TAG);
 
-  if (! self->_path.empty()) {
+  if (!self->_path.empty()) {
     std::error_code ec;
     auto content = swoc::file::load(self->_path, ec);
     if (!ec) {
@@ -210,30 +214,32 @@ Rv<Directive::Handle> Do_text_block_define::load(Config& cfg, CfgStaticData cons
     } else if (self->_text.has_value()) {
       self->_content = nullptr;
     } else {
-      return Error(R"("{}" directive at {} - value "{}" for key "{}" is not readable [{}] and no alternate "{}" key was present.)"
-                   , KEY, drtv_node.Mark(), self->_path, PATH_TAG, ec, TEXT_TAG);
+      return Error(R"("{}" directive at {} - value "{}" for key "{}" is not readable [{}] and no alternate "{}" key was present.)",
+                   KEY, drtv_node.Mark(), self->_path, PATH_TAG, ec, TEXT_TAG);
     }
     self->_last_modified = swoc::file::modify_time(swoc::file::status(self->_path, ec));
   }
 
   // Put the directive in the map.
-  Map* map = self->map(rtti);
-  if (auto spot = map->find(self->_name) ; spot != map->end()) {
-    return Error(R"("{}" directive at {} has the same name "{}" as another instance at line {}.)"
-    , KEY, drtv_node.Mark(), self->_name, spot->second->_line_no);
+  Map *map = self->map(rtti);
+  if (auto spot = map->find(self->_name); spot != map->end()) {
+    return Error(R"("{}" directive at {} has the same name "{}" as another instance at line {}.)", KEY, drtv_node.Mark(),
+                 self->_name, spot->second->_line_no);
   }
   (*map)[self->_name] = self;
 
   return handle;
 }
 
-Errata Do_text_block_define::cfg_init(Config &cfg, CfgStaticData const* rtti) {
+Errata
+Do_text_block_define::cfg_init(Config &cfg, CfgStaticData const *rtti)
+{
   // Get space for instance.
   auto cfg_info = cfg.allocate_cfg_storage(sizeof(CfgInfo), 8).rebind<CfgInfo>().data();
   // Initialize it.
   new (cfg_info) CfgInfo;
   // Remember where it is.
-  rtti->_cfg_store.rebind<CfgInfo*>()[0] = cfg_info;
+  rtti->_cfg_store.rebind<CfgInfo *>()[0] = cfg_info;
   // Create the map.
   cfg_info->_map.reset(new Map);
   // Clean it up when the config is destroyed.
@@ -241,7 +247,9 @@ Errata Do_text_block_define::cfg_init(Config &cfg, CfgStaticData const* rtti) {
   return {};
 }
 
-void Do_text_block_define::Updater::operator()() {
+void
+Do_text_block_define::Updater::operator()()
+{
   auto cfg = _cfg.lock(); // Make sure the config is still around while work is done.
   if (!cfg) {
     return; // presume the config destruction is ongoing and will clean this up.
@@ -256,19 +264,17 @@ void Do_text_block_define::Updater::operator()() {
       return; // same as it ever was...
     }
     auto content = std::make_shared<std::string>();
-    *content = swoc::file::load(_block->_path, ec);
+    *content     = swoc::file::load(_block->_path, ec);
     if (!ec) { // swap in updated content.
       {
         std::unique_lock lock(_block->_content_mutex);
-        _block->_content = content;
+        _block->_content       = content;
         _block->_last_modified = mtime;
       }
-      if ( _block->_notify_idx != FeatureGroup::INVALID_IDX) {
+      if (_block->_notify_idx != FeatureGroup::INVALID_IDX) {
         Context ctx(cfg);
         auto text{_block->_fg.extract(ctx, _block->_notify_idx)};
-        auto msg = ctx.render_transient([&](BufferWriter& w){
-          w.print("[{}] {}", Config::PLUGIN_TAG, text);
-        });
+        auto msg = ctx.render_transient([&](BufferWriter &w) { w.print("[{}] {}", Config::PLUGIN_TAG, text); });
         ts::Log_Note(msg);
       }
       return;
@@ -283,40 +289,45 @@ void Do_text_block_define::Updater::operator()() {
 
 /* ------------------------------------------------------------------------------------ */
 /// Text block extractor.
-class Ex_text_block : public Extractor {
-  using self_type = Ex_text_block; ///< Self reference type.
-  using super_type = Extractor; ///< Parent type.
+class Ex_text_block : public Extractor
+{
+  using self_type  = Ex_text_block; ///< Self reference type.
+  using super_type = Extractor;     ///< Parent type.
 public:
   static constexpr TextView NAME{"text-block"};
 
-  Rv<ActiveType> validate(Config& cfg, Spec& spec, TextView const& arg) override;
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
 
-  Feature extract(Context & ctx, Spec const& spec) override;
-  BufferWriter& format(BufferWriter& w, Spec const& spec, Context& ctx) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+  BufferWriter &format(BufferWriter &w, Spec const &spec, Context &ctx) override;
 };
 
-Rv<ActiveType> Ex_text_block::validate(Config &cfg, Spec &spec, const TextView &arg) {
+Rv<ActiveType>
+Ex_text_block::validate(Config &cfg, Spec &spec, const TextView &arg)
+{
   if (arg.empty()) {
     return Error(R"("{}" extractor requires an argument to specify the defined text block.)", NAME);
   }
-  auto view = cfg.alloc_span<TextView>(1);
-  view[0] = cfg.localize(TextView{arg});
+  auto view       = cfg.alloc_span<TextView>(1);
+  view[0]         = cfg.localize(TextView{arg});
   spec._data.span = view.rebind<void>();
-  return { STRING };
+  return {STRING};
 }
 
-Feature Ex_text_block::extract(Context &ctx, const Spec &spec) {
+Feature
+Ex_text_block::extract(Context &ctx, const Spec &spec)
+{
   auto arg = spec._data.span.rebind<TextView>()[0];
-  if ( auto rtti = ctx.cfg().drtv_info(Do_text_block_define::KEY) ; nullptr != rtti ) {
+  if (auto rtti = ctx.cfg().drtv_info(Do_text_block_define::KEY); nullptr != rtti) {
     // If there's file content, get a shared pointer to it to preserve the full until
     // the end of the transaction.
     auto map = Do_text_block_define::map(rtti);
-    if (auto spot = map->find(arg) ; spot != map->end()) {
+    if (auto spot = map->find(arg); spot != map->end()) {
       auto block = spot->second;
       // This needs to persist until the end of the invoking directive. There's no direct
       // support for that so the best that can be done is to persist until the end of the
       // transaction by putting it in context storage.
-      std::shared_ptr<std::string>& content = *(ctx.make<std::shared_ptr<std::string>>());
+      std::shared_ptr<std::string> &content = *(ctx.make<std::shared_ptr<std::string>>());
 
       { // grab a copy of the shared pointer to file content.
         std::shared_lock lock(block->_content_mutex);
@@ -337,18 +348,21 @@ Feature Ex_text_block::extract(Context &ctx, const Spec &spec) {
   return NIL_FEATURE;
 }
 
-BufferWriter& Ex_text_block::format(BufferWriter &w, Spec const &spec, Context &ctx) {
+BufferWriter &
+Ex_text_block::format(BufferWriter &w, Spec const &spec, Context &ctx)
+{
   return bwformat(w, spec, this->extract(ctx, spec));
 }
 
 /* ------------------------------------------------------------------------------------ */
 
-namespace {
+namespace
+{
 Ex_text_block text_block;
 
-[[maybe_unused]] bool INITIALIZED = [] () -> bool {
+[[maybe_unused]] bool INITIALIZED = []() -> bool {
   Config::define<Do_text_block_define>();
   Extractor::define(Ex_text_block::NAME, &text_block);
   return true;
-} ();
+}();
 } // namespace

--- a/plugin/src/ts_util.cc
+++ b/plugin/src/ts_util.cc
@@ -31,20 +31,20 @@ namespace bwf = swoc::bwf;
 using namespace swoc::literals;
 
 /* ------------------------------------------------------------------------------------ */
-namespace ts {
+namespace ts
+{
 namespace swoc = ::swoc; // Import to avoid global naming weirdness.
 /* ------------------------------------------------------------------------------------ */
 
-const swoc::Lexicon<TSRecordDataType> TSRecordDataTypeNames{
-    {{TS_RECORDDATATYPE_NULL, "null"}
-        , {TS_RECORDDATATYPE_INT, "integer"}
-        , {TS_RECORDDATATYPE_FLOAT, "float"}
-        , {TS_RECORDDATATYPE_STRING, "string"}
-        , {TS_RECORDDATATYPE_COUNTER, "counter"}
-        , {TS_RECORDDATATYPE_STAT_CONST, "stat"}
-        , {TS_RECORDDATATYPE_STAT_FX, "stat function"}
-    }, TS_RECORDDATATYPE_NULL, "null"
-};
+const swoc::Lexicon<TSRecordDataType> TSRecordDataTypeNames{{{TS_RECORDDATATYPE_NULL, "null"},
+                                                             {TS_RECORDDATATYPE_INT, "integer"},
+                                                             {TS_RECORDDATATYPE_FLOAT, "float"},
+                                                             {TS_RECORDDATATYPE_STRING, "string"},
+                                                             {TS_RECORDDATATYPE_COUNTER, "counter"},
+                                                             {TS_RECORDDATATYPE_STAT_CONST, "stat"},
+                                                             {TS_RECORDDATATYPE_STAT_FX, "stat function"}},
+                                                            TS_RECORDDATATYPE_NULL,
+                                                            "null"};
 
 HttpTxn::TxnConfigVarTable ts::HttpTxn::_var_table;
 std::mutex HttpTxn::_var_table_lock;
@@ -52,148 +52,203 @@ int HttpTxn::_arg_idx = -1;
 
 /* ------------------------------------------------------------------------------------ */
 // API changes.
-namespace compat {
-
+namespace compat
+{
 // Sigh - apparently it's not possible even in C++17 to detect the absence of an enum type.
 // Therefore it must be declared when it's not around to make the rest of the compat logic work.
 #if TS_VERSION_MAJOR < 9
-enum TSUserArgType : uint8_t { TS_USER_ARGS_TXN };
+  enum TSUserArgType : uint8_t { TS_USER_ARGS_TXN };
 #endif
 
-template < typename T, typename U > constexpr auto eraser(U && u) -> U { return std::forward<U>(u); }
+  template <typename T, typename U>
+  constexpr auto
+  eraser(U &&u) -> U
+  {
+    return std::forward<U>(u);
+  }
 
-template<typename S = TSHttpStatus> auto
-status_set(ts::HttpTxn &txn, TSHttpStatus status, swoc::meta::CaseTag<0>) -> bool {
-  return txn.prsp_hdr().status_set(status);
-}
+  template <typename S = TSHttpStatus>
+  auto
+  status_set(ts::HttpTxn &txn, TSHttpStatus status, swoc::meta::CaseTag<0>) -> bool
+  {
+    return txn.prsp_hdr().status_set(status);
+  }
 
-// New for ATS 9, prefer this if available.
-template<typename S = void > auto status_set(ts::HttpTxn &txn, TSHttpStatus status, swoc::meta::CaseTag<1>
-                                                   ) -> decltype(TSHttpTxnStatusSet(txn, eraser<S>(status)), bool()) {
-  TSHttpTxnStatusSet(txn, eraser<S>(status)); // no error return, sigh.
-  return true;
-}
+  // New for ATS 9, prefer this if available.
+  template <typename S = void>
+  auto
+  status_set(ts::HttpTxn &txn, TSHttpStatus status, swoc::meta::CaseTag<1>)
+    -> decltype(TSHttpTxnStatusSet(txn, eraser<S>(status)), bool())
+  {
+    TSHttpTxnStatusSet(txn, eraser<S>(status)); // no error return, sigh.
+    return true;
+  }
 
-// ---
+  // ---
 
-// This API changed name in ATS 9.
-template<typename V = void> auto
-vconn_ssl_get(TSVConn vc, swoc::meta::CaseTag<0>) -> decltype(TSVConnSSLConnectionGet(eraser<V>(vc))) {
-  return TSVConnSSLConnectionGet(eraser<V>(vc));
-}
+  // This API changed name in ATS 9.
+  template <typename V = void>
+  auto
+  vconn_ssl_get(TSVConn vc, swoc::meta::CaseTag<0>) -> decltype(TSVConnSSLConnectionGet(eraser<V>(vc)))
+  {
+    return TSVConnSSLConnectionGet(eraser<V>(vc));
+  }
 
-template<typename V = void> auto
-vconn_ssl_get(TSVConn vc, swoc::meta::CaseTag<1>) -> decltype(TSVConnSslConnectionGet(eraser<V>(vc))) {
-  return TSVConnSslConnectionGet(eraser<V>(vc));
-}
+  template <typename V = void>
+  auto
+  vconn_ssl_get(TSVConn vc, swoc::meta::CaseTag<1>) -> decltype(TSVConnSslConnectionGet(eraser<V>(vc)))
+  {
+    return TSVConnSslConnectionGet(eraser<V>(vc));
+  }
 
-// ---
-// Txn / Ssn args were changed for ATS 10. Prefer the new API.
+  // ---
+  // Txn / Ssn args were changed for ATS 10. Prefer the new API.
 
-// First a meta-template to provide a compile time constant on whether TSUserArg are available.
-template < typename A, typename = void> struct has_TS_USER_ARGS : public std::false_type {};
-template < typename A > struct has_TS_USER_ARGS<A, std::void_t<decltype(TSUserArgGet(nullptr, eraser<A>(0)))>> : public std::true_type {};
+  // First a meta-template to provide a compile time constant on whether TSUserArg are available.
+  template <typename A, typename = void> struct has_TS_USER_ARGS : public std::false_type {
+  };
+  template <typename A>
+  struct has_TS_USER_ARGS<A, std::void_t<decltype(TSUserArgGet(nullptr, eraser<A>(0)))>> : public std::true_type {
+  };
 
-template < typename A = void >
-auto user_arg_get(TSHttpTxn txnp, int arg_idx) -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, void *> {
-  return TSHttpTxnArgGet(txnp, eraser<A>(arg_idx));
-}
+  template <typename A = void>
+  auto
+  user_arg_get(TSHttpTxn txnp, int arg_idx) -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, void *>
+  {
+    return TSHttpTxnArgGet(txnp, eraser<A>(arg_idx));
+  }
 
-template < typename A = void >
-auto user_arg_get(TSHttpTxn txnp, int arg_idx) -> std::enable_if_t<has_TS_USER_ARGS<A>::value, void *> {
-  return TSUserArgGet(txnp, eraser<A>(arg_idx));
-}
+  template <typename A = void>
+  auto
+  user_arg_get(TSHttpTxn txnp, int arg_idx) -> std::enable_if_t<has_TS_USER_ARGS<A>::value, void *>
+  {
+    return TSUserArgGet(txnp, eraser<A>(arg_idx));
+  }
 
-template < typename A = void >
-auto user_arg_set(TSHttpTxn txnp, int arg_idx, void *arg) -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, void> {
-  TSHttpTxnArgSet(txnp, arg_idx, eraser<A>(arg));
-}
+  template <typename A = void>
+  auto
+  user_arg_set(TSHttpTxn txnp, int arg_idx, void *arg) -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, void>
+  {
+    TSHttpTxnArgSet(txnp, arg_idx, eraser<A>(arg));
+  }
 
-template < typename A = void >
-auto user_arg_set(TSHttpTxn txnp, int arg_idx, void *arg) -> std::enable_if_t<has_TS_USER_ARGS<A>::value, void> {
-  TSUserArgSet(txnp, arg_idx, eraser<A>(arg));
-}
+  template <typename A = void>
+  auto
+  user_arg_set(TSHttpTxn txnp, int arg_idx, void *arg) -> std::enable_if_t<has_TS_USER_ARGS<A>::value, void>
+  {
+    TSUserArgSet(txnp, arg_idx, eraser<A>(arg));
+  }
 
-template < typename A = void >
-auto user_arg_index_reserve(const char *name, const char *description, int *arg_idx) -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, TSReturnCode> {
-  return TSHttpTxnArgIndexReserve(name, description, eraser<A>(arg_idx));
-}
+  template <typename A = void>
+  auto
+  user_arg_index_reserve(const char *name, const char *description, int *arg_idx)
+    -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, TSReturnCode>
+  {
+    return TSHttpTxnArgIndexReserve(name, description, eraser<A>(arg_idx));
+  }
 
-template < typename A = void>
-auto user_arg_index_reserve(const char *name, const char *description, int *arg_idx) -> std::enable_if_t<has_TS_USER_ARGS<A>::value, TSReturnCode> {
-  return TSUserArgIndexReserve(TS_USER_ARGS_TXN, name, description, eraser<A>(arg_idx));
-}
+  template <typename A = void>
+  auto
+  user_arg_index_reserve(const char *name, const char *description, int *arg_idx)
+    -> std::enable_if_t<has_TS_USER_ARGS<A>::value, TSReturnCode>
+  {
+    return TSUserArgIndexReserve(TS_USER_ARGS_TXN, name, description, eraser<A>(arg_idx));
+  }
 
-template < typename A >
-auto user_arg_index_name_lookup(char const *name, A *arg_idx, char const **description) -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, TSReturnCode> {
-  return TSHttpTxnArgIndexNameLookup(name, arg_idx, description);
-}
+  template <typename A>
+  auto
+  user_arg_index_name_lookup(char const *name, A *arg_idx, char const **description)
+    -> std::enable_if_t<!has_TS_USER_ARGS<A>::value, TSReturnCode>
+  {
+    return TSHttpTxnArgIndexNameLookup(name, arg_idx, description);
+  }
 
-template < typename A >
-auto user_arg_index_name_lookup(char const *name, A *arg_idx, char const **description) -> std::enable_if_t<has_TS_USER_ARGS<A>::value, TSReturnCode> {
-  return TSUserArgIndexNameLookup(TS_USER_ARGS_TXN, name, arg_idx, description);
-}
+  template <typename A>
+  auto
+  user_arg_index_name_lookup(char const *name, A *arg_idx, char const **description)
+    -> std::enable_if_t<has_TS_USER_ARGS<A>::value, TSReturnCode>
+  {
+    return TSUserArgIndexNameLookup(TS_USER_ARGS_TXN, name, arg_idx, description);
+  }
 
-// TSHttpTxnServerSsnTransactionCount API only available in ATS 10.
-template <typename T>
-auto
-get_outbound_txn_count([[maybe_unused]] T const &txn, swoc::meta::CaseTag<0>) -> int
-{
-  // if not ATS 10, then this should not be taken into consideration for connection reuse.
-  return 0;
-}
+  // TSHttpTxnServerSsnTransactionCount API only available in ATS 10.
+  template <typename T>
+  auto
+  get_outbound_txn_count([[maybe_unused]] T const &txn, swoc::meta::CaseTag<0>) -> int
+  {
+    // if not ATS 10, then this should not be taken into consideration for connection reuse.
+    return 0;
+  }
 
-template <typename T>
-auto
-get_outbound_txn_count(T const &txn, swoc::meta::CaseTag<1>) -> decltype(TSHttpTxnServerSsnTransactionCount(txn), int())
-{
-  return TSHttpTxnServerSsnTransactionCount(txn);
-}
+  template <typename T>
+  auto
+  get_outbound_txn_count(T const &txn, swoc::meta::CaseTag<1>) -> decltype(TSHttpTxnServerSsnTransactionCount(txn), int())
+  {
+    return TSHttpTxnServerSsnTransactionCount(txn);
+  }
 
-// ---
+  // ---
 
-// g++ 8 compatibility - it thinks a literal string is part of the template signature for no apparent reason.
-// But declaring this and using the variable fixes it.
-constexpr char const * diag_fmt = "%.*s";
+  // g++ 8 compatibility - it thinks a literal string is part of the template signature for no apparent reason.
+  // But declaring this and using the variable fixes it.
+  constexpr char const *diag_fmt = "%.*s";
 
-template < typename T > auto diag_note(T const& text, swoc::meta::CaseTag<0>) -> decltype(text.size(), text.data(), std::declval<void>()){
-  TSError(diag_fmt, int(text.size()), text.data());
-}
+  template <typename T>
+  auto
+  diag_note(T const &text, swoc::meta::CaseTag<0>) -> decltype(text.size(), text.data(), std::declval<void>())
+  {
+    TSError(diag_fmt, int(text.size()), text.data());
+  }
 
-template < typename T > auto diag_note(T const& text, swoc::meta::CaseTag<1>) -> decltype(TSNote(diag_fmt, int(text.size()), text.data()), std::declval<void>()) {
-  TSNote(diag_fmt, int(text.size()), text.data());
-}
+  template <typename T>
+  auto
+  diag_note(T const &text, swoc::meta::CaseTag<1>)
+    -> decltype(TSNote(diag_fmt, int(text.size()), text.data()), std::declval<void>())
+  {
+    TSNote(diag_fmt, int(text.size()), text.data());
+  }
 
-template < typename T > auto diag_warning(T const& text, swoc::meta::CaseTag<0>) -> decltype(text.size(), text.data(), std::declval<void>()){
-  TSError(diag_fmt, int(text.size()), text.data());
-}
+  template <typename T>
+  auto
+  diag_warning(T const &text, swoc::meta::CaseTag<0>) -> decltype(text.size(), text.data(), std::declval<void>())
+  {
+    TSError(diag_fmt, int(text.size()), text.data());
+  }
 
-template < typename T > auto diag_warning(T const& text, swoc::meta::CaseTag<1>) -> decltype(TSWarning(diag_fmt, int(text.size()), text.data()), std::declval<void>()) {
-  TSWarning(diag_fmt, int(text.size()), text.data());
-}
+  template <typename T>
+  auto
+  diag_warning(T const &text, swoc::meta::CaseTag<1>)
+    -> decltype(TSWarning(diag_fmt, int(text.size()), text.data()), std::declval<void>())
+  {
+    TSWarning(diag_fmt, int(text.size()), text.data());
+  }
 
 } // namespace compat
 
 /* ------------------------------------------------------------------------------------ */
 
-BufferWriter& ts::URL::write_full(BufferWriter& w) const {
+BufferWriter &
+ts::URL::write_full(BufferWriter &w) const
+{
   // Gonna live dangerously - since a reader is only allocated when a new IOBuffer is created
   // it doesn't need to be tracked - it will get cleaned up when the IOBuffer is destroyed.
   // 32K should be large enough to hold the longest valid URL for ATS.
   IOBuffer iob{TSIOBufferSizedCreate(TS_IOBUFFER_SIZE_INDEX_32K)};
-  auto reader = TSIOBufferReaderAlloc(iob.get());
+  auto reader   = TSIOBufferReaderAlloc(iob.get());
   int64_t avail = 0;
 
   TSUrlPrint(_buff, _loc, iob.get());
   auto block = TSIOBufferReaderStart(reader);
-  auto ptr = TSIOBufferBlockReadStart(block, reader, &avail);
+  auto ptr   = TSIOBufferBlockReadStart(block, reader, &avail);
   w.write(ptr, avail);
   return w;
 }
 
-TextView ts::URL::scheme() const {
+TextView
+ts::URL::scheme() const
+{
   if (this->is_valid()) {
-    char const* text;
+    char const *text;
     int size;
     if (nullptr != (text = TSUrlSchemeGet(_buff, _loc, &size))) {
       return {text, static_cast<size_t>(size)};
@@ -202,7 +257,9 @@ TextView ts::URL::scheme() const {
   return ""_tv;
 }
 
-TextView ts::URL::host() const {
+TextView
+ts::URL::host() const
+{
   char const *text;
   int size;
   if (this->is_valid() && nullptr != (text = TSUrlHostGet(_buff, _loc, &size))) {
@@ -211,27 +268,33 @@ TextView ts::URL::host() const {
   return ""_tv;
 }
 
-in_port_t  ts::URL::port() const {
+in_port_t
+ts::URL::port() const
+{
   return this->is_valid() ? TSUrlPortGet(_buff, _loc) : 0;
 }
 
-bool ts::URL::is_port_canonical(TextView const& scheme, in_port_t port) {
+bool
+ts::URL::is_port_canonical(TextView const &scheme, in_port_t port)
+{
   return scheme.starts_with_nocase("http"_tv) &&
-      ((80 == port  && scheme.size() == 4) ||
-       (443 == port && scheme.size() == 5 && 's' == tolower(scheme[4]))
-      );
+         ((80 == port && scheme.size() == 4) || (443 == port && scheme.size() == 5 && 's' == tolower(scheme[4])));
 }
 
-std::tuple<TextView, in_port_t> ts::URL::loc() const {
-  return { this->host(), this->port() };
+std::tuple<TextView, in_port_t>
+ts::URL::loc() const
+{
+  return {this->host(), this->port()};
 }
 
-bool ts::HttpRequest::url_set(TextView text) {
+bool
+ts::HttpRequest::url_set(TextView text)
+{
   TSMLoc url_loc;
   if (TS_SUCCESS != TSUrlCreate(_buff, &url_loc)) {
     return false;
   }
-  auto src = text.data();
+  auto src   = text.data();
   auto limit = text.data_end();
   if (TS_PARSE_DONE != TSUrlParse(_buff, url_loc, &src, limit)) {
     TSHandleMLocRelease(_buff, TS_NULL_MLOC, url_loc);
@@ -245,52 +308,61 @@ bool ts::HttpRequest::url_set(TextView text) {
 }
 
 /* ------------------------------------------------------------------------------------ */
-ts::HttpField::~HttpField() {
+ts::HttpField::~HttpField()
+{
   TSHandleMLocRelease(_buff, _hdr, _loc);
 }
 
-TextView ts::HttpField::name() const {
+TextView
+ts::HttpField::name() const
+{
   int size;
   char const *text;
-  if (this->is_valid() &&
-      nullptr != (text = TSMimeHdrFieldNameGet(_buff, _hdr, _loc, &size))) {
+  if (this->is_valid() && nullptr != (text = TSMimeHdrFieldNameGet(_buff, _hdr, _loc, &size))) {
     return {text, static_cast<size_t>(size)};
   }
   return {};
 }
 
-TextView ts::HttpField::value() const {
+TextView
+ts::HttpField::value() const
+{
   int size;
   char const *text;
-  if (this->is_valid() &&
-      nullptr != (text = TSMimeHdrFieldValueStringGet(_buff, _hdr, _loc, -1, &size))) {
+  if (this->is_valid() && nullptr != (text = TSMimeHdrFieldValueStringGet(_buff, _hdr, _loc, -1, &size))) {
     return {text, static_cast<size_t>(size)};
   }
   return {};
 }
 
-bool ts::HttpField::assign(swoc::TextView value) {
+bool
+ts::HttpField::assign(swoc::TextView value)
+{
   value.rtrim_if(&isspace);
-  return this->is_valid() &&
-       TS_SUCCESS == TSMimeHdrFieldValueStringSet(_buff, _hdr, _loc, -1, value.data(), value.size())
-       ;
+  return this->is_valid() && TS_SUCCESS == TSMimeHdrFieldValueStringSet(_buff, _hdr, _loc, -1, value.data(), value.size());
 }
 
-bool ts::HttpField::destroy() {
+bool
+ts::HttpField::destroy()
+{
   return TS_SUCCESS == TSMimeHdrFieldDestroy(_buff, _hdr, _loc);
 }
 
-unsigned ts::HttpField::dup_count() const {
+unsigned
+ts::HttpField::dup_count() const
+{
   unsigned zret = 0;
   if (this->is_valid()) {
-    for ( auto f = ts::HttpHeader{_buff, _hdr }.field(this->name()) ; f.is_valid() ; f = f.next_dup() ) {
+    for (auto f = ts::HttpHeader{_buff, _hdr}.field(this->name()); f.is_valid(); f = f.next_dup()) {
       ++zret;
     }
   }
   return zret;
 }
 
-ts::URL ts::HttpRequest::url() const {
+ts::URL
+ts::HttpRequest::url() const
+{
   TSMLoc url_loc;
   if (this->is_valid() && TS_SUCCESS == TSHttpHdrUrlGet(_buff, _loc, &url_loc)) {
     return {_buff, url_loc};
@@ -298,34 +370,33 @@ ts::URL ts::HttpRequest::url() const {
   return {};
 }
 
-BufferWriter& ts::HttpRequest::effective_url(BufferWriter& w) {
+BufferWriter &
+ts::HttpRequest::effective_url(BufferWriter &w)
+{
   if (this->is_valid()) {
-    auto url { this->url() };
-    auto scheme { url.scheme() };
-    auto path { url.path() };
-    auto query { url.query() };
-    auto [ host, port ] { this->loc() };
+    auto url{this->url()};
+    auto scheme{url.scheme()};
+    auto path{url.path()};
+    auto query{url.query()};
+    auto [host, port]{this->loc()};
     if (url.is_port_canonical(scheme, port)) {
       port = 0;
     }
 
-    w.print("{}{}{}{}{}"
-            , bwf::Optional("{}:", scheme)
-            , bwf::Optional("//{}", host)
-            , bwf::Optional(":{}", port)
-            , bwf::Optional("/{}", path)
-            , bwf::Optional("?{}", query)
-            );
+    w.print("{}{}{}{}{}", bwf::Optional("{}:", scheme), bwf::Optional("//{}", host), bwf::Optional(":{}", port),
+            bwf::Optional("/{}", path), bwf::Optional("?{}", query));
   }
   return w;
 }
 
-TextView ts::HttpRequest::host() const {
-  auto url { this->url() };
-  if (auto host = url.host() ; ! host.empty()) {
+TextView
+ts::HttpRequest::host() const
+{
+  auto url{this->url()};
+  if (auto host = url.host(); !host.empty()) {
     return host;
   }
-  if (auto field = this->field(HTTP_FIELD_HOST) ; field.is_valid()) {
+  if (auto field = this->field(HTTP_FIELD_HOST); field.is_valid()) {
     auto value = field.value();
     TextView host_token, port_token, rest_token;
     if (swoc::IPEndpoint::tokenize(value, &host_token, &port_token)) {
@@ -335,12 +406,14 @@ TextView ts::HttpRequest::host() const {
   return {};
 }
 
-in_port_t ts::HttpRequest::port() const {
-  auto url { const_cast<self_type*>(this)->url() };
-  if (auto port = url.port() ; port != 0) {
+in_port_t
+ts::HttpRequest::port() const
+{
+  auto url{const_cast<self_type *>(this)->url()};
+  if (auto port = url.port(); port != 0) {
     return port;
   }
-  if (auto field = this->field(HTTP_FIELD_HOST) ; field.is_valid()) {
+  if (auto field = this->field(HTTP_FIELD_HOST); field.is_valid()) {
     auto value = field.value();
     TextView host_token, port_token;
     if (swoc::IPEndpoint::tokenize(value, &host_token, &port_token)) {
@@ -350,22 +423,25 @@ in_port_t ts::HttpRequest::port() const {
   return 0;
 }
 
-std::tuple<TextView, in_port_t> ts::HttpRequest::loc() const {
-  auto loc { url().loc() };
+std::tuple<TextView, in_port_t>
+ts::HttpRequest::loc() const
+{
+  auto loc{url().loc()};
   if (std::get<0>(loc).empty()) {
-    if (auto field = this->field(HTTP_FIELD_HOST) ; field.is_valid()) {
+    if (auto field = this->field(HTTP_FIELD_HOST); field.is_valid()) {
       auto value = field.value();
       TextView host_token, port_token;
       if (swoc::IPEndpoint::tokenize(value, &host_token, &port_token)) {
-        return { host_token, swoc::svtoi(port_token) };
+        return {host_token, swoc::svtoi(port_token)};
       }
     }
   }
-  return { TextView{}, 0 };
+  return {TextView{}, 0};
 }
 
-
-bool ts::HttpRequest::host_set(swoc::TextView const &host) {
+bool
+ts::HttpRequest::host_set(swoc::TextView const &host)
+{
   auto url{this->url()};
   bool force_host_p = true;
   if (!url.host().empty()) {
@@ -378,7 +454,7 @@ bool ts::HttpRequest::host_set(swoc::TextView const &host) {
     TextView host_token, port_token, rest_token;
     if (swoc::IPEndpoint::tokenize(text, &host_token, &port_token)) {
       size_t n = host.size() + 1 + port_token.size();
-      swoc::FixedBufferWriter w{static_cast<char*>(alloca(n)), n};
+      swoc::FixedBufferWriter w{static_cast<char *>(alloca(n)), n};
       if (port_token.size()) {
         w.print("{}:{}", host, port_token);
       } else {
@@ -394,7 +470,9 @@ bool ts::HttpRequest::host_set(swoc::TextView const &host) {
   return true;
 }
 
-bool ts::HttpRequest::port_set(in_port_t port) {
+bool
+ts::HttpRequest::port_set(in_port_t port)
+{
   auto url{this->url()};
   if (!url.host().empty()) {
     url.port_set(port);
@@ -405,7 +483,7 @@ bool ts::HttpRequest::port_set(in_port_t port) {
     TextView host_token, port_token, rest_token;
     if (swoc::IPEndpoint::tokenize(text, &host_token, &port_token)) {
       size_t n = host_token.size() + 1 + std::numeric_limits<in_port_t>::max_digits10;
-      swoc::FixedBufferWriter w{static_cast<char*>(alloca(n)), n};
+      swoc::FixedBufferWriter w{static_cast<char *>(alloca(n)), n};
       w.write(host_token);
       if (port > 0) {
         w.write(':');
@@ -417,23 +495,29 @@ bool ts::HttpRequest::port_set(in_port_t port) {
   return true;
 }
 
-swoc::TextView HttpRequest::method() const {
+swoc::TextView
+HttpRequest::method() const
+{
   int length;
   char const *text;
   text = TSHttpHdrMethodGet(_buff, _loc, &length);
-  return {text, static_cast<size_t>(length) };
+  return {text, static_cast<size_t>(length)};
 }
 
-ts::URL ts::HttpTxn::pristine_url_get() const {
+ts::URL
+ts::HttpTxn::pristine_url_get() const
+{
   TSMBuffer buff;
   TSMLoc loc;
   if (_txn != nullptr && TS_SUCCESS == TSHttpTxnPristineUrlGet(_txn, &buff, &loc)) {
-    return { buff, loc };
+    return {buff, loc};
   }
   return {};
 }
 
-ts::HttpRequest ts::HttpTxn::ua_req_hdr() {
+ts::HttpRequest
+ts::HttpTxn::ua_req_hdr()
+{
   TSMBuffer buff;
   TSMLoc loc;
   if (_txn != nullptr && TS_SUCCESS == TSHttpTxnClientReqGet(_txn, &buff, &loc)) {
@@ -442,7 +526,9 @@ ts::HttpRequest ts::HttpTxn::ua_req_hdr() {
   return {};
 }
 
-ts::HttpRequest ts::HttpTxn::preq_hdr() {
+ts::HttpRequest
+ts::HttpTxn::preq_hdr()
+{
   TSMBuffer buff;
   TSMLoc loc;
   if (_txn != nullptr && TS_SUCCESS == TSHttpTxnServerReqGet(_txn, &buff, &loc)) {
@@ -451,7 +537,9 @@ ts::HttpRequest ts::HttpTxn::preq_hdr() {
   return {};
 }
 
-ts::HttpResponse ts::HttpTxn::ursp_hdr() {
+ts::HttpResponse
+ts::HttpTxn::ursp_hdr()
+{
   TSMBuffer buff;
   TSMLoc loc;
   if (_txn != nullptr && TS_SUCCESS == TSHttpTxnServerRespGet(_txn, &buff, &loc)) {
@@ -460,7 +548,9 @@ ts::HttpResponse ts::HttpTxn::ursp_hdr() {
   return {};
 }
 
-ts::HttpResponse ts::HttpTxn::prsp_hdr() {
+ts::HttpResponse
+ts::HttpTxn::prsp_hdr()
+{
   TSMBuffer buff;
   TSMLoc loc;
   if (_txn != nullptr && TS_SUCCESS == TSHttpTxnClientRespGet(_txn, &buff, &loc)) {
@@ -469,20 +559,22 @@ ts::HttpResponse ts::HttpTxn::prsp_hdr() {
   return {};
 }
 
-ts::HttpField ts::HttpHeader::field(TextView name) const {
+ts::HttpField
+ts::HttpHeader::field(TextView name) const
+{
   TSMLoc field_loc;
-  if (this->is_valid() &&
-      nullptr != (field_loc = TSMimeHdrFieldFind(_buff, _loc, name.data(), name.size()))) {
+  if (this->is_valid() && nullptr != (field_loc = TSMimeHdrFieldFind(_buff, _loc, name.data(), name.size()))) {
     return {_buff, _loc, field_loc};
   }
   return {};
 }
 
-ts::HttpField ts::HttpHeader::field_create(TextView name) {
+ts::HttpField
+ts::HttpHeader::field_create(TextView name)
+{
   if (this->is_valid()) {
     TSMLoc field_loc;
-    if (TS_SUCCESS ==
-        TSMimeHdrFieldCreateNamed(_buff, _loc, name.data(), name.size(), &field_loc)) {
+    if (TS_SUCCESS == TSMimeHdrFieldCreateNamed(_buff, _loc, name.data(), name.size(), &field_loc)) {
       if (TS_SUCCESS == TSMimeHdrFieldAppend(_buff, _loc, field_loc)) {
         return HttpField{_buff, _loc, field_loc};
       }
@@ -492,7 +584,9 @@ ts::HttpField ts::HttpHeader::field_create(TextView name) {
   return {};
 }
 
-ts::HttpField ts::HttpHeader::field_obtain(TextView name) {
+ts::HttpField
+ts::HttpHeader::field_obtain(TextView name)
+{
   if (this->is_valid()) {
     if (HttpField field{this->field(name)}; field.is_valid()) {
       return field;
@@ -502,7 +596,9 @@ ts::HttpField ts::HttpHeader::field_obtain(TextView name) {
   return {};
 }
 
-ts::HttpHeader &ts::HttpHeader::field_remove(swoc::TextView name) {
+ts::HttpHeader &
+ts::HttpHeader::field_remove(swoc::TextView name)
+{
   if (this->is_valid()) {
     if (HttpField field{this->field(name)}; field.is_valid()) {
       field.destroy();
@@ -511,65 +607,86 @@ ts::HttpHeader &ts::HttpHeader::field_remove(swoc::TextView name) {
   return *this;
 }
 
-bool ts::HttpResponse::status_set(TSHttpStatus status) const {
+bool
+ts::HttpResponse::status_set(TSHttpStatus status) const
+{
   return TS_SUCCESS == TSHttpHdrStatusSet(_buff, _loc, status);
 }
 
-TextView ts::HttpResponse::reason() const {
-  int length = 0;
-  char const * text = TSHttpHdrReasonGet(_buff, _loc, &length);
-  return length > 0 ? TextView{text, size_t(length) } : TextView{};
+TextView
+ts::HttpResponse::reason() const
+{
+  int length       = 0;
+  char const *text = TSHttpHdrReasonGet(_buff, _loc, &length);
+  return length > 0 ? TextView{text, size_t(length)} : TextView{};
 }
 
-bool ts::HttpResponse::reason_set(swoc::TextView reason) {
-  return this->is_valid() &&
-         TS_SUCCESS == TSHttpHdrReasonSet(_buff, _loc, reason.data(), reason.size());
+bool
+ts::HttpResponse::reason_set(swoc::TextView reason)
+{
+  return this->is_valid() && TS_SUCCESS == TSHttpHdrReasonSet(_buff, _loc, reason.data(), reason.size());
 }
 
-bool ts::HttpTxn::is_internal() const {
+bool
+ts::HttpTxn::is_internal() const
+{
   return static_cast<bool>(TSHttpTxnIsInternal(_txn));
 }
 
-void ts::HttpTxn::error_body_set(swoc::TextView body, swoc::TextView content_type) {
+void
+ts::HttpTxn::error_body_set(swoc::TextView body, swoc::TextView content_type)
+{
   auto body_double{ts_dup(body)};
   TSHttpTxnErrorBodySet(_txn, body_double.data(), body_double.size(), ts_dup(content_type).data());
 }
 
-bool ts::HttpTxn::set_upstream_addr(const swoc::IPAddr &addr) const {
+bool
+ts::HttpTxn::set_upstream_addr(const swoc::IPAddr &addr) const
+{
   return TS_SUCCESS == TSHttpTxnServerAddrSet(_txn, (swoc::IPEndpoint(addr)));
 }
 
-swoc::MemSpan<char> ts::HttpTxn::ts_dup(swoc::TextView const &text) {
+swoc::MemSpan<char>
+ts::HttpTxn::ts_dup(swoc::TextView const &text)
+{
   auto dup = static_cast<char *>(TSmalloc(text.size() + 1));
   memcpy(dup, text.data(), text.size());
   dup[text.size()] = '\0';
   return {dup, text.size()};
 }
 
-void ts::HttpTxn::status_set(int status) {
+void
+ts::HttpTxn::status_set(int status)
+{
   compat::status_set(*this, static_cast<TSHttpStatus>(status), swoc::meta::CaseArg);
 }
 
-ts::String ts::HttpTxn::effective_url_get() const {
+ts::String
+ts::HttpTxn::effective_url_get() const
+{
   int size;
   auto s = TSHttpTxnEffectiveUrlStringGet(_txn, &size);
   return {s, size};
 }
 
-ts::SSLContext ts::HttpSsn::ssl_context() const {
+ts::SSLContext
+ts::HttpSsn::ssl_context() const
+{
   if (_ssn) {
     TSVConn ssl_vc = TSHttpSsnClientVConnGet(_ssn);
     return {reinterpret_cast<SSL *>(compat::vconn_ssl_get(ssl_vc, swoc::meta::CaseArg))};
   }
-  return { nullptr };
+  return {nullptr};
 }
 
-TextView ts::HttpSsn::inbound_sni() const {
+TextView
+ts::HttpSsn::inbound_sni() const
+{
   if (_ssn) {
-    TSVConn ssl_vc = TSHttpSsnClientVConnGet(_ssn);
+    TSVConn ssl_vc             = TSHttpSsnClientVConnGet(_ssn);
     TSSslConnection ts_ssl_ctx = compat::vconn_ssl_get(ssl_vc, swoc::meta::CaseArg);
     if (ts_ssl_ctx) {
-      SSL *ssl = reinterpret_cast<SSL *>(ts_ssl_ctx);
+      SSL *ssl        = reinterpret_cast<SSL *>(ts_ssl_ctx);
       const char *sni = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
       if (sni) {
         return {sni, strlen(sni)};
@@ -579,24 +696,30 @@ TextView ts::HttpSsn::inbound_sni() const {
   return {};
 }
 
-TextView ts::HttpSsn::proto_contains(const swoc::TextView &tag) const {
-  TextView probe { tag };
+TextView
+ts::HttpSsn::proto_contains(const swoc::TextView &tag) const
+{
+  TextView probe{tag};
   if (tag.empty() || tag.back() != '\0') {
-    char* span = static_cast<char*>(alloca(tag.size() + 1));
+    char *span = static_cast<char *>(alloca(tag.size() + 1));
     memcpy(span, tag.data(), tag.size());
     span[tag.size()] = '\0';
     probe.assign(span, tag.size() + 1);
   }
   auto result = TSHttpSsnClientProtocolStackContains(_ssn, probe.data());
-  return { result, result ? strlen(result) : 0 };
+  return {result, result ? strlen(result) : 0};
 }
 
-swoc::IPEndpoint ts::HttpSsn::addr_remote() const {
-  return swoc::IPEndpoint{ TSHttpSsnClientAddrGet(_ssn) };
+swoc::IPEndpoint
+ts::HttpSsn::addr_remote() const
+{
+  return swoc::IPEndpoint{TSHttpSsnClientAddrGet(_ssn)};
 }
 
-swoc::IPEndpoint ts::HttpSsn::addr_local() const {
-  return swoc::IPEndpoint{ TSHttpSsnIncomingAddrGet(_ssn) };
+swoc::IPEndpoint
+ts::HttpSsn::addr_local() const
+{
+  return swoc::IPEndpoint{TSHttpSsnIncomingAddrGet(_ssn)};
 }
 
 int ts::HttpTxn::inbound_fd() const {
@@ -605,16 +728,22 @@ int ts::HttpTxn::inbound_fd() const {
   return result != TS_SUCCESS ? -1 : fd;
 }
 
-Errata ts::HttpTxn::cache_key_assign(TextView const &key) {
+Errata
+ts::HttpTxn::cache_key_assign(TextView const &key)
+{
   TSCacheUrlSet(_txn, key.data(), key.size());
   return {};
 }
 
-void * HttpTxn::arg(int idx) {
+void *
+HttpTxn::arg(int idx)
+{
   return compat::user_arg_get(_txn, idx);
 }
 
-void HttpTxn::arg_assign(int idx, void * value) {
+void
+HttpTxn::arg_assign(int idx, void *value)
+{
   compat::user_arg_set(_txn, idx, value);
 }
 
@@ -624,21 +753,25 @@ HttpTxn::outbound_txn_count() const
   return compat::get_outbound_txn_count(_txn, swoc::meta::CaseArg);
 }
 
-swoc::Rv<int> HttpTxn::reserve_arg(swoc::TextView const &name, swoc::TextView const &description) {
+swoc::Rv<int>
+HttpTxn::reserve_arg(swoc::TextView const &name, swoc::TextView const &description)
+{
   int idx = -1;
 
-  char const * buff = nullptr;
+  char const *buff = nullptr;
   if (TS_SUCCESS == ts::compat::user_arg_index_name_lookup(name.data(), &idx, &buff)) {
     return idx;
   }
 
   if (TS_ERROR == ts::compat::user_arg_index_reserve(name.data(), description.data(), &idx)) {
-    return { idx, Error(R"(Failed to reserve transaction argument index.)") };
+    return {idx, Error(R"(Failed to reserve transaction argument index.)")};
   }
   return idx;
 }
 
-TxnConfigVar * HttpTxn::find_override(swoc::TextView const& name) {
+TxnConfigVar *
+HttpTxn::find_override(swoc::TextView const &name)
+{
   TSOverridableConfigKey key;
   TSRecordDataType type;
 
@@ -654,12 +787,14 @@ TxnConfigVar * HttpTxn::find_override(swoc::TextView const& name) {
   }
 
   // It exists, put it in the table and return it.
-  auto var = new TxnConfigVar{name, key, type};
+  auto var    = new TxnConfigVar{name, key, type};
   auto result = _var_table.emplace(var->name(), var);
   return std::get<0>(result)->second.get();
 }
 
-Errata HttpTxn::override_assign(TxnConfigVar const &var, intmax_t n) {
+Errata
+HttpTxn::override_assign(TxnConfigVar const &var, intmax_t n)
+{
   if (!var.is_valid(n)) {
     return Error(R"(Integer value {} is not valid for transaction overridable configuration variable "{}".)", n, var.name());
   }
@@ -669,17 +804,22 @@ Errata HttpTxn::override_assign(TxnConfigVar const &var, intmax_t n) {
   return {};
 }
 
-Errata HttpTxn::override_assign(TxnConfigVar const &var, TextView const& text){
+Errata
+HttpTxn::override_assign(TxnConfigVar const &var, TextView const &text)
+{
   if (!var.is_valid(text)) {
     return Error(R"(String value "{}" is not valid for transaction overridable configuration variable "{}".)", text, var.name());
   }
   if (TS_ERROR == TSHttpTxnConfigStringSet(_txn, var.key(), text.data(), text.size())) {
-    return Error(R"(String value "{}" assignment to transaction overridable configuration variable "{}" failed.)", text, var.name());
+    return Error(R"(String value "{}" assignment to transaction overridable configuration variable "{}" failed.)", text,
+                 var.name());
   }
   return {};
 }
 
-Errata HttpTxn::override_assign(TxnConfigVar const &var, double f) {
+Errata
+HttpTxn::override_assign(TxnConfigVar const &var, double f)
+{
   if (!var.is_valid(f)) {
     return Error(R"(Floating value {} is not valid for transaction overridable configuration variable "{}".)", var.name());
   }
@@ -689,38 +829,42 @@ Errata HttpTxn::override_assign(TxnConfigVar const &var, double f) {
   return {};
 }
 
-Rv<ConfVarData> HttpTxn::override_fetch(const TxnConfigVar &var) {
+Rv<ConfVarData>
+HttpTxn::override_fetch(const TxnConfigVar &var)
+{
   switch (var.type()) {
-    case TS_RECORDDATATYPE_FLOAT: {
-      TSMgmtFloat v;
-      if (TS_SUCCESS == TSHttpTxnConfigFloatGet(_txn, var.key(), &v)) {
-        return ConfVarData{v};
-      }
-      break;
+  case TS_RECORDDATATYPE_FLOAT: {
+    TSMgmtFloat v;
+    if (TS_SUCCESS == TSHttpTxnConfigFloatGet(_txn, var.key(), &v)) {
+      return ConfVarData{v};
     }
-    case TS_RECORDDATATYPE_STRING: {
-      char const* text;
-      int len;
-      if (TS_SUCCESS == TSHttpTxnConfigStringGet(_txn, var.key(), &text, &len)) {
-        return ConfVarData{TextView{text, size_t(len)}};
-      }
-      break;
+    break;
+  }
+  case TS_RECORDDATATYPE_STRING: {
+    char const *text;
+    int len;
+    if (TS_SUCCESS == TSHttpTxnConfigStringGet(_txn, var.key(), &text, &len)) {
+      return ConfVarData{TextView{text, size_t(len)}};
     }
-    case TS_RECORDDATATYPE_INT: {
-      TSMgmtInt v;
-      if (TS_SUCCESS == TSHttpTxnConfigIntGet(_txn, var.key(), &v)) {
-        return ConfVarData{v};
-      }
-      break;
+    break;
+  }
+  case TS_RECORDDATATYPE_INT: {
+    TSMgmtInt v;
+    if (TS_SUCCESS == TSHttpTxnConfigIntGet(_txn, var.key(), &v)) {
+      return ConfVarData{v};
     }
-    default:
-      return Error("Var '{}' does not have a valid data type [{}]", var.name(), var.type());
-      break;
+    break;
+  }
+  default:
+    return Error("Var '{}' does not have a valid data type [{}]", var.name(), var.type());
+    break;
   }
   return Error(R"(Failed to retrieve config variable "{})", var.name());
 }
 
-int HttpSsn::protocol_stack(MemSpan<const char *> tags) const {
+int
+HttpSsn::protocol_stack(MemSpan<const char *> tags) const
+{
   int n = 0;
   if (TS_SUCCESS != TSHttpSsnClientProtocolStackGet(_ssn, tags.count(), tags.data(), &n)) {
     return -1;
@@ -728,17 +872,23 @@ int HttpSsn::protocol_stack(MemSpan<const char *> tags) const {
   return n;
 }
 
-Errata &HttpTxn::init(swoc::Errata &errata) {
+Errata &
+HttpTxn::init(swoc::Errata &errata)
+{
   return errata;
 }
 
 // ----
 
-int plugin_stat_value(int idx) {
+int
+plugin_stat_value(int idx)
+{
   return TSStatIntGet(idx);
 }
 
-int plugin_stat_index(TextView const & name) {
+int
+plugin_stat_index(TextView const &name)
+{
   int idx;
   if (TS_SUCCESS == TSStatFindName(name.data(), &idx)) {
     return idx;
@@ -746,13 +896,16 @@ int plugin_stat_index(TextView const & name) {
   return -1;
 }
 
-Rv<int> plugin_stat_define(TextView const& name, int value, bool persistent_p) {
+Rv<int>
+plugin_stat_define(TextView const &name, int value, bool persistent_p)
+{
   int idx = plugin_stat_index(name);
   if (idx >= 0) { // Already there, just return the index.
     return idx;
   }
   // Create the stat.
-  idx = TSStatCreate(name.data(), TS_RECORDDATATYPE_INT, (persistent_p ? TS_STAT_PERSISTENT : TS_STAT_NON_PERSISTENT), TS_STAT_SYNC_SUM);
+  idx = TSStatCreate(name.data(), TS_RECORDDATATYPE_INT, (persistent_p ? TS_STAT_PERSISTENT : TS_STAT_NON_PERSISTENT),
+                     TS_STAT_SYNC_SUM);
   if (idx == TS_ERROR) {
     return Error("Failed to create stat '{}'", name);
   }
@@ -760,12 +913,16 @@ Rv<int> plugin_stat_define(TextView const& name, int value, bool persistent_p) {
   return idx;
 }
 
-void plugin_stat_update(int idx, intmax_t value) {
+void
+plugin_stat_update(int idx, intmax_t value)
+{
   TSStatIntIncrement(idx, value);
 }
 
 // ----
-void TaskHandle::cancel() {
+void
+TaskHandle::cancel()
+{
   if (_action != nullptr) {
     TSMutex m = TSContMutexGet(_cont);
     auto data = static_cast<Data *>(TSContDataGet(_cont));
@@ -786,9 +943,11 @@ void TaskHandle::cancel() {
   }
 }
 
-TaskHandle PerformAsTask(std::function<void ()> &&task) {
+TaskHandle
+PerformAsTask(std::function<void()> &&task)
+{
   static auto lambda = [](TSCont contp, TSEvent, void *) -> int {
-    auto data = static_cast<TaskHandle::Data*>(TSContDataGet(contp));
+    auto data = static_cast<TaskHandle::Data *>(TSContDataGet(contp));
     if (data->_active) {
       data->_f();
     }
@@ -798,23 +957,25 @@ TaskHandle PerformAsTask(std::function<void ()> &&task) {
   };
 
   auto contp = TSContCreate(lambda, TSMutexCreate());
-  auto data = new TaskHandle::Data(std::move(task));
+  auto data  = new TaskHandle::Data(std::move(task));
   TSContDataSet(contp, data);
-  return { TSContScheduleOnPool(contp, 0, TS_THREAD_POOL_TASK), contp };
+  return {TSContScheduleOnPool(contp, 0, TS_THREAD_POOL_TASK), contp};
 }
 
-TaskHandle PerformAsTaskEvery(std::function<void ()> &&task, std::chrono::milliseconds period) {
+TaskHandle
+PerformAsTaskEvery(std::function<void()> &&task, std::chrono::milliseconds period)
+{
   // The lambda runs under lock for the continuation mutex, therefore it can cancel as needed.
   // External cancel tries the lock - if that succeeds it can cancel and prevent the lambda
   // entirely. Otherwise it atomically sets @a _active to @c false.
   static auto lambda = [](TSCont contp, TSEvent, void *event) -> int {
-    auto data = static_cast<TaskHandle::Data*>(TSContDataGet(contp));
+    auto data = static_cast<TaskHandle::Data *>(TSContDataGet(contp));
     if (data->_active) {
       data->_f();
     }
 
     // See if there as a request to cancel while busy.
-    if (! data->_active) {
+    if (!data->_active) {
       TSActionCancel(static_cast<TSAction>(event));
       delete data;
       TSContDestroy(contp);
@@ -822,40 +983,47 @@ TaskHandle PerformAsTaskEvery(std::function<void ()> &&task, std::chrono::millis
     return 0;
   };
   auto contp = TSContCreate(lambda, TSMutexCreate());
-  auto data = new TaskHandle::Data(std::move(task));
+  auto data  = new TaskHandle::Data(std::move(task));
   TSContDataSet(contp, data);
-  return { TSContScheduleEveryOnPool(contp, period.count(), TS_THREAD_POOL_TASK), contp };
+  return {TSContScheduleEveryOnPool(contp, period.count(), TS_THREAD_POOL_TASK), contp};
 }
 /* ------------------------------------------------------------------------ */
 // --- OpenSSL support ---
-int ssl_nid(swoc::TextView const& name) {
+int
+ssl_nid(swoc::TextView const &name)
+{
   // Unfortunately the OpenSSL internals are done badly and use of a C-string is not just an
   // interface issue, but built deeply into the NID table handling. Users of this interface should
   // try to do the NID conversions at configuration load time, not transaction time.
   char buff[name.size() + 1];
   memcpy(buff, name.data(), name.size());
   buff[name.size()] = 0;
-  if (auto nid = OBJ_sn2nid(buff) ; nid != NID_undef) {
+  if (auto nid = OBJ_sn2nid(buff); nid != NID_undef) {
     return nid;
   }
   return OBJ_ln2nid(buff);
 }
 
-namespace {
-TextView ssl_value_for(X509_NAME* name, int nid) {
-  if (int loc = X509_NAME_get_index_by_NID(name, nid, -1) ; loc >= 0) {
-    if (auto entry = X509_NAME_get_entry(name, loc) ; entry != nullptr) {
-      if (auto value = X509_NAME_ENTRY_get_data(entry) ; value != nullptr) {
-        return { reinterpret_cast<char const*>(ASN1_STRING_get0_data(value)), size_t(ASN1_STRING_length(value)) };
+namespace
+{
+  TextView
+  ssl_value_for(X509_NAME *name, int nid)
+  {
+    if (int loc = X509_NAME_get_index_by_NID(name, nid, -1); loc >= 0) {
+      if (auto entry = X509_NAME_get_entry(name, loc); entry != nullptr) {
+        if (auto value = X509_NAME_ENTRY_get_data(entry); value != nullptr) {
+          return {reinterpret_cast<char const *>(ASN1_STRING_get0_data(value)), size_t(ASN1_STRING_length(value))};
+        }
       }
     }
+    return {};
   }
-  return {};
-}
 
 } // namespace
 
-TextView SSLContext::sni() const {
+TextView
+SSLContext::sni() const
+{
   if (_obj != nullptr) {
     if (const char *sni = SSL_get_servername(_obj, TLSEXT_NAMETYPE_host_name); sni != nullptr) {
       return {sni, strlen(sni)};
@@ -864,17 +1032,21 @@ TextView SSLContext::sni() const {
   return {};
 }
 
-long SSLContext::verify_result() const {
+long
+SSLContext::verify_result() const
+{
   if (_obj != nullptr) {
     return SSL_get_verify_result(_obj);
   }
   return X509_V_ERR_INVALID_CALL;
 }
 
-TextView SSLContext::local_subject_value(int nid) const {
+TextView
+SSLContext::local_subject_value(int nid) const
+{
   if (_obj != nullptr) {
-    if ( auto cert = SSL_get_certificate(_obj) ; cert != nullptr ) {
-      if (auto subject = X509_get_subject_name(cert) ; subject != nullptr) {
+    if (auto cert = SSL_get_certificate(_obj); cert != nullptr) {
+      if (auto subject = X509_get_subject_name(cert); subject != nullptr) {
         return ssl_value_for(subject, nid);
       }
     }
@@ -882,20 +1054,24 @@ TextView SSLContext::local_subject_value(int nid) const {
   return {};
 }
 
-TextView SSLContext::local_issuer_value(int nid) const {
+TextView
+SSLContext::local_issuer_value(int nid) const
+{
   if (_obj != nullptr) {
-    if ( auto cert = SSL_get_certificate(_obj) ; cert != nullptr ) {
-      if (auto subject = X509_get_issuer_name(cert) ; subject != nullptr) {
+    if (auto cert = SSL_get_certificate(_obj); cert != nullptr) {
+      if (auto subject = X509_get_issuer_name(cert); subject != nullptr) {
         return ssl_value_for(subject, nid);
       }
     }
   }
   return {};
 }
-TextView SSLContext::remote_subject_value(int nid) const {
+TextView
+SSLContext::remote_subject_value(int nid) const
+{
   if (_obj != nullptr) {
-    if ( auto cert = SSL_get_peer_certificate(_obj) ; cert != nullptr ) {
-      if (auto subject = X509_get_subject_name(cert) ; subject != nullptr) {
+    if (auto cert = SSL_get_peer_certificate(_obj); cert != nullptr) {
+      if (auto subject = X509_get_subject_name(cert); subject != nullptr) {
         return ssl_value_for(subject, nid);
       }
     }
@@ -903,10 +1079,12 @@ TextView SSLContext::remote_subject_value(int nid) const {
   return {};
 }
 
-TextView SSLContext::remote_issuer_value(int nid) const {
+TextView
+SSLContext::remote_issuer_value(int nid) const
+{
   if (_obj != nullptr) {
-    if ( auto cert = SSL_get_peer_certificate(_obj) ; cert != nullptr ) {
-      if (auto subject = X509_get_issuer_name(cert) ; subject != nullptr) {
+    if (auto cert = SSL_get_peer_certificate(_obj); cert != nullptr) {
+      if (auto subject = X509_get_issuer_name(cert); subject != nullptr) {
         return ssl_value_for(subject, nid);
       }
     }
@@ -914,54 +1092,77 @@ TextView SSLContext::remote_issuer_value(int nid) const {
   return {};
 }
 /* ------------------------------------------------------------------------------------ */
-TextView query_value_for(TextView query_str, TextView search_key, bool caseless_p) {
+TextView
+query_value_for(TextView query_str, TextView search_key, bool caseless_p)
+{
   while (query_str) {
     auto token = query_str.take_prefix_at("&;"_tv);
-    auto key = token.take_prefix_at('=');
-    if ((!caseless_p && key == search_key) || (caseless_p && 0 == strcasecmp(key, search_key))){
+    auto key   = token.take_prefix_at('=');
+    if ((!caseless_p && key == search_key) || (caseless_p && 0 == strcasecmp(key, search_key))) {
       return token;
     }
   }
   return {};
 }
 /* ------------------------------------------------------------------------------------ */
-void Log_Note(TextView const& text) {
+void
+Log_Note(TextView const &text)
+{
   compat::diag_note(text, swoc::meta::CaseArg);
 }
 
-void Log_Warning(TextView const& text) {
+void
+Log_Warning(TextView const &text)
+{
   compat::diag_warning(text, swoc::meta::CaseArg);
 }
 
-void Log_Error(TextView const& text) {
+void
+Log_Error(TextView const &text)
+{
   TSError(compat::diag_fmt, int(text.size()), text.data());
 }
 /* ------------------------------------------------------------------------------------ */
 } // namespace ts
 /* ------------------------------------------------------------------------------------ */
-namespace swoc {
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, TSHttpStatus status) {
+namespace swoc
+{
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, TSHttpStatus status)
+{
   return bwformat(w, spec, static_cast<unsigned>(status));
 }
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, TSRecordDataType type) {
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, TSRecordDataType type)
+{
   return bwformat(w, spec, ts::TSRecordDataTypeNames[type]);
 }
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, ts::ConfVarData const& data) {
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, ts::ConfVarData const &data)
+{
   switch (data.index()) {
-    default: w.write("NIL"); break;
-    case 1: bwformat(w, spec, std::get<1>(data)); break;
-    case 2: bwformat(w, spec, std::get<2>(data)); break;
-    case 3: bwformat(w, spec, std::get<2>(data)); break;
+  default:
+    w.write("NIL");
+    break;
+  case 1:
+    bwformat(w, spec, std::get<1>(data));
+    break;
+  case 2:
+    bwformat(w, spec, std::get<2>(data));
+    break;
+  case 3:
+    bwformat(w, spec, std::get<2>(data));
+    break;
   }
   return w;
 }
 } // namespace swoc
 
-
 /* ------------------------------------------------------------------------------------ */
-namespace {
+namespace
+{
 [[maybe_unused]] bool INITIALIZED = []() -> bool {
   ts::HttpTxn::init(G._preload_errata);
   return true;

--- a/plugin/src/ts_util.cc
+++ b/plugin/src/ts_util.cc
@@ -914,6 +914,17 @@ TextView SSLContext::remote_issuer_value(int nid) const {
   return {};
 }
 /* ------------------------------------------------------------------------------------ */
+TextView query_value_for(TextView query_str, TextView search_key, bool caseless_p) {
+  while (query_str) {
+    auto token = query_str.take_prefix_at("&;"_tv);
+    auto key = token.take_prefix_at('=');
+    if ((!caseless_p && key == search_key) || (caseless_p && 0 == strcasecmp(key, search_key))){
+      return token;
+    }
+  }
+  return {};
+}
+/* ------------------------------------------------------------------------------------ */
 void Log_Note(TextView const& text) {
   compat::diag_note(text, swoc::meta::CaseArg);
 }

--- a/plugin/src/txn_box.cc
+++ b/plugin/src/txn_box.cc
@@ -30,44 +30,45 @@ using namespace swoc::literals;
 Global G;
 extern std::string glob_to_rxp(TextView glob);
 
-const std::string Config::GLOBAL_ROOT_KEY {"txn_box" };
-const std::string Config::REMAP_ROOT_KEY { "." };
+const std::string Config::GLOBAL_ROOT_KEY{"txn_box"};
+const std::string Config::REMAP_ROOT_KEY{"."};
 
-Hook Convert_TS_Event_To_TxB_Hook(TSEvent ev) {
+Hook
+Convert_TS_Event_To_TxB_Hook(TSEvent ev)
+{
   static const std::map<TSEvent, Hook> table{
-      { TS_EVENT_HTTP_TXN_START, Hook::TXN_START}
-      , {TS_EVENT_HTTP_READ_REQUEST_HDR,  Hook::CREQ}
-      , {TS_EVENT_HTTP_SEND_REQUEST_HDR,  Hook::PREQ}
-      , {TS_EVENT_HTTP_READ_RESPONSE_HDR, Hook::URSP}
-      , {TS_EVENT_HTTP_SEND_RESPONSE_HDR, Hook::PRSP}
-      , {TS_EVENT_HTTP_PRE_REMAP, Hook::PRE_REMAP}
-      , {TS_EVENT_HTTP_POST_REMAP, Hook::POST_REMAP}
-      , { TS_EVENT_HTTP_TXN_CLOSE, Hook::TXN_CLOSE}
-  };
+    {TS_EVENT_HTTP_TXN_START, Hook::TXN_START},    {TS_EVENT_HTTP_READ_REQUEST_HDR, Hook::CREQ},
+    {TS_EVENT_HTTP_SEND_REQUEST_HDR, Hook::PREQ},  {TS_EVENT_HTTP_READ_RESPONSE_HDR, Hook::URSP},
+    {TS_EVENT_HTTP_SEND_RESPONSE_HDR, Hook::PRSP}, {TS_EVENT_HTTP_PRE_REMAP, Hook::PRE_REMAP},
+    {TS_EVENT_HTTP_POST_REMAP, Hook::POST_REMAP},  {TS_EVENT_HTTP_TXN_CLOSE, Hook::TXN_CLOSE}};
   if (auto spot{table.find(ev)}; spot != table.end()) {
     return spot->second;
   }
   return Hook::INVALID;
 }
 
-namespace {
+namespace
+{
+Config::Handle Plugin_Config;
+std::shared_mutex Plugin_Config_Mutex; // safe updating of the shared ptr.
+std::atomic<bool> Plugin_Reloading = false;
 
- Config::Handle Plugin_Config;
- std::shared_mutex Plugin_Config_Mutex; // safe updating of the shared ptr.
- std::atomic<bool> Plugin_Reloading = false;
+// Get a shared pointer to the configuration safely against updates.
+std::shared_ptr<Config>
+scoped_plugin_config()
+{
+  std::shared_lock lock(Plugin_Config_Mutex);
+  return Plugin_Config;
+}
 
- // Get a shared pointer to the configuration safely against updates.
- std::shared_ptr<Config> scoped_plugin_config() {
-   std::shared_lock lock(Plugin_Config_Mutex);
-   return Plugin_Config;
- }
-
- } // namespace
+} // namespace
 /* ------------------------------------------------------------------------------------ */
-void Global::reserve_txn_arg() {
+void
+Global::reserve_txn_arg()
+{
   if (G.TxnArgIdx < 0) {
-    auto && [ idx, errata ] { ts::HttpTxn::reserve_arg(Config::GLOBAL_ROOT_KEY, "Transaction Box") };
-    if (! errata.is_ok()) {
+    auto &&[idx, errata]{ts::HttpTxn::reserve_arg(Config::GLOBAL_ROOT_KEY, "Transaction Box")};
+    if (!errata.is_ok()) {
       _preload_errata.note(errata);
     } else {
       TxnArgIdx = idx;
@@ -78,18 +79,22 @@ void Global::reserve_txn_arg() {
 // Global callback, thread safe.
 // This sets up local context for a transaction and spins up a per TXN Continuation which is
 // protected by a mutex. This hook isn't set if there are no top level directives.
-int CB_Txn_Start(TSCont, TSEvent, void * payload) {
-  auto txn {reinterpret_cast<TSHttpTxn>(payload) };
+int
+CB_Txn_Start(TSCont, TSEvent, void *payload)
+{
+  auto txn{reinterpret_cast<TSHttpTxn>(payload)};
   Context *ctx = new Context(scoped_plugin_config());
   ctx->enable_hooks(txn);
   TSHttpTxnReenable(txn, TS_EVENT_HTTP_CONTINUE);
   return TS_SUCCESS;
 }
 
-void Task_ConfigReload() {
+void
+Task_ConfigReload()
+{
   std::shared_ptr cfg = std::make_shared<Config>();
-  auto t0 = std::chrono::system_clock::now();
-  auto errata = cfg->load_cli_args(cfg, G._args, 1);
+  auto t0             = std::chrono::system_clock::now();
+  auto errata         = cfg->load_cli_args(cfg, G._args, 1);
   if (!errata.is_ok()) {
     std::string err_str;
     swoc::bwprint(err_str, "{}: Failed to reload configuration.\n{}", Config::PLUGIN_NAME, errata);
@@ -99,16 +104,21 @@ void Task_ConfigReload() {
     Plugin_Config = cfg;
   }
   Plugin_Reloading = false;
-  auto delta = std::chrono::system_clock::now() - t0;
+  auto delta       = std::chrono::system_clock::now() - t0;
   std::string text;
-  TSDebug(Config::PLUGIN_TAG.data(), "%s", swoc::bwprint(text, "{} files loaded in {} ms.", Plugin_Config->file_count(), std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()).c_str());
+  TSDebug(Config::PLUGIN_TAG.data(), "%s",
+          swoc::bwprint(text, "{} files loaded in {} ms.", Plugin_Config->file_count(),
+                        std::chrono::duration_cast<std::chrono::milliseconds>(delta).count())
+            .c_str());
 }
 
-int CB_TxnBoxMsg(TSCont, TSEvent, void * data) {
-  static constexpr TextView TAG {"txn_box."};
+int
+CB_TxnBoxMsg(TSCont, TSEvent, void *data)
+{
+  static constexpr TextView TAG{"txn_box."};
   static constexpr TextView RELOAD("reload");
   auto msg = static_cast<TSPluginMsg *>(data);
-  if (TextView tag{msg->tag, strlen(msg->tag)} ; tag.starts_with_nocase(TAG)) {
+  if (TextView tag{msg->tag, strlen(msg->tag)}; tag.starts_with_nocase(TAG)) {
     tag.remove_prefix(TAG.size());
     if (0 == strcasecmp(tag, RELOAD)) {
       bool expected = false;
@@ -125,19 +135,22 @@ int CB_TxnBoxMsg(TSCont, TSEvent, void * data) {
 }
 
 Errata
-TxnBoxInit() {
-  TSPluginRegistrationInfo info{Config::PLUGIN_TAG.data(), "Verizon Media"
-                                , "solidwallofcode@verizonmedia.com"};
+TxnBoxInit()
+{
+  TSPluginRegistrationInfo info{Config::PLUGIN_TAG.data(), "Verizon Media", "solidwallofcode@verizonmedia.com"};
 
   Plugin_Config = std::make_shared<Config>();
-  auto t0 = std::chrono::system_clock::now();
-  auto errata = Plugin_Config->load_cli_args(Plugin_Config, G._args, 1);
+  auto t0       = std::chrono::system_clock::now();
+  auto errata   = Plugin_Config->load_cli_args(Plugin_Config, G._args, 1);
   if (!errata.is_ok()) {
     return errata;
   }
   auto delta = std::chrono::system_clock::now() - t0;
   std::string text;
-  TSDebug(Config::PLUGIN_TAG.data(), "%s", swoc::bwprint(text, "{} files loaded in {} ms.", Plugin_Config->file_count(), std::chrono::duration_cast<std::chrono::milliseconds>(delta).count()).c_str());
+  TSDebug(Config::PLUGIN_TAG.data(), "%s",
+          swoc::bwprint(text, "{} files loaded in {} ms.", Plugin_Config->file_count(),
+                        std::chrono::duration_cast<std::chrono::milliseconds>(delta).count())
+            .c_str());
 
   if (TSPluginRegister(&info) == TS_SUCCESS) {
     TSCont cont{TSContCreate(CB_Txn_Start, nullptr)};
@@ -151,18 +164,19 @@ TxnBoxInit() {
 }
 
 void
-TSPluginInit(int argc, char const *argv[]) {
-  for ( int idx = 0 ; idx < argc ; ++idx ) {
+TSPluginInit(int argc, char const *argv[])
+{
+  for (int idx = 0; idx < argc; ++idx) {
     G._args.emplace_back(argv[idx]);
   }
   std::string err_str;
-  if (! G._preload_errata.is_ok()) {
+  if (!G._preload_errata.is_ok()) {
     swoc::bwprint(err_str, "{}: startup issues.\n{}", Config::PLUGIN_NAME, G._preload_errata);
     G._preload_errata.clear();
     TSError("%s", err_str.c_str());
   }
-  auto errata { TxnBoxInit() };
-  if (! errata.is_ok()) {
+  auto errata{TxnBoxInit()};
+  if (!errata.is_ok()) {
     swoc::bwprint(err_str, "{}: initialization failure.\n{}", Config::PLUGIN_NAME, errata);
     TSError("%s", err_str.c_str());
   }

--- a/plugin/src/util.cc
+++ b/plugin/src/util.cc
@@ -134,7 +134,7 @@ UnitParser<E>::UnitParser(UnitParser::unit_type&& units, bool unit_required_p) n
 
 template < typename E >
 auto UnitParser<E>::unit_required(bool flag) -> self_type & {
-  _unit_required_p = false;
+  _unit_required_p = flag;
   return *this;
 }
 
@@ -351,7 +351,9 @@ bool operator == (Feature const& lhs, Feature const& rhs) {
     return false;
   }
   switch (lidx) {
-    case IndexFor(NIL): return true;
+    case IndexFor(NO_VALUE):
+    case IndexFor(NIL):
+      return true;
     case IndexFor(BOOLEAN):
       return std::get<IndexFor(BOOLEAN)>(lhs) == std::get<IndexFor(BOOLEAN)>(rhs);
     case IndexFor(INTEGER):
@@ -405,7 +407,11 @@ bool operator <= (Feature const& lhs, Feature const& rhs) {
 }
 /* ------------------------------------------------------------------------------------ */
 namespace swoc {
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &, std::monostate) {
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &, feature_type_for<NO_VALUE>) {
+  return w.write("!NO_VALUE");
+}
+
+BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &, feature_type_for<NIL>) {
   return w.write("NULL");
 }
 

--- a/plugin/src/util.cc
+++ b/plugin/src/util.cc
@@ -21,13 +21,16 @@ using swoc::Errata;
 using swoc::Rv;
 
 // ----
-namespace {
+namespace
+{
 struct join_visitor {
-  swoc::BufferWriter & _w;
+  swoc::BufferWriter &_w;
   TextView _glue;
   unsigned _recurse = 0;
 
-  swoc::BufferWriter&  glue() {
+  swoc::BufferWriter &
+  glue()
+  {
     if (_w.size()) {
       _w.write(_glue);
     }
@@ -35,17 +38,35 @@ struct join_visitor {
   }
 
   void operator()(feature_type_for<NIL>) {}
-  void operator()(feature_type_for<STRING> const& s) { this->glue().write(s); }
-  void operator()(feature_type_for<INTEGER> n) { this->glue().print("{}", n); }
-  void operator()(feature_type_for<BOOLEAN> flag) { this->glue().print("{}", flag);}
-  void operator()(feature_type_for<DURATION> d) { this->glue().print("{}", d);}
-  void operator()(feature_type_for<TUPLE> t) {
+  void
+  operator()(feature_type_for<STRING> const &s)
+  {
+    this->glue().write(s);
+  }
+  void
+  operator()(feature_type_for<INTEGER> n)
+  {
+    this->glue().print("{}", n);
+  }
+  void
+  operator()(feature_type_for<BOOLEAN> flag)
+  {
+    this->glue().print("{}", flag);
+  }
+  void
+  operator()(feature_type_for<DURATION> d)
+  {
+    this->glue().print("{}", d);
+  }
+  void
+  operator()(feature_type_for<TUPLE> t)
+  {
     this->glue();
     if (_recurse) {
       _w.write("[ "_tv);
     }
     auto lw = swoc::FixedBufferWriter{_w.aux_span()};
-    for ( auto const& item : t) {
+    for (auto const &item : t) {
       std::visit(join_visitor{lw, _glue, _recurse + 1}, item);
     }
     _w.commit(lw.size());
@@ -54,16 +75,19 @@ struct join_visitor {
     }
   }
 
-  template < typename T > auto operator()(T const&) -> EnableForFeatureTypes<T, void> {}
+  template <typename T>
+  auto
+  operator()(T const &) -> EnableForFeatureTypes<T, void>
+  {
+  }
 };
 
-}
+} // namespace
 
-Feature Feature::join(Context &ctx, const swoc::TextView &glue) const {
-  return {
-      ctx.render_transient([=](BufferWriter & w) {
-        std::visit(join_visitor{w, glue}, *this);
-      } ) };
+Feature
+Feature::join(Context &ctx, const swoc::TextView &glue) const
+{
+  return {ctx.render_transient([=](BufferWriter &w) { std::visit(join_visitor{w, glue}, *this); })};
 }
 // ----
 /** Parse a string that consists of counts and units.
@@ -82,73 +106,81 @@ Feature Feature::join(Context &ctx, const swoc::TextView &glue) const {
  * - "1M 4C 4X" : 1,440
  * - "3M 5 C3 X" : 3,530
  */
-template < typename E >
-class UnitParser {
+template <typename E> class UnitParser
+{
   using self_type = UnitParser; ///< Self reference type.
 public:
-  using value_type = E; ///< Integral type returned.
-  using unit_type = swoc::Lexicon<value_type>; ///< Unit definition type.
-  static constexpr value_type NIL { 0 };
+  using value_type = E;                         ///< Integral type returned.
+  using unit_type  = swoc::Lexicon<value_type>; ///< Unit definition type.
+  static constexpr value_type NIL{0};
 
   /** Constructor.
    *
    * @param units A @c Lexicon of unit definitions.
    */
-  UnitParser(unit_type && units) noexcept;
+  UnitParser(unit_type &&units) noexcept;
 
   /** Constructor.
    *
    * @param units A @c Lexicon of unit definitions.
    * @param unit_required_p Specify if every number must have an attached unit.
    */
-  UnitParser(unit_type && units, bool unit_required_p) noexcept;
+  UnitParser(unit_type &&units, bool unit_required_p) noexcept;
 
   /** Set whether a unit is required.
    *
    * @param flag @c true if a unit is required, @c false if not.
    * @return @a this.
    */
-  self_type & unit_required(bool flag);
+  self_type &unit_required(bool flag);
 
   /** Parse a string.
    *
    * @param src Input string.
    * @return The computed value if the input it valid, or an error report.
    */
-  Rv<value_type> operator() (swoc::TextView const& src) const noexcept;
+  Rv<value_type> operator()(swoc::TextView const &src) const noexcept;
 
-  unit_type const& units() { return _units; }
+  unit_type const &
+  units()
+  {
+    return _units;
+  }
+
 protected:
   bool _unit_required_p = true; ///< Whether unitless values are allowed.
-  const unit_type _units; ///< Unit definitions.
+  const unit_type _units;       ///< Unit definitions.
 };
 
-template < typename E >
-UnitParser<E>::UnitParser(UnitParser::unit_type&& units) noexcept : UnitParser(std::move(units), true) {}
+template <typename E> UnitParser<E>::UnitParser(UnitParser::unit_type &&units) noexcept : UnitParser(std::move(units), true) {}
 
-template < typename E >
-UnitParser<E>::UnitParser(UnitParser::unit_type&& units, bool unit_required_p) noexcept
-  : _unit_required_p(unit_required_p)
-  , _units(std::move(units.set_default(NIL)))
-{}
+template <typename E>
+UnitParser<E>::UnitParser(UnitParser::unit_type &&units, bool unit_required_p) noexcept
+  : _unit_required_p(unit_required_p), _units(std::move(units.set_default(NIL)))
+{
+}
 
-template < typename E >
-auto UnitParser<E>::unit_required(bool flag) -> self_type & {
+template <typename E>
+auto
+UnitParser<E>::unit_required(bool flag) -> self_type &
+{
   _unit_required_p = flag;
   return *this;
 }
 
-template < typename E >
-auto UnitParser<E>::operator()(swoc::TextView const& src) const noexcept -> Rv<value_type> {
-  value_type zret { 0 };
+template <typename E>
+auto
+UnitParser<E>::operator()(swoc::TextView const &src) const noexcept -> Rv<value_type>
+{
+  value_type zret{0};
   TextView text = src; // Keep @a src around to report error offsets.
 
   while (text.ltrim_if(&isspace)) {
     // Get a count first.
-    auto ptr = text.data(); // save for error reporting.
+    auto ptr   = text.data(); // save for error reporting.
     auto count = text.clip_prefix_of(&isdigit);
     if (count.empty()) {
-      return { NIL , Error("Required count not found at offset {}", ptr - src.data()) };
+      return {NIL, Error("Required count not found at offset {}", ptr - src.data())};
     }
     // Should always parse correctly as @a count is a non-empty sequence of digits.
     auto n = svtou(count);
@@ -156,10 +188,10 @@ auto UnitParser<E>::operator()(swoc::TextView const& src) const noexcept -> Rv<v
     // Next, the unit.
     ptr = text.ltrim_if(&isspace).data(); // save for error reporting.
     // Everything up to the next digit or whitespace.
-    auto unit = text.clip_prefix_of([](char c) { return !(isspace(c) || isdigit(c)); } );
+    auto unit = text.clip_prefix_of([](char c) { return !(isspace(c) || isdigit(c)); });
     if (unit.empty()) {
       if (_unit_required_p) {
-        return { NIL, Error("Required unit not found at offset {}", ptr - src.data()) };
+        return {NIL, Error("Required unit not found at offset {}", ptr - src.data())};
       }
       zret += value_type{n}; // no metric -> unit metric.
     } else {
@@ -174,33 +206,66 @@ auto UnitParser<E>::operator()(swoc::TextView const& src) const noexcept -> Rv<v
 }
 
 // ----
-namespace {
+namespace
+{
 struct bool_visitor {
   bool operator()(feature_type_for<NIL>) { return false; }
 
-  bool operator()(feature_type_for<STRING> const& s) { return BoolNames[s] == True; }
+  bool
+  operator()(feature_type_for<STRING> const &s)
+  {
+    return BoolNames[s] == True;
+  }
 
-  bool operator()(feature_type_for<INTEGER> n) { return n != 0; }
+  bool
+  operator()(feature_type_for<INTEGER> n)
+  {
+    return n != 0;
+  }
 
-  bool operator()(feature_type_for<FLOAT> f) { return f != 0; }
+  bool
+  operator()(feature_type_for<FLOAT> f)
+  {
+    return f != 0;
+  }
 
-  bool operator()(feature_type_for<IP_ADDR> addr) { return addr.is_valid(); }
+  bool
+  operator()(feature_type_for<IP_ADDR> addr)
+  {
+    return addr.is_valid();
+  }
 
-  bool operator()(feature_type_for<BOOLEAN> flag) { return flag; }
+  bool
+  operator()(feature_type_for<BOOLEAN> flag)
+  {
+    return flag;
+  }
 
-  bool operator()(feature_type_for<TUPLE> t) { return t.size() > 0; }
+  bool
+  operator()(feature_type_for<TUPLE> t)
+  {
+    return t.size() > 0;
+  }
 
-  template<typename T> auto operator()(T const&) -> EnableForFeatureTypes<T, bool> { return false; }
+  template <typename T>
+  auto
+  operator()(T const &) -> EnableForFeatureTypes<T, bool>
+  {
+    return false;
+  }
 };
 
-}
+} // namespace
 
-auto Feature::as_bool() const -> type_for<BOOLEAN> {
+auto
+Feature::as_bool() const -> type_for<BOOLEAN>
+{
   return std::visit(bool_visitor{}, *this);
 }
 
 // ----
-namespace {
+namespace
+{
 struct integer_visitor {
   /// Target feature type.
   using ftype = feature_type_for<INTEGER>;
@@ -211,80 +276,100 @@ struct integer_visitor {
 
   explicit integer_visitor(ftype invalid) : _invalid(invalid) {}
 
-  ret_type operator()(feature_type_for<STRING> const& s) {
+  ret_type
+  operator()(feature_type_for<STRING> const &s)
+  {
     TextView parsed;
     ftype zret = swoc::svtoi(s, &parsed);
     if (parsed.size() != s.size()) {
-      return { _invalid
-               , Error("Invalid format for integer at offset {}", parsed.size() + 1)};
+      return {_invalid, Error("Invalid format for integer at offset {}", parsed.size() + 1)};
     }
     return zret;
   }
 
-  ret_type operator()(feature_type_for<INTEGER> n) { return n; }
+  ret_type
+  operator()(feature_type_for<INTEGER> n)
+  {
+    return n;
+  }
 
-  ret_type operator()(feature_type_for<FLOAT> f) { return ftype(f); }
+  ret_type
+  operator()(feature_type_for<FLOAT> f)
+  {
+    return ftype(f);
+  }
 
-  ret_type operator()(feature_type_for<BOOLEAN> flag) { return ftype(flag); }
+  ret_type
+  operator()(feature_type_for<BOOLEAN> flag)
+  {
+    return ftype(flag);
+  }
 
-  ret_type operator()(feature_type_for<TUPLE> t) { return t.size(); }
+  ret_type
+  operator()(feature_type_for<TUPLE> t)
+  {
+    return t.size();
+  }
 
-  template<typename F> auto operator()(F const&) -> EnableForFeatureTypes<F, ret_type> {
-    return { _invalid
-             , Error("Feature of type {} cannot be coerced to type {}."
-                     ,   value_type_of<F>, INTEGER)
-    };
+  template <typename F>
+  auto
+  operator()(F const &) -> EnableForFeatureTypes<F, ret_type>
+  {
+    return {_invalid, Error("Feature of type {} cannot be coerced to type {}.", value_type_of<F>, INTEGER)};
   }
 };
 
-}
-auto Feature::as_integer(type_for<INTEGER> invalid) const -> Rv<type_for<INTEGER>> {
-return std::visit(integer_visitor{invalid}, *this);
+} // namespace
+auto
+Feature::as_integer(type_for<INTEGER> invalid) const -> Rv<type_for<INTEGER>>
+{
+  return std::visit(integer_visitor{invalid}, *this);
 }
 // ----
 // Duration conversion support.
 using namespace std::chrono;
-namespace swoc {
-  template <> uintmax_t Lexicon_Hash(system_clock::duration d) { return static_cast<uintmax_t>(d.count()); }
+namespace swoc
+{
+template <>
+uintmax_t
+Lexicon_Hash(system_clock::duration d)
+{
+  return static_cast<uintmax_t>(d.count());
 }
+} // namespace swoc
 
-UnitParser<system_clock::duration> DurationParser{    UnitParser<system_clock::duration>::unit_type{
-                                                          {nanoseconds(1), {"ns", "nanoseconds"}}
-                                                          , {microseconds(1), {"us", "microseconds"}}
-                                                          , {milliseconds(1), {"ms", "milliseconds"}}
-                                                          , {seconds(1), {"s", "sec", "second", "seconds"}}
-                                                          , {minutes(1), {"m", "min", "minute", "minutes"}}
-                                                          , {hours(1), {"h", "hour", "hours"}}
-                                                          , {days(1), {"d", "day", "days"}}
-                                                          , {days(7), {"w", "week", "weeks"}}
-                                                      }
-};
+UnitParser<system_clock::duration> DurationParser{
+  UnitParser<system_clock::duration>::unit_type{{nanoseconds(1), {"ns", "nanoseconds"}},
+                                                {microseconds(1), {"us", "microseconds"}},
+                                                {milliseconds(1), {"ms", "milliseconds"}},
+                                                {seconds(1), {"s", "sec", "second", "seconds"}},
+                                                {minutes(1), {"m", "min", "minute", "minutes"}},
+                                                {hours(1), {"h", "hour", "hours"}},
+                                                {days(1), {"d", "day", "days"}},
+                                                {days(7), {"w", "week", "weeks"}}}};
 
 // Generate a list, ordered largest to smallest, of the duration name units.
 // The lambda constructs such a vector, which is then used to move construct @c DurationOrder.
-std::vector<decltype(DurationParser)::unit_type::iterator> DurationOrder {
-  []() {
-    using I = decltype(DurationParser)::unit_type::iterator;
-    auto const& lexicon = DurationParser.units();
-    auto n = lexicon.count();
+std::vector<decltype(DurationParser)::unit_type::iterator> DurationOrder{[]() {
+  using I             = decltype(DurationParser)::unit_type::iterator;
+  auto const &lexicon = DurationParser.units();
+  auto n              = lexicon.count();
 
-    std::vector<I> zret;
-    zret.reserve(n);
-    // Load the iterators into the vector.
-    for ( auto spot = lexicon.begin() ; spot != lexicon.end() ; ++spot ) {
-      zret.push_back(spot);
-    }
+  std::vector<I> zret;
+  zret.reserve(n);
+  // Load the iterators into the vector.
+  for (auto spot = lexicon.begin(); spot != lexicon.end(); ++spot) {
+    zret.push_back(spot);
+  }
 
-    // Sort the iterators by scale, largest first.
-    std::sort(zret.begin(), zret.end(), [](I const& lhs, I const& rhs) {
-      return std::get<0>(*lhs) > std::get<0>(*rhs);
-    });
+  // Sort the iterators by scale, largest first.
+  std::sort(zret.begin(), zret.end(), [](I const &lhs, I const &rhs) { return std::get<0>(*lhs) > std::get<0>(*rhs); });
 
-    return zret;
-  } ()
-};
+  return zret;
+}()};
 
-namespace {
+namespace
+{
 /// Handlers for coercing feature types into duration.
 struct duration_visitor {
   /// Target feature type.
@@ -296,24 +381,30 @@ struct duration_visitor {
 
   explicit duration_visitor(ftype invalid) : _invalid(invalid) {}
 
-  ret_type operator()(feature_type_for<DURATION> const& d);
+  ret_type operator()(feature_type_for<DURATION> const &d);
 
-  ret_type operator()(feature_type_for<STRING> const& s);
+  ret_type operator()(feature_type_for<STRING> const &s);
 
   ret_type operator()(feature_type_for<TUPLE> t);
 
-  template<typename F> auto operator()(F const&) -> EnableForFeatureTypes<F, ret_type> {
-    return {_invalid
-            , Error("Feature of type {} cannot be coerced to type {}."
-                    , value_type_of<F>, INTEGER)
-    };
+  template <typename F>
+  auto
+  operator()(F const &) -> EnableForFeatureTypes<F, ret_type>
+  {
+    return {_invalid, Error("Feature of type {} cannot be coerced to type {}.", value_type_of<F>, INTEGER)};
   }
 };
 
 // It's already the correct type, pass it back.
-auto duration_visitor::operator()(feature_type_for<DURATION> const& d) -> ret_type { return d; }
+auto
+duration_visitor::operator()(feature_type_for<DURATION> const &d) -> ret_type
+{
+  return d;
+}
 
-duration_visitor::ret_type duration_visitor::operator()(feature_type_for<STRING> const& s) {
+duration_visitor::ret_type
+duration_visitor::operator()(feature_type_for<STRING> const &s)
+{
   auto &&[n, errata] = DurationParser(s);
   if (!errata.is_ok()) {
     errata.info("Duration string was not a valid format.");
@@ -323,10 +414,12 @@ duration_visitor::ret_type duration_visitor::operator()(feature_type_for<STRING>
 }
 
 // Sum the durations in the tuple, coercing as it goes.
-duration_visitor::ret_type duration_visitor::operator()(feature_type_for<TUPLE> t) {
+duration_visitor::ret_type
+duration_visitor::operator()(feature_type_for<TUPLE> t)
+{
   ftype zret{0};
   unsigned idx = 0; // Just for error reporting.
-  for (auto const& item : t) {
+  for (auto const &item : t) {
     auto &&[value, errata]{std::visit(duration_visitor{_invalid}, item)};
     if (!errata.is_ok()) {
       errata.info("The tuple element at index {} was not a valid duration.", idx);
@@ -340,82 +433,101 @@ duration_visitor::ret_type duration_visitor::operator()(feature_type_for<TUPLE> 
 
 } // namespace
 
-auto Feature::as_duration(type_for<DURATION> invalid) const -> Rv<type_for < DURATION>> {
- return std::visit(duration_visitor{invalid}, *this);
+auto
+Feature::as_duration(type_for<DURATION> invalid) const -> Rv<type_for<DURATION>>
+{
+  return std::visit(duration_visitor{invalid}, *this);
 }
 
 /* ------------------------------------------------------------------------------------ */
-bool operator == (Feature const& lhs, Feature const& rhs) {
+bool
+operator==(Feature const &lhs, Feature const &rhs)
+{
   auto lidx = lhs.index();
   if (lidx != rhs.index()) {
     return false;
   }
   switch (lidx) {
-    case IndexFor(NO_VALUE):
-    case IndexFor(NIL):
-      return true;
-    case IndexFor(BOOLEAN):
-      return std::get<IndexFor(BOOLEAN)>(lhs) == std::get<IndexFor(BOOLEAN)>(rhs);
-    case IndexFor(INTEGER):
-      return std::get<IndexFor(INTEGER)>(lhs) == std::get<IndexFor(INTEGER)>(rhs);
-    case IndexFor(IP_ADDR):
-      return std::get<IndexFor(IP_ADDR)>(lhs) == std::get<IndexFor(IP_ADDR)>(rhs);
-    case IndexFor(DURATION):
-      return std::get<IndexFor(DURATION)>(lhs) == std::get<IndexFor(DURATION)>(rhs);
-    default: break;
+  case IndexFor(NO_VALUE):
+  case IndexFor(NIL):
+    return true;
+  case IndexFor(BOOLEAN):
+    return std::get<IndexFor(BOOLEAN)>(lhs) == std::get<IndexFor(BOOLEAN)>(rhs);
+  case IndexFor(INTEGER):
+    return std::get<IndexFor(INTEGER)>(lhs) == std::get<IndexFor(INTEGER)>(rhs);
+  case IndexFor(IP_ADDR):
+    return std::get<IndexFor(IP_ADDR)>(lhs) == std::get<IndexFor(IP_ADDR)>(rhs);
+  case IndexFor(DURATION):
+    return std::get<IndexFor(DURATION)>(lhs) == std::get<IndexFor(DURATION)>(rhs);
+  default:
+    break;
   }
   return false;
 }
 
-bool operator < (Feature const& lhs, Feature const& rhs) {
+bool
+operator<(Feature const &lhs, Feature const &rhs)
+{
   auto lidx = lhs.index();
   if (lidx != rhs.index()) {
     return false;
   }
   switch (lidx) {
-    case IndexFor(BOOLEAN):
-      return std::get<IndexFor(BOOLEAN)>(lhs) < std::get<IndexFor(BOOLEAN)>(rhs);
-    case IndexFor(INTEGER):
-      return std::get<IndexFor(INTEGER)>(lhs) < std::get<IndexFor(INTEGER)>(rhs);
-    case IndexFor(IP_ADDR):
-      return std::get<IndexFor(IP_ADDR)>(lhs) < std::get<IndexFor(IP_ADDR)>(rhs);
-    case IndexFor(DURATION):
-      return std::get<IndexFor(DURATION)>(lhs) < std::get<IndexFor(DURATION)>(rhs);
-    default: break;
+  case IndexFor(BOOLEAN):
+    return std::get<IndexFor(BOOLEAN)>(lhs) < std::get<IndexFor(BOOLEAN)>(rhs);
+  case IndexFor(INTEGER):
+    return std::get<IndexFor(INTEGER)>(lhs) < std::get<IndexFor(INTEGER)>(rhs);
+  case IndexFor(IP_ADDR):
+    return std::get<IndexFor(IP_ADDR)>(lhs) < std::get<IndexFor(IP_ADDR)>(rhs);
+  case IndexFor(DURATION):
+    return std::get<IndexFor(DURATION)>(lhs) < std::get<IndexFor(DURATION)>(rhs);
+  default:
+    break;
   }
   return false;
 }
 
-bool operator <= (Feature const& lhs, Feature const& rhs) {
+bool
+operator<=(Feature const &lhs, Feature const &rhs)
+{
   auto lidx = lhs.index();
   if (lidx != rhs.index()) {
     return false;
   }
   switch (lidx) {
-    case IndexFor(NIL): return true;
-    case IndexFor(BOOLEAN):
-      return std::get<IndexFor(BOOLEAN)>(lhs) <= std::get<IndexFor(BOOLEAN)>(rhs);
-    case IndexFor(INTEGER):
-      return std::get<IndexFor(INTEGER)>(lhs) <= std::get<IndexFor(INTEGER)>(rhs);
-    case IndexFor(IP_ADDR):
-      return std::get<IndexFor(IP_ADDR)>(lhs) <= std::get<IndexFor(IP_ADDR)>(rhs);
-    case IndexFor(DURATION):
-      return std::get<IndexFor(DURATION)>(lhs) <= std::get<IndexFor(DURATION)>(rhs);
-    default: break;
+  case IndexFor(NIL):
+    return true;
+  case IndexFor(BOOLEAN):
+    return std::get<IndexFor(BOOLEAN)>(lhs) <= std::get<IndexFor(BOOLEAN)>(rhs);
+  case IndexFor(INTEGER):
+    return std::get<IndexFor(INTEGER)>(lhs) <= std::get<IndexFor(INTEGER)>(rhs);
+  case IndexFor(IP_ADDR):
+    return std::get<IndexFor(IP_ADDR)>(lhs) <= std::get<IndexFor(IP_ADDR)>(rhs);
+  case IndexFor(DURATION):
+    return std::get<IndexFor(DURATION)>(lhs) <= std::get<IndexFor(DURATION)>(rhs);
+  default:
+    break;
   }
   return false;
 }
 /* ------------------------------------------------------------------------------------ */
-namespace swoc {
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &, feature_type_for<NO_VALUE>) {
+namespace swoc
+{
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &, feature_type_for<NO_VALUE>)
+{
   return w.write("!NO_VALUE");
 }
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &, feature_type_for<NIL>) {
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &, feature_type_for<NIL>)
+{
   return w.write("NULL");
 }
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ValueType type) {
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, ValueType type)
+{
   if (spec.has_numeric_type()) {
     return bwformat(w, spec, static_cast<unsigned>(type));
   }
@@ -423,14 +535,15 @@ BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, ValueType type) {
 }
 
 BufferWriter &
-bwformat(BufferWriter &w, bwf::Spec const &spec, ValueMask const &mask) {
+bwformat(BufferWriter &w, bwf::Spec const &spec, ValueMask const &mask)
+{
   auto span{w.aux_span()};
   if (span.size() > spec._max) {
     span = span.prefix(spec._max);
   }
   swoc::FixedBufferWriter lw{span};
   if (mask.any()) {
-    for (auto const&[e, v] : ValueTypeNames) {
+    for (auto const &[e, v] : ValueTypeNames) {
       if (!mask[e]) {
         continue;
       }
@@ -446,10 +559,12 @@ bwformat(BufferWriter &w, bwf::Spec const &spec, ValueMask const &mask) {
   return w;
 }
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, FeatureTuple const& t) {
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, FeatureTuple const &t)
+{
   if (t.count() > 0) {
     bwformat(w, spec, t[0]);
-    for (auto && f : t.subspan(1, t.count() - 1)) {
+    for (auto &&f : t.subspan(1, t.count() - 1)) {
       w.write(", ");
       bwformat(w, spec, f);
     }
@@ -457,7 +572,9 @@ BufferWriter &bwformat(BufferWriter &w, bwf::Spec const& spec, FeatureTuple cons
   return w;
 }
 
-BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Feature const &feature) {
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, Feature const &feature)
+{
   if (is_nil(feature)) {
     return bwformat(w, spec, "NULL"_tv);
   } else {
@@ -466,12 +583,14 @@ BufferWriter &bwformat(BufferWriter &w, bwf::Spec const &spec, Feature const &fe
   }
 }
 
-BufferWriter & bwformat(BufferWriter & w, bwf::Spec const& spec, feature_type_for<DURATION> const& d) {
+BufferWriter &
+bwformat(BufferWriter &w, bwf::Spec const &spec, feature_type_for<DURATION> const &d)
+{
   bool sep_p = false;
-  auto n = d.count();
-  for ( auto item : DurationOrder) {
+  auto n     = d.count();
+  for (auto item : DurationOrder) {
     auto scale = std::get<0>(*item).count();
-    auto c = n / scale;
+    auto c     = n / scale;
     if (c > 0) {
       if (sep_p) {
         w.write(' ');
@@ -488,7 +607,8 @@ BufferWriter & bwformat(BufferWriter & w, bwf::Spec const& spec, feature_type_fo
 } // namespace swoc
 
 BufferWriter &
-bwformat(BufferWriter& w, swoc::bwf::Spec const& spec, ActiveType const& type) {
+bwformat(BufferWriter &w, swoc::bwf::Spec const &spec, ActiveType const &type)
+{
   bwformat(w, spec, type._base_type);
   if (type._tuple_type.any()) {
     w.write(", Tuples of [");

--- a/plugin/src/yaml_util.cc
+++ b/plugin/src/yaml_util.cc
@@ -17,10 +17,12 @@ using swoc::Errata;
 using swoc::Rv;
 
 /* ------------------------------------------------------------------------------------ */
-YAML::Node yaml_merge(YAML::Node root) {
-  static constexpr auto flatten = [] (YAML::Node dst, YAML::Node const& src) -> void {
+YAML::Node
+yaml_merge(YAML::Node root)
+{
+  static constexpr auto flatten = [](YAML::Node dst, YAML::Node const &src) -> void {
     if (src.IsMap()) {
-      for ( auto const& [ key, value ] : src ) {
+      for (auto const &[key, value] : src) {
         // don't need to check for nested merge key, because this function is called only if
         // that's already set in @a dst therefore it won't be copied up from @a src.
         if (!dst[key]) {
@@ -31,16 +33,16 @@ YAML::Node yaml_merge(YAML::Node root) {
   };
 
   if (root.IsSequence()) {
-    for ( auto child : root ) {
+    for (auto child : root) {
       yaml_merge(child);
     }
   } else if (root.IsMap()) {
     // Do all nested merges first, so the result is iteration order independent.
-    for ( auto [ key, value ] : root ) {
+    for (auto [key, value] : root) {
       value = yaml_merge(value);
     }
     // If there's a merge key, merge it in.
-    if ( auto merge_node { root[YAML_MERGE_KEY] } ; merge_node ) {
+    if (auto merge_node{root[YAML_MERGE_KEY]}; merge_node) {
       if (merge_node.IsMap()) {
         flatten(root, merge_node);
       } else if (merge_node.IsSequence()) {
@@ -54,8 +56,10 @@ YAML::Node yaml_merge(YAML::Node root) {
   return root;
 }
 
-Rv<YAML::Node> yaml_load(swoc::file::path const& path) {
-//  static_assert(sizeof(YAML::Node) == sizeof(static_cast<Rv<YAML::Node>*>(nullptr)->_r));
+Rv<YAML::Node>
+yaml_load(swoc::file::path const &path)
+{
+  //  static_assert(sizeof(YAML::Node) == sizeof(static_cast<Rv<YAML::Node>*>(nullptr)->_r));
   std::error_code ec;
   std::string content = swoc::file::load(path, ec);
 

--- a/plugin/txn_box.part
+++ b/plugin/txn_box.part
@@ -7,9 +7,9 @@ ts_ver = Version(env.subst(Component("trafficserver").DelaySubst("$PART_VERSION"
 
 DependsOn([
     Component("openssl"),
-    Component("trafficserver", version_range='7.*-*'),
+    Component("libswoc", version_range='1.2.17-*'),
     Component("libswoc.static", version_range='1.2.17-*'),
-    Component("libyaml-cpp"),
+    Component("trafficserver", version_range='7.*-*'),
 ])
 
 if ts_ver < Version("9"):
@@ -17,7 +17,7 @@ if ts_ver < Version("9"):
 
 files = Pattern(src_dir="src",includes=["*.cc"]).files()
 env.Append(CPPPATH="include")
-env.AppendUnique(CXXFLAGS=['-std=c++17'])
+env.AppendUnique(CPPFLAGS=['-std=c++17'])
 env.Append(LIBS = [ 'pcre2-8' ])
 out = env.SharedLibrary("txn_box", files, SHLIBPREFIX='')
 env.InstallLib(out)

--- a/plugin/txn_box.part
+++ b/plugin/txn_box.part
@@ -1,14 +1,14 @@
 Import('*')
 PartName("txn_box")
-PartVersion("0.3.20")
+PartVersion("0.4.0")
 env.Part("txn_box.rpm.part")
 
 ts_ver = Version(env.subst(Component("trafficserver").DelaySubst("$PART_VERSION")))
 
 DependsOn([
     Component("openssl"),
-    Component("libswoc", version_range='1.2.17-*'),
-    Component("libswoc.static", version_range='1.2.17-*'),
+    Component("libswoc", version_range='1.2.23-*'),
+    Component("libswoc.static", version_range='1.2.23-*'),
     Component("trafficserver", version_range='7.*-*'),
 ])
 

--- a/test/autest/gold_tests/autest-site/txn_box.test.ext
+++ b/test/autest/gold_tests/autest-site/txn_box.test.ext
@@ -118,6 +118,7 @@ def TxnBoxTest(self, replay_path, config_path=None, config_key="meta.txn_box", r
     ts.Disk.records_config.update({
         'proxy.config.dns.nameservers': '127.0.0.1:{0}'.format(self.Variables.TXNBOX_DNS.Variables.Port),
         'proxy.config.dns.resolv_conf': 'NULL',
+        'proxy.config.ssl.client.verify.server.policy': 'DISABLED'
         # The following is needed for ATS 9 and later.
         # 'proxy.config.plugin.dynamic_reload': 0
     })

--- a/test/autest/gold_tests/prod/query-delete-regex.replay.yaml
+++ b/test/autest/gold_tests/prod/query-delete-regex.replay.yaml
@@ -1,0 +1,167 @@
+meta:
+  version: "1.0"
+
+  txn-box:
+  - when: ua-req
+    do:
+    - with: ua-req-query
+      select:
+      - rxp<nc>: "^emailaddress=[^&;]*[;&]?(.*)$" # first value.
+        do:
+        - ua-req-query: "{1}"
+      - rxp<nc>: "(.*?)[&;]emailaddress=[^&;]*(.*)$" # not first value
+        do:
+        - ua-req-query: "{1}{2}"
+
+  blocks:
+  - base-req: &base-req
+      version: "1.1"
+      method: "GET"
+  - base-rsp: &base-rsp
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 96 ]
+
+sessions:
+- protocol: [ { name: ip, version : 4} ]
+  transactions:
+
+  # No query
+  - all: { headers: { fields: [[ uuid, no-query ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { as: absent } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # No match on query.
+  - all: { headers: { fields: [[ uuid, not-present ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?Delain=best"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "Delain=best", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Remove single value.
+  - all: { headers: { fields: [[ uuid, delete-one ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?emailAddress=solidwallofcode@verizonmedia.com"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { as: absent } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete first of two
+  - all: { headers: { fields: [[ uuid, delete-first-of-two ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?emailaddress=me@nowhere.com&delain=best"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "delain=best", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete last of two
+  - all: { headers: { fields: [[ uuid, delete-last-two ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?emailaddress=me@nowhere.com&delain=best"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "delain=best", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete last of four
+  - all: { headers: { fields: [[ uuid, delete-last-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?xandria=nice&leah=cool&nightwish=good&EmailAddress=alpha@bravo.com"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete first of four
+  - all: { headers: { fields: [[ uuid, delete-first-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?EmailAddress=alpha@bravo.com&xandria=nice&leah=cool&nightwish=good"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete middle of four
+  - all: { headers: { fields: [[ uuid, delete-middle-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?xandria=nice&EmailAddress=alpha@bravo.com&leah=cool&nightwish=good"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+

--- a/test/autest/gold_tests/prod/query-delete-regex.test.py
+++ b/test/autest/gold_tests/prod/query-delete-regex.test.py
@@ -1,0 +1,28 @@
+# @file
+#
+# Copyright 2021, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os.path
+
+Test.Summary = '''
+Production use case: Manipulate specific query parameters.
+'''
+
+replay_file="query-delete-regex.replay.yaml"
+
+tr = Test.TxnBoxTestAndRun("Query Delete with RXP", replay_file
+                          , config_path='Auto', config_key="meta.txn-box"
+                          , verifier_client_args="--verbose info"
+                          )
+
+ts = tr.Variables.TS
+
+ts.Setup.Copy(replay_file, ts.Variables.CONFIGDIR) # because it's remap only - not auto-copied.
+
+ts.Disk.records_config.update({
+      'proxy.config.diags.debug.enabled': 1
+    , 'proxy.config.diags.debug.tags': 'txn_box'
+    , 'proxy.config.http.cache.http':  0
+})

--- a/test/autest/gold_tests/prod/query.replay.yaml
+++ b/test/autest/gold_tests/prod/query.replay.yaml
@@ -1,0 +1,412 @@
+meta:
+  version: "1.0"
+
+  txn-box:
+    remap:
+      one:
+      - ua-req-field<Q>: ua-req-query-value<delain>
+      two:
+      - ua-req-query-value<Delain>: "best"
+      three:
+      - ua-req-query-value<Delain>: NULL
+
+  blocks:
+  - base-req: &base-req
+      version: "1.1"
+      method: "GET"
+  - base-rsp: &base-rsp
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 96 ]
+
+sessions:
+- protocol: [ { name: ip, version : 4} ]
+  transactions:
+
+  # No query -> no field.
+  - all: { headers: { fields: [[ uuid, no-query ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { as: absent } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Single matching
+  - all: { headers: { fields: [[ uuid, match-one ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?delain=best"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { value: best, as: equal } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Single not matching
+  - all: { headers: { fields: [[ uuid, no-match-one ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?nightwish=best"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { as: absent } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # First
+  - all: { headers: { fields: [[ uuid, match2-first ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?delain=best&nightwish=great"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { value: best, as: equal } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Last
+  - all: { headers: { fields: [[ uuid, match2-last ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?nightwish=great&delain=best"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { value: best, as: equal } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # First (many)
+  - all: { headers: { fields: [[ uuid, match-many-first ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?delain=best&nightwish=great&xandria=fine&leah=cool"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { value: best, as: equal } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Last (many)
+  - all: { headers: { fields: [[ uuid, match-many-last ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?nightwish=great&xandria=fine&leah=cool&delain=best"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { value: best, as: equal } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Middle (many)
+  - all: { headers: { fields: [[ uuid, match-many-middle ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?nightwish=great&xandria=fine&delain=best&leah=cool"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { value: best, as: equal } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Middle (many) (case)
+  - all: { headers: { fields: [[ uuid, match-many-middle-case ]]}}
+    client-request:
+      <<: *base-req
+      url: "/one.html?nightwish=great&xandria=fine&DeLaIn=best&leah=cool"
+      headers:
+        fields:
+        - [ Host, one.ex ]
+    proxy-request:
+      <<: *base-req
+      headers:
+        fields:
+        - [ Q, { value: best, as: equal } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  ## Test directive.
+  # No query
+  - all: { headers: { fields: [[ uuid, not-present ]]}}
+    client-request:
+      <<: *base-req
+      url: "/two.html"
+      headers:
+        fields:
+        - [ Host, two.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "Delain=best", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Update single value.
+  - all: { headers: { fields: [[ uuid, update-one ]]}}
+    client-request:
+      <<: *base-req
+      url: "/two.html?delain=ok"
+      headers:
+        fields:
+        - [ Host, two.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "Delain=best", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Remove single value.
+  - all: { headers: { fields: [[ uuid, delete-one ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?delain=ok"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { as: absent } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Update first of two
+  - all: { headers: { fields: [[ uuid, update-first-of-two ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?delain=ok&nightwish=good"
+      headers:
+        fields:
+        - [ Host, two.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "Delain=best&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete first of two
+  - all: { headers: { fields: [[ uuid, delete-first-of-two ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?delain=ok&nightwish=good"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Update last of two
+  - all: { headers: { fields: [[ uuid, update-last-two ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?nightwish=good&delain=ok"
+      headers:
+        fields:
+        - [ Host, two.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "nightwish=good&Delain=best", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete last of two
+  - all: { headers: { fields: [[ uuid, delete-last-two ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?nightwish=good&delain=ok"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Update last of four
+  - all: { headers: { fields: [[ uuid, update-last-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?xandria=nice&leah=cool&nightwish=good&delain=ok"
+      headers:
+        fields:
+        - [ Host, two.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&leah=cool&nightwish=good&Delain=best", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete last of four
+  - all: { headers: { fields: [[ uuid, delete-last-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?xandria=nice&leah=cool&nightwish=good&delain=ok"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Update first of four
+  - all: { headers: { fields: [[ uuid, update-first-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?delain=ok&xandria=nice&leah=cool&nightwish=good"
+      headers:
+        fields:
+        - [ Host, two.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "Delain=best&xandria=nice&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete first of four
+  - all: { headers: { fields: [[ uuid, delete-first-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?delain=ok&xandria=nice&leah=cool&nightwish=good"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Update middle of four
+  - all: { headers: { fields: [[ uuid, update-middle-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?xandria=nice&delain=ok&leah=cool&nightwish=good"
+      headers:
+        fields:
+        - [ Host, two.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&Delain=best&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+
+  # Delete middle of four
+  - all: { headers: { fields: [[ uuid, delete-middle-four ]]}}
+    client-request:
+      <<: *base-req
+      url: "/page.html?xandria=nice&delain=ok&leah=cool&nightwish=good"
+      headers:
+        fields:
+        - [ Host, three.ex ]
+    proxy-request:
+      <<: *base-req
+      url:
+      - [ query, { value: "xandria=nice&leah=cool&nightwish=good", as: "equal" } ]
+    server-response:
+      <<: *base-rsp
+    proxy-response:
+      status: 200
+

--- a/test/autest/gold_tests/prod/query.test.py
+++ b/test/autest/gold_tests/prod/query.test.py
@@ -1,0 +1,32 @@
+# @file
+#
+# Copyright 2021, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os.path
+
+Test.Summary = '''
+Production use case: Manipulate specific query parameters.
+'''
+
+replay_file="query.replay.yaml"
+
+tr = Test.TxnBoxTestAndRun("Query", replay_file
+                , remap=[ [ 'http://one.ex',  ( '--key=meta.txn-box.remap.one', replay_file) ]
+                        , [ 'http://two.ex',  ( '--key=meta.txn-box.remap.two', replay_file) ]
+                        , [ 'http://three.ex',  ( '--key=meta.txn-box.remap.three', replay_file) ]
+                        , [ 'http://unmatched.ex/' ]
+                        ]
+                , verifier_client_args="--verbose info"
+                )
+
+ts = tr.Variables.TS
+
+ts.Setup.Copy(replay_file, ts.Variables.CONFIGDIR) # because it's remap only - not auto-copied.
+
+ts.Disk.records_config.update({
+      'proxy.config.diags.debug.enabled': 1
+    , 'proxy.config.diags.debug.tags': 'txn_box'
+    , 'proxy.config.http.cache.http':  0
+})

--- a/test/autest/gold_tests/static_file/static_file.replay.yaml
+++ b/test/autest/gold_tests/static_file/static_file.replay.yaml
@@ -66,6 +66,7 @@ meta:
           - eq: 404
           - match: "security.txt"
           do:
+          - debug: "Resetting upstream response"
           - upstream-rsp-status: [ 200 , "OK" ]
           - upstream-rsp-body: *secure-text
           - upstream-rsp-field<Cache-Control>: "max-age=3600"
@@ -77,7 +78,7 @@ meta:
       # If this is checking it could be because there was an early failure. In that case the proxy
       # request may never have been created and proxy-req-path will be NULL. This syntax tries
       # proxy-req-path and if it is NULL, tries ua-req-path instead which will always be something.
-      - debug: "id {upstream-rsp-field<UUID>} proxy-rsp-status {proxy-rsp-status} proxy-req-path {proxy-req-path}"
+      - debug: "id {ua-req-field<UUID>} proxy-rsp-status {proxy-rsp-status} proxy-req-path {proxy-req-path}"
       - with: [ proxy-rsp-status , [ proxy-req-path , { else: ua-req-path } ] ]
         select:
         - as-tuple:
@@ -88,6 +89,21 @@ meta:
           - proxy-rsp-status: [ 200 , "OK" ]
           - proxy-rsp-body: [ *secure-text , "text/plain" ]
 # -- doc-proxy-rsp--<
+
+     # This is for testing empty (zero content length) responses from the upstream.
+    - when: upstream-rsp
+      do:
+      - with: [ upstream-rsp-status , [ proxy-req-path , { else: ua-req-path } ] ]
+        select:
+        - as-tuple:
+          - eq: 404
+          - all-of:
+            - prefix: "security-"
+            - suffix: ".txt"
+          do:
+          - debug: "Resetting upstream response for {ua-req-field<UUID>}"
+          - upstream-rsp-status: [ 200 , "OK" ]
+          - upstream-rsp-body: *secure-text
 
     remap:
     - when: proxy-rsp
@@ -354,3 +370,69 @@ sessions:
       <<: *base-rsp
     proxy-response:
       status: 404
+
+  # Verify caching
+  - all: { headers: { fields: [[ uuid, cached-security ]]}}
+    client-request:
+      <<: *base-req
+      url: "/security.txt"
+      headers:
+        fields:
+        - [ Host, base.ex ]
+    proxy-request:
+      <<: *base-req
+    server-response:
+      status: 404
+      reason: "Missing"
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 90 ]
+        - [ Cache-Status, live ] # Should not arrive because not in cached version.
+    proxy-response:
+      status: 200
+      headers:
+        fields:
+        - [ Cache-Status, { absent: }]
+        - [ uuid, { as: equal, value: "3" }] # cached in transaction 3
+
+
+  # Verify correctness for empty upstream response - base case
+  - all: { headers: { fields: [[ uuid, base-case ]]}}
+    client-request:
+      <<: *base-req
+      url: "/security-2.txt"
+      headers:
+        fields:
+        - [ Host, base.ex ]
+    proxy-request:
+      <<: *base-req
+    server-response:
+      status: 404
+      reason: "Missing"
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 96 ]
+    proxy-response:
+      status: 200
+
+  # Verify correctness for empty upstream response - empty case
+  - all: { headers: { fields: [[ uuid, empty-response ]]}}
+    client-request:
+      <<: *base-req
+      url: "/security-3.txt"
+      headers:
+        fields:
+        - [ Host, base.ex ]
+    proxy-request:
+      <<: *base-req
+    server-response:
+      status: 404
+      reason: "Missing"
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 0 ]
+    proxy-response:
+      status: 200

--- a/test/autest/gold_tests/static_file/static_file.test.py
+++ b/test/autest/gold_tests/static_file/static_file.test.py
@@ -21,5 +21,5 @@ ts = r.Variables.TS
 ts.Setup.Copy("static_file.txt", ts.Variables.CONFIGDIR)
 ts.Disk.records_config.update({
     'proxy.config.diags.debug.enabled': 1
-    , 'proxy.config.diags.debug.tags' : 'txn_box'
+    , 'proxy.config.diags.debug.tags' : 'txn_box|http'
 })

--- a/test/unit_tests/test_accl_utils.cc
+++ b/test/unit_tests/test_accl_utils.cc
@@ -217,7 +217,7 @@ TEST_CASE("Very basic perf test")
                                                                {"ASF.com", "ASF.com"},
                                                                {"txn_box", "ok.txn_box"},
                                                                {"trafficserver.apache.com", "es.apache.com"}};
-  
+
   // We should make this more accurate and run it several time to sample the avg time
   // on inserts and find. As a first approach is ok.
   SECTION("string_tree_map")

--- a/test/unit_tests/test_txn_box.cc
+++ b/test/unit_tests/test_txn_box.cc
@@ -23,8 +23,9 @@
 #include "txn_box/yaml_util.h"
 using namespace swoc::literals;
 
-TEST_CASE("YAML special features", "[yaml]") {
-  #if 0
+TEST_CASE("YAML special features", "[yaml]")
+{
+#if 0
   // Verify I understand how quoted values are distinguished.
   swoc::TextView quoted=R"(key: "value")";
   swoc::TextView unquoted=R"(key: value)";
@@ -51,5 +52,5 @@ TEST_CASE("YAML special features", "[yaml]") {
   REQUIRE(n["key"].Tag() == "!");
   REQUIRE(n["key"].IsNull() == false);
   REQUIRE(n["key"].Scalar().empty() == true);
-  #endif
+#endif
 }

--- a/test/unit_tests/unit_test_main.cc
+++ b/test/unit_tests/unit_test_main.cc
@@ -23,7 +23,9 @@
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
 
-int main(int argc, char *argv[]) {
+int
+main(int argc, char *argv[])
+{
   int result = Catch::Session().run(argc, argv);
 
   return result;

--- a/tools/clang-format.sh
+++ b/tools/clang-format.sh
@@ -1,0 +1,79 @@
+#! /usr/bin/env bash
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  Simple wrapper to run clang-format on a bunch of files
+#
+
+# Update the PKGDATE with the new version date when making a new clang-format binary package.
+PKGDATE="20200514"
+
+function main() {
+  set -e # exit on error
+  ROOT=${ROOT:-$(cd $(dirname $0) && git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
+
+  DIRS=${@:-plugin/src plugin/include/txn_box test/unit_tests}
+  PACKAGE="clang-format-${PKGDATE}.tar.bz2"
+  VERSION="clang-format version 10.0.0 (https://github.com/llvm/llvm-project.git d32170dbd5b0d54436537b6b75beaf44324e0c28)"
+
+  URL=${URL:-https://ci.trafficserver.apache.org/bintray/${PACKAGE}}
+
+  TAR=${TAR:-tar}
+  CURL=${CURL:-curl}
+
+  # default to using native sha1sum command when available
+  if [ $(which sha1sum) ] ; then
+    SHASUM=${SHASUM:-sha1sum}
+  else
+    SHASUM=${SHASUM:-shasum}
+  fi
+
+  ARCHIVE=$ROOT/$(basename ${URL})
+
+  case $(uname -s) in
+  Darwin)
+    FORMAT=${FORMAT:-${ROOT}/clang-format/clang-format.osx}
+    ;;
+  Linux)
+    FORMAT=${FORMAT:-${ROOT}/clang-format/clang-format.linux}
+    ;;
+  *)
+    echo "Leif needs to build a clang-format for $(uname -s)"
+    exit 2
+  esac
+
+  mkdir -p ${ROOT}
+
+  # Note that the two spaces between the hash and ${ARCHIVE) is needed
+  if [ ! -e ${FORMAT} -o ! -e ${ROOT}/${PACKAGE} ] ; then
+    ${CURL} -L --progress-bar -o ${ARCHIVE} ${URL}
+    ${TAR} -x -C ${ROOT} -f ${ARCHIVE}
+    cat > ${ROOT}/sha1 << EOF
+5eec43e5c7f3010d6e6f37639491cabe51de0ab2  ${ARCHIVE}
+EOF
+    ${SHASUM} -c ${ROOT}/sha1
+    chmod +x ${FORMAT}
+  fi
+
+
+  # Make sure we only run this with our exact version
+  ver=$(${FORMAT} --version)
+  if [ "$ver" != "$VERSION" ]; then
+      echo "Wrong version of clang-format!"
+      echo "See https://bintray.com/apache/trafficserver/clang-format-tools/view for a newer version,"
+      echo "or alternatively, undefine the FORMAT environment variable"
+      exit 1
+  else
+      for dir in $DIRS ; do
+          for file in $(find $dir -iname \*.[ch] -o -iname \*.cc); do
+              echo $file
+              ${FORMAT} -i $file
+          done
+      done
+  fi
+}
+
+if [[ "$(basename -- "$0")" == 'clang-format.sh' ]]; then
+  main "$@"
+else
+  ROOT=${ROOT:-$(git rev-parse --show-toplevel)/.git/fmt/${PKGDATE}}
+fi


### PR DESCRIPTION
The primary change here is to add a `NO_VALUE` state to `Feature`. This is subtle but it is useful to be able to distinguish `NIL`, a valid value that can be in the configuration, from a feature that has no value at all, which is always an error on use.