### PR TITLE
Outbound address extractors(local/remote)

### DIFF
--- a/doc/user/ExtractorReference.en.rst
+++ b/doc/user/ExtractorReference.en.rst
@@ -633,6 +633,16 @@ Session
    For ATS versions before 10, this will return `0` and the value should not be taken
    into consideration to determine connection reuse.
 
+.. extractor:: outbound-addr-remote
+   :result: IP address
+
+   The address of the origin server for a transaction.
+
+.. extractor:: outbound-addr-local
+   :result: IP address
+
+   The local address of the server connection for a transaction.
+
 .. _ex-duration:
 
 Duration

--- a/plugin/include/txn_box/ts_util.h
+++ b/plugin/include/txn_box/ts_util.h
@@ -719,10 +719,10 @@ public:
    */
   int inbound_fd() const;
 
-  /// @return The local address for the outbound transaction.
+  /// @return The local address of the server connection for a transaction.
   swoc::IPEndpoint outbound_local_addr() const;
 
-  /// @return The remote address for the outbound transaction.
+  /// @return The address of the origin server for a transaction.
   swoc::IPEndpoint outbound_remote_addr() const;
 
 protected:

--- a/plugin/include/txn_box/ts_util.h
+++ b/plugin/include/txn_box/ts_util.h
@@ -719,6 +719,12 @@ public:
    */
   int inbound_fd() const;
 
+  /// @return The local address for the outbound transaction.
+  swoc::IPEndpoint outbound_local_addr() const;
+
+  /// @return The remote address for the outbound transaction.
+  swoc::IPEndpoint outbound_remote_addr() const;
+
 protected:
   using TxnConfigVarTable = std::unordered_map<swoc::TextView, std::unique_ptr<TxnConfigVar>, std::hash<std::string_view>>;
 

--- a/plugin/src/Ex_HTTP.cc
+++ b/plugin/src/Ex_HTTP.cc
@@ -1329,6 +1329,56 @@ Ex_outbound_txn_count::extract(Context &ctx, Extractor::Spec const &)
   return static_cast<feature_type_for<INTEGER>>(ctx._txn.outbound_txn_count());
 }
 /* ------------------------------------------------------------------------------------ */
+/// Extract the transaction remote address.
+class Ex_outbound_addr_remote : public Extractor
+{
+public:
+  static constexpr TextView NAME{"outbound-addr-remote"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+};
+
+Rv<ActiveType>
+Ex_outbound_addr_remote::validate(Config &, Extractor::Spec &, TextView const &)
+{
+  return ActiveType{NIL, IP_ADDR};
+}
+
+Feature
+Ex_outbound_addr_remote::extract(Context &ctx, Spec const &)
+{
+  if (auto endpoint = ctx._txn.outbound_remote_addr(); endpoint.is_valid()) {
+    return swoc::IPAddr{endpoint};
+  }
+
+  return NIL_FEATURE;
+}
+/* ------------------------------------------------------------------------------------ */
+/// Extract the transaction local address.
+class Ex_outbound_addr_local : public Extractor
+{
+public:
+  static constexpr TextView NAME{"outbound-addr-local"};
+  Rv<ActiveType> validate(Config &cfg, Spec &spec, TextView const &arg) override;
+  Feature extract(Context &ctx, Spec const &spec) override;
+};
+
+Rv<ActiveType>
+Ex_outbound_addr_local::validate(Config &, Extractor::Spec &, TextView const &)
+{
+  return ActiveType{NIL, IP_ADDR};
+}
+
+Feature
+Ex_outbound_addr_local::extract(Context &ctx, Spec const &)
+{
+  if (auto endpoint = ctx._txn.outbound_local_addr(); endpoint.is_valid()) {
+    return swoc::IPAddr{endpoint};
+  }
+
+  return NIL_FEATURE;
+}
+/* ------------------------------------------------------------------------------------ */
 namespace
 {
 // Extractors aren't constructed, they are always named references to singletons.
@@ -1396,6 +1446,8 @@ Ex_upstream_rsp_status upstream_rsp_status;
 Ex_proxy_rsp_status_reason proxy_rsp_status_reason;
 Ex_upstream_rsp_status_reason upstream_rsp_status_reason;
 Ex_outbound_txn_count outbound_txn_count;
+Ex_outbound_addr_remote outbound_addr_remote;
+Ex_outbound_addr_local outbound_addr_local;
 
 
 [[maybe_unused]] bool INITIALIZED = []() -> bool {
@@ -1456,6 +1508,8 @@ Ex_outbound_txn_count outbound_txn_count;
   Extractor::define(Ex_proxy_rsp_status_reason::NAME, &proxy_rsp_status_reason);
   Extractor::define(Ex_upstream_rsp_status_reason::NAME, &upstream_rsp_status_reason);
   Extractor::define(Ex_outbound_txn_count::NAME, &outbound_txn_count);
+  Extractor::define(Ex_outbound_addr_remote::NAME, &outbound_addr_remote);
+  Extractor::define(Ex_outbound_addr_local::NAME, &outbound_addr_local);
 
   Extractor::define(Ex_ua_req_field::NAME, &ua_req_field);
   Extractor::define(Ex_proxy_req_field::NAME, &proxy_req_field);

--- a/plugin/src/ts_util.cc
+++ b/plugin/src/ts_util.cc
@@ -759,6 +759,26 @@ int ts::HttpTxn::inbound_fd() const {
   return result != TS_SUCCESS ? -1 : fd;
 }
 
+swoc::IPEndpoint
+ts::HttpTxn::outbound_local_addr() const
+{
+  if (auto addr = TSHttpTxnOutgoingAddrGet(_txn); addr) {
+    return swoc::IPEndpoint{addr};
+  }
+
+  return {};
+}
+
+swoc::IPEndpoint
+ts::HttpTxn::outbound_remote_addr() const
+{
+  if (auto addr = TSHttpTxnServerAddrGet(_txn); addr) {
+    return swoc::IPEndpoint{addr};
+  }
+
+  return {};
+}
+
 Errata
 ts::HttpTxn::cache_key_assign(TextView const &key)
 {

--- a/test/autest/gold_tests/basic/ip-addr.replay.yaml
+++ b/test/autest/gold_tests/basic/ip-addr.replay.yaml
@@ -16,6 +16,20 @@ meta:
           do:
           - txn-conf<proxy.config.http.insert_request_via_str>: 1
           - ua-req-field<via>: [ ua-req-field<via> , { concat: [ "," , "non-standard loopback" ] } ]
+    - when: proxy-req
+      do:
+      - with: outbound-addr-remote
+        select:
+        - eq: 127.0.0.1
+          do:
+          - proxy-req-field<outbound-addr-remote>: "Smoke-Test-Ok"
+    - when: proxy-req
+      do:
+      - with: outbound-addr-local
+        select:
+        - eq: 127.0.0.1
+          do:
+          - proxy-req-field<outbound-addr-local>: "Smoke-Test-Ok"
 
 
   blocks:
@@ -46,6 +60,8 @@ sessions:
       headers:
         fields:
         - [ "via", { value: "traffic_server", as: contains } ]
+        - [ "outbound-addr-local", { value: "Smoke-Test-Ok", as: equal } ]
+        - [ "outbound-addr-remote", { value: "Smoke-Test-Ok", as: equal } ]
     server-response:
       <<: *base-rsp
     proxy-response:


### PR DESCRIPTION
Two new extractors are now implemented to fetch the local and remote outbound address from a transaction:

`outbound-addr-remote`
`outbound-addr-local`

fixes https://github.com/SolidWallOfCode/txn_box/issues/74