### PR TITLE
Fix for Issue 87

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,12 @@ find_package(PkgConfig REQUIRED)
 FetchContent_Declare(
     libSWOC
     GIT_REPOSITORY "https://github.com/solidwallofcode/libswoc"
-    GIT_TAG "master"
+    GIT_TAG "1.3.11"
 )
 set(LIBSWOC_INSTALL off)
 set(LIBSWOC_TEST off)
 FetchContent_MakeAvailable(libSWOC)
 
-#pkg_check_modules(swoc REQUIRED IMPORTED_TARGET libswoc.static)
-#pkg_check_modules(yaml-cpp REQUIRED IMPORTED_TARGET yaml-cpp)
 pkg_check_modules(trafficserver REQUIRED IMPORTED_TARGET trafficserver)
 
 add_subdirectory(plugin)

--- a/Sconstruct
+++ b/Sconstruct
@@ -29,7 +29,7 @@ AddOption("--with-ssl",
 
 # the depends
 Part("code/libswoc.part"
-     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.3.2")
+     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.3.11")
      )
 Part("#lib/libyaml-cpp.part", vcs_type=VcsGit(server="github.com", repository="jbeder/yaml-cpp.git", protocol="https", tag="yaml-cpp-0.6.3"))
 #Part("#lib/libyaml-cpp.part")

--- a/doc/dev/memory-management.en.rst
+++ b/doc/dev/memory-management.en.rst
@@ -11,7 +11,11 @@
 Memory Mangement
 ****************
 
-While most elements do not require additional memory, this is not always the case. |TxB| provides
+While most elements do not require additional memory, this is not always the case. If elements in a
+constellation need to share
+
+
+|TxB| provides
 a number of mechanisms for allocating memory efficiently in the context of handling transactions.
 
 The primary reason to use |TxB| memory instead of :code:`malloc` is memory lifetime management.

--- a/plugin/include/txn_box/Config.h
+++ b/plugin/include/txn_box/Config.h
@@ -117,15 +117,17 @@ public:
     ~ActiveCaptureScope();
   };
   friend ActiveCaptureScope;
-  ActiveCaptureScope
-  capture_scope(unsigned count, unsigned line_no)
-  {
-    ActiveCaptureScope scope(*this);
-    _active_capture._count = count;
-    _active_capture._line  = line_no;
-    _active_capture._ref_p = false;
-    return scope;
-  }
+
+  /** Preserve the current capture group state.
+   *
+   * @param count Number of capture groups in the new state.
+   * @param line_no Configuration line number that required the change.
+   * @return A cached scope object.
+   *
+   * The current state is preserved in the returned object which, when destructed,
+   * restores the previous state.
+   */
+  ActiveCaptureScope capture_scope(unsigned count, unsigned line_no);
 
   /** Local extractor table.
    *
@@ -389,15 +391,13 @@ public:
    * This is used when a directive needs to be available under an alternative name. All of the arguments
    * are pulled from standard class members except the key (directive name).
    */
-  template <typename D>
-  static swoc::Errata
-  define(swoc::TextView name);
+  template <typename D> static swoc::Errata define(swoc::TextView name);
 
   /** Allocate storage in @a this.
    *
    * @param n Size in bytes.
    * @param align Memory alignment.
-   * @return The allocated span.
+   * @return The allocated memory.
    */
   swoc::MemSpan<void> allocate_cfg_storage(size_t n, size_t align = 1);
 

--- a/plugin/include/txn_box/Config.h
+++ b/plugin/include/txn_box/Config.h
@@ -392,6 +392,26 @@ public:
    */
   swoc::MemSpan<void> allocate_cfg_storage(size_t n, size_t align = 1);
 
+
+  template < typename T, typename ... Args > T * make_drtv_data(swoc::TextView name, Args && ... args) {
+    if ( auto rtti = this->drtv_info(name) ; rtti ) {
+      auto span = this->allocate_cfg_storage(sizeof(T), alignof(T));
+      // Temporary - need to clean up how config storage is handled for directives.
+      // Need to either hid the other CfgStaticData or have a method to get it non-cost.
+      const_cast<swoc::MemSpan<void>&>(rtti->_cfg_store) = span;
+      return new (span.data()) T(std::forward<Args>(args)...);
+    }
+    return nullptr;
+  }
+
+  template < typename T > T * find_drtv_data(swoc::TextView name) {
+    T * zret = nullptr;
+    if ( auto rtti = this->drtv_info(name) ; rtti ) {
+      zret = static_cast<T*>(rtti->_cfg_store.data());
+    }
+    return zret;
+  }
+
   /** Find or allocate an instance of @a T in configuration storage.
    *
    * @tparam T Type of object.

--- a/plugin/include/txn_box/Directive.h
+++ b/plugin/include/txn_box/Directive.h
@@ -58,6 +58,8 @@ public:
    * perform any initialization needed for the directive as a type, rather than as an instance used
    * in the configuration. The most common use is if the directive needs space in a @c Context -
    * that space must be reserved during the invocation of this functor.
+   *
+   * @see Config::obtain_named_object
    */
   using CfgInitializer = std::function<swoc::Errata(Config &cfg, CfgStaticData const *rtti)>;
 
@@ -67,7 +69,6 @@ public:
   struct FactoryInfo {
     unsigned _idx;                          ///< Index for doing config time type info lookup.
     HookMask _hook_mask;                    ///< Valid hooks for this directive.
-    size_t _cfg_reserve;                    ///< Reserved storage in configuration.
     Directive::InstanceLoader _load_cb;     ///< Functor to load the directive from YAML data.
     Directive::CfgInitializer _cfg_init_cb; ///< Configuration init callback.
   };
@@ -79,20 +80,7 @@ public:
   struct CfgStaticData {
     FactoryInfo const *_static;     ///< Related static information.
     unsigned _count = 0;            ///< Number of instances.
-    swoc::MemSpan<void> _cfg_store; ///< Shared config storage.
   };
-
-  /// Options for directive definition.
-  struct Options {
-    // Due to a compiler bug in g++ and clang, no in line initializer for nested classes.
-    // In turn, that means a default constructor which disables aggregate construction. Sigh.
-    constexpr Options() : _cfg_store_required(0) {}
-    constexpr Options(size_t storage) : _cfg_store_required(storage) {}
-    size_t _cfg_store_required; ///< Reserved per configuration storage.
-  };
-
-  /// Provide a default so the templated method works as expected.
-  inline static const Options OPTIONS;
 
   virtual ~Directive() = default;
 

--- a/plugin/src/Config.cc
+++ b/plugin/src/Config.cc
@@ -813,6 +813,16 @@ Config::feature_scope(ActiveType const &ex_type)
   return scope;
 }
 
+Config::ActiveCaptureScope
+Config::capture_scope(unsigned int count, unsigned int line_no)
+{
+  ActiveCaptureScope scope(*this);
+  _active_capture._count = count;
+  _active_capture._line  = line_no;
+  _active_capture._ref_p = false;
+  return scope;
+}
+
 Config::ActiveFeatureScope::~ActiveFeatureScope()
 {
   if (_cfg) {

--- a/plugin/src/Config.cc
+++ b/plugin/src/Config.cc
@@ -515,9 +515,6 @@ Config::load_directive(YAML::Node const &drtv_node)
 
       // If this is the first use of the directive, do config level setup for the directive type.
       if (rtti->_count == 0) {
-        if (rtti->_static->_cfg_reserve > 0) {
-          rtti->_cfg_store = this->allocate_cfg_storage(rtti->_static->_cfg_reserve, 8);
-        }
         info._cfg_init_cb(*this, rtti);
       }
       ++(rtti->_count);
@@ -643,16 +640,12 @@ Config::parse_yaml(YAML::Node root, TextView path)
 };
 
 Errata
-Config::define(swoc::TextView name, HookMask const &hooks, Directive::Options const &options, Directive::InstanceLoader &&worker,
+Config::define(swoc::TextView name, HookMask const &hooks, Directive::InstanceLoader &&worker,
                Directive::CfgInitializer &&cfg_init_cb)
 {
   auto &info{_factory[name]};
   info._idx       = _factory.size() - 1;
   info._hook_mask = hooks;
-  if (options._cfg_store_required > 0) {
-    info._cfg_reserve = options._cfg_store_required;
-    self_type::_cfg_storage_required += swoc::Scalar<8>(swoc::round_up(info._cfg_reserve));
-  }
   info._load_cb     = std::move(worker);
   info._cfg_init_cb = std::move(cfg_init_cb);
   return {};

--- a/plugin/src/Machinery.cc
+++ b/plugin/src/Machinery.cc
@@ -2626,11 +2626,6 @@ class Do_proxy_reply : public Directive
   using self_type  = Do_proxy_reply; ///< Self reference type.
   using super_type = Directive;      ///< Parent type.
 
-  /// Per configuration storage.
-  struct CfgInfo {
-    ReservedSpan _ctx_span; ///< Reserved span for @c CtxInfo.
-  };
-
   /// Per context information.
   /// This is what is stored in the span @c CfgInfo::_ctx_span
   struct CtxInfo {
@@ -2643,7 +2638,7 @@ public:
   inline static const std::string REASON_KEY = "reason";      ///< Key for reason value.
   inline static const std::string BODY_KEY   = "body";        ///< Key for body.
 
-  static const HookMask HOOKS; ///< Valid hooks for directive.
+  static inline const HookMask HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP})}; ///< Valid hooks for directive.
 
   /// Need to do fixups on a later hook.
   static constexpr Hook FIXUP_HOOK = Hook::PRSP;
@@ -2662,9 +2657,7 @@ public:
   static Rv<Handle> load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &name,
                          swoc::TextView const &arg, YAML::Node key_value);
 
-  /// Configuration level initialization.
-  static Errata cfg_init(Config &cfg, CfgStaticData const *rtti);
-
+  static Errata cfg_init(Config &cfg, CfgStaticData const *);
 protected:
   using index_type = FeatureGroup::index_type;
 
@@ -2683,14 +2676,9 @@ protected:
   Errata fixup(Context &ctx);
 };
 
-const HookMask Do_proxy_reply::HOOKS{MaskFor({Hook::CREQ, Hook::PRE_REMAP, Hook::REMAP})};
-
 Errata
 Do_proxy_reply::cfg_init(Config &cfg, CfgStaticData const *)
 {
-  auto cfg_info = cfg.obtain_named_object<CfgInfo>(KEY);
-  // Only one proxy_reply can be effective per transaction, therefore shared state per context is best.
-  cfg_info->_ctx_span = cfg.reserve_ctx_storage(sizeof(CtxInfo));
   cfg.reserve_slot(FIXUP_HOOK); // needed to fix up "Location" field in proxy response.
   return {};
 }
@@ -2698,10 +2686,7 @@ Do_proxy_reply::cfg_init(Config &cfg, CfgStaticData const *)
 Errata
 Do_proxy_reply::invoke(Context &ctx)
 {
-  auto cfg_info = ctx.cfg().named_object<CfgInfo>(KEY);
-  if (!cfg_info) { return {}; } // Indicates shutdown is ongoing.
-
-  auto ctx_info = ctx.initialized_storage_for<CtxInfo>(cfg_info->_ctx_span).data();
+  auto ctx_info = ctx.obtain_named_object<CtxInfo>(KEY);
 
   // Is a fix up hook required to set the reason correctly?
   bool need_hook_p = false;
@@ -2742,11 +2727,9 @@ Do_proxy_reply::invoke(Context &ctx)
 Errata
 Do_proxy_reply::fixup(Context &ctx)
 {
-  if ( auto cfg_info = ctx.cfg().named_object<CfgInfo>(KEY) ; cfg_info ) {
-    auto ctx_info = ctx.storage_for(cfg_info->_ctx_span).rebind<CtxInfo>().data();
-    auto hdr{ctx.proxy_rsp_hdr()};
-    // Set the reason.
+  if ( auto ctx_info = ctx.named_object<CtxInfo>(KEY) ; ctx_info ) {
     if (!ctx_info->_reason.empty()) {
+      auto hdr{ctx.proxy_rsp_hdr()};
       hdr.reason_set(ctx_info->_reason);
     }
   }
@@ -2846,11 +2829,6 @@ class Do_redirect : public Directive
   using self_type  = Do_redirect; ///< Self reference type.
   using super_type = Directive;   ///< Parent type.
 
-  /// Per configuration storage.
-  struct CfgInfo {
-    ReservedSpan _ctx_span; ///< Reserved span for @c CtxInfo.
-  };
-
   /// Per context information, used for fix up on proxy response hook.
   /// -- doc Do_redirect::CtxInfo
   struct CtxInfo {
@@ -2913,8 +2891,6 @@ const HookMask Do_redirect::HOOKS{MaskFor(Hook::PRE_REMAP, Hook::REMAP)};
 Errata
 Do_redirect::cfg_init(Config &cfg, CfgStaticData const *)
 {
-  auto cfg_info = cfg.obtain_named_object<CfgInfo>(KEY);
-  cfg_info->_ctx_span = cfg.reserve_ctx_storage(sizeof(CtxInfo));
   cfg.reserve_slot(FIXUP_HOOK); // needed to fix up "Location" field in proxy response.
   return {};
 }
@@ -2923,11 +2899,7 @@ Do_redirect::cfg_init(Config &cfg, CfgStaticData const *)
 Errata
 Do_redirect::invoke(Context &ctx)
 {
-  auto cfg_info = ctx.cfg().named_object<CfgInfo>(KEY);
-  if (!cfg_info) {
-    return {}; // shutdown in progress and config data is already gone.
-  }
-  auto ctx_info = ctx.initialized_storage_for<CtxInfo>(cfg_info->_ctx_span).data();
+  auto ctx_info = ctx.obtain_named_object<CtxInfo>(KEY);
 
   // If the Location view is empty, it hasn't been set and therefore the clean up hook
   // hasn't been set either, so need to do that.
@@ -2976,8 +2948,7 @@ Do_redirect::invoke(Context &ctx)
 Errata
 Do_redirect::fixup(Context &ctx)
 {
-  if ( auto cfg_info = ctx.cfg().named_object<CfgInfo>(KEY) ; cfg_info ) {
-    auto ctx_info = ctx.storage_for(cfg_info->_ctx_span).rebind<CtxInfo>().data();
+  if ( auto ctx_info = ctx.named_object<CtxInfo>(KEY) ; ctx_info ) {
     auto hdr{ctx.proxy_rsp_hdr()};
 
     auto field{hdr.field_obtain(ts::HTTP_FIELD_LOCATION)};

--- a/plugin/src/text_block.cc
+++ b/plugin/src/text_block.cc
@@ -56,8 +56,6 @@ public:
   static inline const std::string KEY{"text-block-define"}; ///< Directive name.
   static const HookMask HOOKS;                              ///< Valid hooks for directive.
 
-  static constexpr Options OPTIONS{sizeof(CfgInfo *)};
-
   /// Functor to do file content updating as needed.
   struct Updater {
     std::weak_ptr<Config> _cfg;   ///< Configuration.
@@ -126,7 +124,7 @@ protected:
   static inline const std::string NOTIFY_TAG{"notify"};
 
   /// Map of names to text blocks.
-  static Map *map(Directive::CfgStaticData const *rtti);
+  static Map *map(Config & cfg);
 
   /// Get the "update" time for a file - the max of modified and changed times.
   static Clock::time_point update_time(swoc::file::file_status const& stat);
@@ -153,9 +151,10 @@ Do_text_block_define::~Do_text_block_define() noexcept
 }
 
 auto
-Do_text_block_define::map(Directive::CfgStaticData const *rtti) -> Map *
+Do_text_block_define::map(Config & cfg) -> Map *
 {
-  return rtti->_cfg_store.rebind<CfgInfo>().data()->_map.get();
+  auto cfg_info = cfg.named_object<CfgInfo>(KEY);
+  return cfg_info ? cfg_info->_map.get() : nullptr;
 }
 
 Errata
@@ -170,7 +169,7 @@ Do_text_block_define::invoke(Context &ctx)
 }
 
 Rv<Directive::Handle>
-Do_text_block_define::load(Config &cfg, CfgStaticData const *rtti, YAML::Node drtv_node, swoc::TextView const &,
+Do_text_block_define::load(Config &cfg, CfgStaticData const *, YAML::Node drtv_node, swoc::TextView const &,
                            swoc::TextView const &, YAML::Node key_value)
 {
   auto self = new self_type();
@@ -244,7 +243,7 @@ Do_text_block_define::load(Config &cfg, CfgStaticData const *rtti, YAML::Node dr
   }
 
   // Put the directive in the map.
-  Map *map = self->map(rtti);
+  Map *map = self->map(cfg);
   if (auto spot = map->find(self->_name); spot != map->end()) {
     return Errata(S_ERROR, R"("{}" directive at {} has the same name "{}" as another instance at line {}.)", KEY, drtv_node.Mark(),
                  self->_name, spot->second->_line_no);
@@ -257,21 +256,8 @@ Do_text_block_define::load(Config &cfg, CfgStaticData const *rtti, YAML::Node dr
 Errata
 Do_text_block_define::cfg_init(Config &cfg, CfgStaticData const *)
 {
-#if 1
-  auto cfg_info = cfg.make_drtv_data<CfgInfo>(KEY, MapHandle(new Map));
+  auto cfg_info = cfg.obtain_named_object<CfgInfo>(KEY, MapHandle(new Map));
   cfg.mark_for_cleanup(cfg_info);
-#else
-  // Get space for instance.
-  auto cfg_info = cfg.allocate_cfg_storage(sizeof(CfgInfo), 8).rebind<CfgInfo>().data();
-  // Initialize it.
-  new (cfg_info) CfgInfo;
-  // Remember where it is.
-  rtti->_cfg_store.rebind<CfgInfo *>()[0] = cfg_info;
-  // Create the map.
-  cfg_info->_map.reset(new Map);
-  // Clean it up when the config is destroyed.
-  cfg.mark_for_cleanup(cfg_info);
-#endif
   return {};
 }
 
@@ -356,7 +342,7 @@ Ex_text_block::validate(Config &cfg, Spec &spec, const TextView &arg)
 
 Feature Ex_text_block::extract_block(Context& ctx, TextView tag)
 {
-  if (auto info = ctx.cfg().find_drtv_data<Do_text_block_define::CfgInfo>(Do_text_block_define::KEY); info) {
+  if (auto info = ctx.cfg().named_object<Do_text_block_define::CfgInfo>(Do_text_block_define::KEY) ; info) {
     if (auto spot = info->_map->find(tag); spot != info->_map->end()) {
       auto block = spot->second;
       std::shared_ptr<std::string> content;

--- a/test/autest/gold_tests/basic/redirect.replay.yaml
+++ b/test/autest/gold_tests/basic/redirect.replay.yaml
@@ -240,7 +240,7 @@ sessions:
   - all: { headers: { fields: [ [ uuid, decode ] ] } }
     client-request:
       <<: *base-req
-      url: "/run/query.html?comets%3D1P%2FHalley%2C%2021P%2FGiacobini-Zinner%2C%20103P%2FHartley%26area%3Dsolar"
+      url: "/run/query.html?comets%3D1P%2FHalley%2C21P%2FGiacobini-Zinner%2C103P%2FHartley%26area%3Dsolar"
       headers:
         fields:
         - [ "Host", "decode.ex" ]
@@ -252,4 +252,4 @@ sessions:
       status: 302
       headers:
         fields:
-        - [ "Location", { value: "http://delta.ex/run/query.html?comets=1P/Halley, 21P/Giacobini-Zinner, 103P/Hartley&area=solar", as: equal } ]
+        - [ "Location", { value: "http://delta.ex/run/query.html?comets=1P/Halley,21P/Giacobini-Zinner,103P/Hartley&area=solar", as: equal } ]

--- a/test/autest/gold_tests/basic/tls-cert.replay.yaml
+++ b/test/autest/gold_tests/basic/tls-cert.replay.yaml
@@ -61,7 +61,6 @@ sessions:
 
 - protocol: [ { name: ip, version : 4} ]
   transactions:
-    -
   # Verify the outbound client cert is there with the expected values.
   - all: { headers: { fields: [[ uuid, outbound-TLS ]]}}
     client-request:


### PR DESCRIPTION
The root cause was during shutdown, the global config pointer would be cleared but there would still be some traffic. If a element using config storage was used it would assume it could get the config storage from the global config, leading to a failure. A quick fix that checked for that was tested successfully. This is change is more comprehensive and refactors all of the element constellations that use config storage to be consistent.