### PR TITLE
Update CMake to build libswoc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ Project(TxnBox)
 set(CMAKE_CXX_STANDARD 17)
 include(GNUInstallDirs)
 include(FindOpenSSL)
+include(FetchContent)
 
 set(INSTALL_DIR ${CMAKE_HOME_DIRECTORY})
 set(CMAKE_PREFIX_PATH ${INSTALL_DIR})
@@ -12,16 +13,16 @@ endif()
 
 find_package(PkgConfig REQUIRED)
 
-# libSWOC
-#pkg_check_modules(swoc IMPORTED_TARGET libswoc.static)
-#if(NOT swoc_FOUND)
-#    message("Building libSWOC")
-#    execute_process(COMMAND git clone https://github.com/solidwallofcode/libswoc extern/libswoc)
-#    # cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DCMAKE_INSTALL_LIBDIR=lib extern/libswoc
-#endif()
+FetchContent_Declare(
+    libSWOC
+    GIT_REPOSITORY "https://github.com/solidwallofcode/libswoc"
+    GIT_TAG "master"
+)
+set(LIBSWOC_INSTALL off)
+FetchContent_MakeAvailable(libSWOC)
 
-pkg_check_modules(swoc REQUIRED IMPORTED_TARGET libswoc.static)
-pkg_check_modules(yaml-cpp REQUIRED IMPORTED_TARGET yaml-cpp)
+#pkg_check_modules(swoc REQUIRED IMPORTED_TARGET libswoc.static)
+#pkg_check_modules(yaml-cpp REQUIRED IMPORTED_TARGET yaml-cpp)
 pkg_check_modules(trafficserver REQUIRED IMPORTED_TARGET trafficserver)
 
 add_subdirectory(plugin)

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -34,9 +34,9 @@ add_library(plugin SHARED
 set_property(TARGET plugin PROPERTY PREFIX "")
 set_property(TARGET plugin PROPERTY OUTPUT_NAME "txn_box")
 
-target_link_libraries(plugin PUBLIC PkgConfig::swoc PkgConfig::yaml-cpp pcre2-8)
+target_link_libraries(plugin PRIVATE libswoc pcre2-8)
 target_include_directories(plugin PUBLIC include)
-target_include_directories(plugin PRIVATE ${PLUGIN_SOURCE_DIR}/include ${trafficserver_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
+target_include_directories(plugin PRIVATE ${PLUGIN_SOURCE_DIR}/include ${trafficserver_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR}, libswoc)
 if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(plugin PRIVATE -Wall -Wextra -Werror -Wnon-virtual-dtor)
 endif()


### PR DESCRIPTION
Based on [libswoc PR 68](https://github.com/SolidWallOfCode/libswoc/pull/68) this makes the CMake support build entirely from scratch.