### PR TITLE
Adding an SNI based txn-open configuration test.

### DIFF
--- a/test/autest/gold_tests/basic/sni-based-configuration.replay.yaml
+++ b/test/autest/gold_tests/basic/sni-based-configuration.replay.yaml
@@ -1,0 +1,65 @@
+meta:
+  version: "1.0"
+
+  # Testing configuration based upon sni.
+  txn_box:
+    global:
+    - when: txn-open
+      do:
+      - with: inbound-sni
+        select:
+          - none-of:
+            - tld: "avoid_configuration.com"
+            do:
+            - txn-conf<proxy.config.http.insert_forwarded>: "by=unknown"
+
+sessions:
+- protocol: [ { name: ip, version : 4} , { name: "tls", sni: "server1.avoid_configuration.com" } ]
+  transactions:
+  - client-request:
+      version: "1.1"
+      method: "GET"
+      url: "https://server1.avoid_configuration.com/candy"
+      headers:
+        fields:
+        - [ Host, server1.avoid_configuration.com ]
+        - [ uuid, 1 ]
+
+    # The inserted_forwarded should not be engaged for this SNI.
+    proxy-request:
+      headers:
+        fields:
+        - [ Forwarded, { as: absent } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 234 ]
+
+- protocol: [ { name: ip, version : 4} , { name: "tls", sni: "server1.configure_me.com" } ]
+  transactions:
+  - client-request:
+      version: "1.1"
+      method: "GET"
+      url: "https://server1.configure_me.com/candy"
+      headers:
+        fields:
+        - [ Host, server1.configure_me.com ]
+        - [ uuid, 2 ]
+
+    # The inserted_forwarded should be engaged for this SNI.
+    proxy-request:
+      headers:
+        fields:
+        - [ Forwarded, { value: "by=unknown", as: equal } ]
+
+    server-response:
+      status: 200
+      reason: OK
+      headers:
+        fields:
+        - [ Content-Type, html/plaintext ]
+        - [ Content-Length, 234 ]

--- a/test/autest/gold_tests/basic/sni-based-configuration.test.py
+++ b/test/autest/gold_tests/basic/sni-based-configuration.test.py
@@ -1,0 +1,38 @@
+# @file
+#
+# Copyright 2022, Verizon Media
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os
+
+"""SNI-based configuration test."""
+
+Test.Summary = "Test SNI-based configuration."
+
+tr = Test.TxnBoxTestAndRun(
+      "Test SNI based configuration"
+    , "sni-based-configuration.replay.yaml"
+    , config_path='Auto'
+    , config_key="meta.txn_box.global"
+    , verifier_client_args="--verbose diag"
+    , verifier_server_args="--verbose diag"
+    , enable_tls=True
+)
+
+ts = tr.Variables.TS
+ts.Disk.records_config.update({
+      'proxy.config.diags.debug.enabled': 1
+    , 'proxy.config.diags.debug.tags': 'txn_box|ssl|http'
+
+    # TLS configuration.
+    , 'proxy.config.ssl.server.cert.path': f'{ts.Variables.CONFIGDIR}'
+    , 'proxy.config.ssl.server.private_key.path': f'{ts.Variables.CONFIGDIR}'
+    , 'proxy.config.http.server_ports': f'{ts.Variables.port} {ts.Variables.ssl_port}:ssl'
+    , 'proxy.config.ssl.client.verify.server.policy': 'DISABLED'
+})
+ts.Setup.Copy("../../ssl/server.key", os.path.join(ts.Variables.CONFIGDIR, "server.key"))
+ts.Setup.Copy("../../ssl/server.pem", os.path.join(ts.Variables.CONFIGDIR, "server.pem"))
+ts.Disk.ssl_multicert_config.AddLine(
+    'dest_ip=* ssl_cert_name=server.pem ssl_key_name=server.key'
+)


### PR DESCRIPTION
Adding an autest which demonstrates dynamic configuration based upon SNI in txn-open. This is helpful for sni.yaml tunnel_route configurations for which TS_HTTP_TXN_START_HOOK and TS_HTTP_TXN_END_HOOK are the only hooks called. This means that such connections cannot have configurations overriden via conf_remap.so, but txn_box provides a handy solution for this.