### PR TITLE
Fix issue #78 - ip space failing after global configuration reload.

### DIFF
--- a/plugin/src/ip_space.cc
+++ b/plugin/src/ip_space.cc
@@ -872,7 +872,7 @@ Mod_ip_space::load(Config &cfg, YAML::Node node, TextView, TextView arg, YAML::N
     errata.note(R"(While parsing "{}" modifier at {}.)", KEY, key_value.Mark());
     return std::move(errata);
   }
-  return Handle(new self_type{std::move(expr), arg, info._drtv});
+  return Handle(new self_type{std::move(expr), cfg.localize(arg), info._drtv});
 }
 
 Rv<Feature>


### PR DESCRIPTION
I think the problem is the `arg` for the column is a view into the parsed YAML. For global rules, this doesn't matter because the index has already been computed and the `arg` value is not referenced. For remap parsed YAML data is dumped in `TSRemapPostConfigReload` which apparently doesn't get reused for a while so the modifier works "for a while". @brbzull0 has verified this fixes the problem.