### PR TITLE
Scons build fixes for latest ATS 10.

### DIFF
--- a/Sconstruct
+++ b/Sconstruct
@@ -29,9 +29,9 @@ AddOption("--with-ssl",
 
 # the depends
 Part("code/libswoc.part"
-     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.3.11")
+     ,vcs_type=VcsGit(server="github.com", repository="SolidWallOfCode/libswoc", tag="1.5.8")
      )
-Part("#lib/libyaml-cpp.part", vcs_type=VcsGit(server="github.com", repository="jbeder/yaml-cpp.git", protocol="https", tag="yaml-cpp-0.6.3"))
+Part("#lib/libyaml-cpp.part", vcs_type=VcsGit(server="github.com", repository="jbeder/yaml-cpp.git", protocol="https", tag="0.8.0"))
 #Part("#lib/libyaml-cpp.part")
 
 # this is just a shim part. it passes info based on stuff being installed on the box

--- a/lib/libyaml-cpp.part
+++ b/lib/libyaml-cpp.part
@@ -1,18 +1,22 @@
 Import('*')
-PartName("libyaml-cpp")
-PartVersion(GitVersionFromTag("0.6.3"))
+PartName("yaml-cpp")
+PartVersion(GitVersionFromTag("0.8.0"))
 
 env.AppendUnique(
     CPPPATH=["${CHECK_OUT_DIR}/include"],
     # add these to C++ compiler (CCFLAGS are for both c and C++, CFLAGS for C only)
-    CXXFLAGS=["-std=c++17","-fPIC"],
+    CXXFLAGS=["-std=c++17", "-fPIC"],
 )
 
-files = env.Pattern(src_dir="${CHECK_OUT_DIR}/src",includes=['*.cpp']).files()
+files = env.Pattern(src_dir="${CHECK_OUT_DIR}/src", includes=['*.cpp']).files()
 
 env.InstallLib(
-    env.StaticLibrary("yaml-cpp",files)
-    )
+    env.StaticLibrary("yaml-cpp", files)
+)
 
 # include headers
-env.InstallInclude(env.Pattern(src_dir="${CHECK_OUT_DIR}/include",includes=['*.h']))
+env.SdkInclude(env.Pattern(src_dir="${CHECK_OUT_DIR}/include", includes=['*.h']))
+
+env.InstallInclude(
+    Pattern(src_dir="${CHECK_OUT_DIR}/include/", includes=["*.h"]),
+)

--- a/lib/trafficserver.part
+++ b/lib/trafficserver.part
@@ -3,7 +3,7 @@ Import('*')
 PartName("trafficserver")
 PartVersion(env.get("PKG_VERSION"))
 
-# if we have a --with-trafficserver use that as value we pass 
+# if we have a --with-trafficserver use that as value we pass
 # else use the system which is the default of the compiler
 pkg_prefix = env.get("PKG_PREFIX")
 if pkg_prefix:
@@ -15,8 +15,6 @@ if pkg_prefix:
 
 
 cfg = env.Configure()
-if not cfg.CheckCHeader("ts/ts.h"):
-    env.PrintError("ts/ts.h was not found!",show_stack=False)
 cfg.Finish()
 
 # Based on current design we don't link with anything from trafficserver directly

--- a/plugin/txn_box.part
+++ b/plugin/txn_box.part
@@ -9,10 +9,8 @@ DependsOn([
     Component("libswoc", version_range='1.3.0-*'),
     Component("libswoc.static", version_range='1.3.0-*'),
     Component("trafficserver", version_range='7.*-*'),
+    Component("yaml-cpp"),
 ])
-
-if ts_ver < Version("9"):
-    DependsOn([ Component("libyaml-cpp") ])
 
 files = Pattern(src_dir="src",includes=["*.cc"]).files()
 env.Append(CPPPATH="include")


### PR DESCRIPTION
I've verified that this allows me to build txn_box via scons locally with latest ATS master.

I also needed Walt's #94 cherry-picked in locally to build with the latest ATS 10 that I did not include in this patch.