### PR TITLE
Docs: specify --enable-yaml-headers to ATS configuration

### DIFF
--- a/doc/building.en.rst
+++ b/doc/building.en.rst
@@ -19,7 +19,13 @@ Other dependencies
 
    Generally ``sudo dnf install pcre2-devel`` or ``sudo yum install pcre2-devel``.
 
-*  Scons/Parts::
+*  Scons/Parts
+
+   As mentioned above, |TxB| is built using the Scons build tool. This is distributed as a Python
+   package. A root level ``Pipenv`` is provided with which a Python virtual environment containing
+   the required Scons dependencies can be created. Simply run ``pipenv install`` to create the
+   environment followed by ``pipenv shell`` to enter it. Alternatively you can install the required
+   scons-parts package into your PATH's Python 3 environment via ::
 
       python3 -m pip install --user scons-parts
 
@@ -28,9 +34,11 @@ Other dependencies
    reason. This should be "~/.local/bin/scons". If scons or parts doesn't seem to be found, make
    sure the first line in that file has "python3" and not just "python".
 
-To build the plugin, first build and install Traffic Server. Then use the command ::
+To build |TxB|, first build and install Traffic Server. When configuring Traffic Server, specify
+that its YAML headers should be exported via the ``--enable-yaml-headers`` configuration option.
+Once Traffic Server is built, build |TxB| using the following command ::
 
-   scons txn_box --with-trafficserver=<ts_path>
+   scons txn_box --with-trafficserver=<ts_install_path>
 
-where ``<ts_path>`` is the path to a Traffic Server install. In general this wil be the same
-path as used for the ``prefix`` configuration option in Traffic Server.
+where ``<ts_install_path>`` is the path to a Traffic Server install. In general this will be the
+same path as used for the ``prefix`` configuration option in Traffic Server.


### PR DESCRIPTION
Our example scons build command requires that ATS be built with YAML
headers exported. This doc update clarifies that this should be
configured when building ATS via the --enable-yaml-headers configuration
option.