### PR TITLE
Extractors: inbound, outbound addr.

### DIFF
--- a/plugin/include/txn_box/ts_util.h
+++ b/plugin/include/txn_box/ts_util.h
@@ -496,10 +496,10 @@ public:
   int protocol_stack(swoc::MemSpan<char const *> tags) const;
 
   /// @return The remote address of the session.
-  swoc::IPEndpoint addr_remote() const;
+  sockaddr const *addr_remote() const;
 
   /// @return The local address of the session.
-  swoc::IPEndpoint addr_local() const;
+  sockaddr const *addr_local() const;
 
   /** The SSL context for the session.
    *
@@ -720,10 +720,10 @@ public:
   int inbound_fd() const;
 
   /// @return The local address of the server connection for a transaction.
-  swoc::IPEndpoint outbound_local_addr() const;
+  sockaddr const *outbound_local_addr() const;
 
   /// @return The address of the origin server for a transaction.
-  swoc::IPEndpoint outbound_remote_addr() const;
+  sockaddr const *outbound_remote_addr() const;
 
 protected:
   using TxnConfigVarTable = std::unordered_map<swoc::TextView, std::unique_ptr<TxnConfigVar>, std::hash<std::string_view>>;

--- a/plugin/src/Ex_HTTP.cc
+++ b/plugin/src/Ex_HTTP.cc
@@ -1347,8 +1347,8 @@ Ex_outbound_addr_remote::validate(Config &, Extractor::Spec &, TextView const &)
 Feature
 Ex_outbound_addr_remote::extract(Context &ctx, Spec const &)
 {
-  if (auto endpoint = ctx._txn.outbound_remote_addr(); endpoint.is_valid()) {
-    return swoc::IPAddr{endpoint};
+  if (auto addr = ctx._txn.outbound_remote_addr(); addr) {
+    return swoc::IPAddr{addr};
   }
 
   return NIL_FEATURE;
@@ -1372,8 +1372,8 @@ Ex_outbound_addr_local::validate(Config &, Extractor::Spec &, TextView const &)
 Feature
 Ex_outbound_addr_local::extract(Context &ctx, Spec const &)
 {
-  if (auto endpoint = ctx._txn.outbound_local_addr(); endpoint.is_valid()) {
-    return swoc::IPAddr{endpoint};
+  if (auto addr = ctx._txn.outbound_local_addr(); addr) {
+    return swoc::IPAddr{addr};
   }
 
   return NIL_FEATURE;

--- a/plugin/src/Ex_Ssn.cc
+++ b/plugin/src/Ex_Ssn.cc
@@ -98,7 +98,11 @@ Ex_inbound_addr_remote::validate(Config &, Extractor::Spec &, TextView const &)
 Feature
 Ex_inbound_addr_remote::extract(Context &ctx, Spec const &)
 {
-  return swoc::IPAddr(ctx.inbound_ssn().addr_remote());
+  if (auto addr = ctx.inbound_ssn().addr_remote(); addr) {
+    return swoc::IPAddr{addr};
+  }
+
+  return NIL_FEATURE;
 }
 /* ------------------------------------------------------------------------------------ */
 /// Extract the client session local address.
@@ -119,7 +123,11 @@ Ex_inbound_addr_local::validate(Config &, Extractor::Spec &, TextView const &)
 Feature
 Ex_inbound_addr_local::extract(Context &ctx, Spec const &)
 {
-  return swoc::IPAddr(ctx.inbound_ssn().addr_local());
+  if (auto addr = ctx.inbound_ssn().addr_local(); addr) {
+    return swoc::IPAddr{addr};
+  }
+
+  return NIL_FEATURE;
 }
 /* ------------------------------------------------------------------------------------ */
 class Ex_has_inbound_protocol_prefix : public Extractor

--- a/plugin/src/ts_util.cc
+++ b/plugin/src/ts_util.cc
@@ -741,16 +741,16 @@ ts::HttpSsn::proto_contains(const swoc::TextView &tag) const
   return {result, result ? strlen(result) : 0};
 }
 
-swoc::IPEndpoint
+sockaddr const *
 ts::HttpSsn::addr_remote() const
 {
-  return swoc::IPEndpoint{TSHttpSsnClientAddrGet(_ssn)};
+  return TSHttpSsnClientAddrGet(_ssn);
 }
 
-swoc::IPEndpoint
+sockaddr const *
 ts::HttpSsn::addr_local() const
 {
-  return swoc::IPEndpoint{TSHttpSsnIncomingAddrGet(_ssn)};
+  return TSHttpSsnIncomingAddrGet(_ssn);
 }
 
 int ts::HttpTxn::inbound_fd() const {
@@ -759,24 +759,16 @@ int ts::HttpTxn::inbound_fd() const {
   return result != TS_SUCCESS ? -1 : fd;
 }
 
-swoc::IPEndpoint
+sockaddr const *
 ts::HttpTxn::outbound_local_addr() const
 {
-  if (auto addr = TSHttpTxnOutgoingAddrGet(_txn); addr) {
-    return swoc::IPEndpoint{addr};
-  }
-
-  return {};
+  return TSHttpTxnOutgoingAddrGet(_txn);
 }
 
-swoc::IPEndpoint
+sockaddr const *
 ts::HttpTxn::outbound_remote_addr() const
 {
-  if (auto addr = TSHttpTxnServerAddrGet(_txn); addr) {
-    return swoc::IPEndpoint{addr};
-  }
-
-  return {};
+  return TSHttpTxnServerAddrGet(_txn);
 }
 
 Errata


### PR DESCRIPTION
Avoid unnecessary copy of an IPEndpoint, use sockaddr* instead.